### PR TITLE
Better errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# fast-json-stringify&nbsp;&nbsp;[![Build Status](https://travis-ci.org/fastify/fast-json-stringify.svg?branch=master)](https://travis-ci.org/fastify/fast-json-stringify)
+# fast-json-stringify
+
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
+  [![Build Status](https://travis-ci.org/fastify/fast-json-stringify.svg?branch=master)](https://travis-ci.org/fastify/fast-json-stringify)
 
 __fast-json-stringify__ is x1-4 times faster than `JSON.stringify()`.
 It is particularly suited if you are sending small JSON payloads, the
@@ -297,7 +300,9 @@ const stringify = fastJson(schema, { schema: externalSchema })
 <a name="acknowledgements"></a>
 ## Acknowledgements
 
-This project was kindly sponsored by [nearForm](http://nearform.com).
+This project is kindly sponsored by:
+- [nearForm](http://nearform.com)
+- [LetzDoIt](http://www.letzdoitapp.com/)
 
 <a name="license"></a>
 ## License

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function build (schema, options) {
       code = buildArray(schema, code, main, options.schema, schema)
       break
     default:
-      throw new Error(`${schema.type} unsupported`)
+      throw new Error(`${schema.type} unsupported in schema:\n${JSON.stringify(schema, null, 2)}`)
   }
 
   code += `
@@ -391,7 +391,7 @@ function nested (laterCode, name, key, schema, externalSchema, fullSchema) {
       `
       break
     default:
-      throw new Error(`${type} unsupported`)
+      throw new Error(`${type} unsupported in schema:\n${JSON.stringify(fullSchema, null, 2)}`)
   }
 
   return {

--- a/test/type-not-supported.test.js
+++ b/test/type-not-supported.test.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const test = require('tap').test
+const build = require('..')
+
+test('type not supported', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'object with RegExp',
+    type: 'object',
+    properties: {
+      reg: 'string'
+    }
+  }
+
+  try {
+    build(schema)
+  } catch (err) {
+    t.equal(err.message, `undefined unsupported in schema:\n${JSON.stringify(schema, null, 2)}`)
+  }
+})
+
+test('type not supported - nested', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'object with RegExp',
+    type: 'object',
+    properties: {
+      key: {
+        type: 'object',
+        properties: {
+          key: 'number'
+        }
+      }
+    }
+  }
+
+  try {
+    build(schema)
+  } catch (err) {
+    t.equal(err.message, `undefined unsupported in schema:\n${JSON.stringify(schema, null, 2)}`)
+  }
+})


### PR DESCRIPTION
If we throw an `${type} unsupported` error, is damn hard understand which schema is failing if you have more than one.
This pr fixes that by logging the wrong schema. 