### PR TITLE
Allow non alpha keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,10 +303,10 @@ function buildObject (schema, code, name, externalSchema, fullSchema) {
   var laterCode = ''
 
   Object.keys(schema.properties || {}).forEach((key, i, a) => {
-    // Using obj.key !== undefined instead of obj.hasOwnProperty(prop) for perf reasons,
+    // Using obj['key'] !== undefined instead of obj.hasOwnProperty(prop) for perf reasons,
     // see https://github.com/mcollina/fast-json-stringify/pull/3 for discussion.
     code += `
-      if (obj.${key} !== undefined) {
+      if (obj['${key}'] !== undefined) {
         json += '${$asString(key)}:'
       `
 
@@ -314,7 +314,7 @@ function buildObject (schema, code, name, externalSchema, fullSchema) {
       schema.properties[key] = refFinder(schema.properties[key]['$ref'], fullSchema, externalSchema)
     }
 
-    const result = nested(laterCode, name, '.' + key, schema.properties[key], externalSchema, fullSchema)
+    const result = nested(laterCode, name, key, schema.properties[key], externalSchema, fullSchema)
 
     code += result.code
     laterCode = result.laterCode
@@ -392,6 +392,7 @@ function nested (laterCode, name, key, schema, externalSchema, fullSchema) {
   var code = ''
   var funcName
   const type = schema.type
+  const accessor = key.indexOf('[') === 0 ? key : `['${key}']`
   switch (type) {
     case 'null':
       code += `
@@ -400,36 +401,36 @@ function nested (laterCode, name, key, schema, externalSchema, fullSchema) {
       break
     case 'string':
       code += `
-        json += $asString(obj${key})
+        json += $asString(obj${accessor})
       `
       break
     case 'integer':
       code += `
-        json += $asInteger(obj${key})
+        json += $asInteger(obj${accessor})
       `
       break
     case 'number':
       code += `
-        json += $asNumber(obj${key})
+        json += $asNumber(obj${accessor})
       `
       break
     case 'boolean':
       code += `
-        json += $asBoolean(obj${key})
+        json += $asBoolean(obj${accessor})
       `
       break
     case 'object':
       funcName = (name + key).replace(/[-.\[\]]/g, '') // eslint-disable-line
       laterCode = buildObject(schema, laterCode, funcName, externalSchema, fullSchema)
       code += `
-        json += ${funcName}(obj${key})
+        json += ${funcName}(obj${accessor})
       `
       break
     case 'array':
       funcName = (name + key).replace(/[-.\[\]]/g, '') // eslint-disable-line
       laterCode = buildArray(schema, laterCode, funcName, externalSchema, fullSchema)
       code += `
-        json += ${funcName}(obj${key})
+        json += ${funcName}(obj${accessor})
       `
       break
     default:

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -114,6 +114,18 @@ buildTest({
 }, null)
 
 buildTest({
+  'title': 'deep object with weird keys',
+  'type': 'object',
+  'properties': {
+    '@version': {
+      'type': 'integer'
+    }
+  }
+}, {
+  '@version': 1
+})
+
+buildTest({
   'title': 'with null',
   'type': 'object',
   'properties': {


### PR DESCRIPTION
I tried this:

```diff
diff --git i/index.js w/index.js
index ff80f46..923d310 100644
--- i/index.js
+++ w/index.js
@@ -306,7 +306,7 @@ function buildObject (schema, code, name, externalSchema, fullSchema) {
     // Using obj.key !== undefined instead of obj.hasOwnProperty(prop) for perf reasons,
     // see https://github.com/mcollina/fast-json-stringify/pull/3 for discussion.
     code += `
-      if (obj.${key} !== undefined) {
+      if (obj['${key}'] !== undefined) {
         json += '${$asString(key)}:'
       `
 
@@ -392,6 +392,7 @@ function nested (laterCode, name, key, schema, externalSchema, fullSchema) {
   var code = ''
   var funcName
   const type = schema.type
+  const value = `obj['${key.substring(1)}']`
   switch (type) {
     case 'null':
       code += `
@@ -400,36 +401,36 @@ function nested (laterCode, name, key, schema, externalSchema, fullSchema) {
       break
     case 'string':
       code += `
-        json += $asString(obj${key})
+        json += $asString(${value})
       `
       break
     case 'integer':
       code += `
-        json += $asInteger(obj${key})
+        json += $asInteger(${value})
       `
       break
     case 'number':
       code += `
-        json += $asNumber(obj${key})
+        json += $asNumber(${value})
       `
       break
     case 'boolean':
       code += `
-        json += $asBoolean(obj${key})
+        json += $asBoolean(${value})
       `
       break
     case 'object':
       funcName = (name + key).replace(/[-.\[\]]/g, '') // eslint-disable-line
       laterCode = buildObject(schema, laterCode, funcName, externalSchema, fullSchema)
       code += `
-        json += ${funcName}(obj${key})
+        json += ${funcName}(${value})
       `
       break
     case 'array':
       funcName = (name + key).replace(/[-.\[\]]/g, '') // eslint-disable-line
       laterCode = buildArray(schema, laterCode, funcName, externalSchema, fullSchema)
       code += `
-        json += ${funcName}(obj${key})
+        json += ${funcName}(${value})
       `
       break
     default:
```

The top part worked fine, it failed a bunch of tests with the second one, though