### PR TITLE
Handle null when value should be string

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,8 @@ function $asBoolean (bool) {
 function $asString (str) {
   if (str instanceof Date) {
     return '"' + str.toISOString() + '"'
+  } else if (str === null) {
+    return '""'
   } else if (str instanceof RegExp) {
     str = str.source
   } else if (typeof str !== 'string') {

--- a/test/missing-values.test.js
+++ b/test/missing-values.test.js
@@ -26,3 +26,18 @@ test('missing values', (t) => {
   t.equal('{"str":"string","val":"value"}', stringify({ str: 'string', val: 'value' }))
   t.equal('{"str":"string","num":42,"val":"value"}', stringify({ str: 'string', num: 42, val: 'value' }))
 })
+
+test('handle null when value should be string', (t) => {
+  t.plan(1)
+
+  const stringify = build({
+    type: 'object',
+    properties: {
+      str: {
+        type: 'string'
+      }
+    }
+  })
+
+  t.equal('{"str":""}', stringify({ str: null }))
+})


### PR DESCRIPTION
As titled, see #40 for more info.

`undefined` is not handled because of [this](https://github.com/fastify/fast-json-stringify/blob/master/index.js#L351).