### PR TITLE
Faster string serialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,8 +104,8 @@ function $asStringSmall (str) {
   for (var i = 0; i < l && point >= 32; i++) {
     point = str.charCodeAt(i)
     if (point === 34 || point === 92) {
-      result += str.slice(last, i) + '\\' + str[i]
-      last = i + 1
+      result += str.slice(last, i) + '\\'
+      last = i
     }
   }
   if (last === 0) {


### PR DESCRIPTION
I've applied the @addaleax's suggestions (#23) and we got a sensible increase of the performances in string serialization! :)

Before
```
JSON.stringify short string x 5,045,063 ops/sec ±1.14% (88 runs sampled)
fast-json-stringify short string x 11,559,636 ops/sec ±0.82% (90 runs sampled)
```
After
```
JSON.stringify short string x 5,088,404 ops/sec ±0.79% (92 runs sampled)
fast-json-stringify short string x 12,171,333 ops/sec ±0.75% (90 runs sampled)
```

Nice catch @addaleax! :)
cc @mcollina 