### PR TITLE
fix(build): Correctly handle repeated array types

### DIFF
--- a/index.js
+++ b/index.js
@@ -407,35 +407,35 @@ function buildArray (schema, code, name, externalSchema, fullSchema) {
     result = schema.items.reduce((res, item, i) => {
       var accessor = '[i]'
       const tmpRes = nested(laterCode, name, accessor, item, externalSchema, fullSchema, i)
-      var condition
+      var condition = `i === ${i} && `
       switch (item.type) {
         case 'null':
-          condition = `obj${accessor} === null`
+          condition += `obj${accessor} === null`
           break
         case 'string':
-          condition = `typeof obj${accessor} === 'string'`
+          condition += `typeof obj${accessor} === 'string'`
           break
         case 'integer':
-          condition = `Number.isInteger(obj${accessor})`
+          condition += `Number.isInteger(obj${accessor})`
           break
         case 'number':
-          condition = `!Number.isInteger(obj${accessor}) && Number.isFinite(obj${accessor})`
+          condition += `Number.isFinite(obj${accessor})`
           break
         case 'boolean':
-          condition = `typeof obj${accessor} === 'boolean'`
+          condition += `typeof obj${accessor} === 'boolean'`
           break
         case 'object':
-          condition = `obj${accessor} && typeof obj${accessor} === 'object' && obj${accessor}.constructor === Object`
+          condition += `obj${accessor} && typeof obj${accessor} === 'object' && obj${accessor}.constructor === Object`
           break
         case 'array':
-          condition = `Array.isArray(obj${accessor})`
+          condition += `Array.isArray(obj${accessor})`
           break
         default:
           throw new Error(`${item.type} unsupported`)
       }
       return {
         code: `${res.code}
-        if (${condition}) {
+        ${i > 0 ? 'else' : ''} if (${condition}) {
           ${tmpRes.code}
         }`,
         laterCode: `${res.laterCode}

--- a/index.js
+++ b/index.js
@@ -442,6 +442,11 @@ function buildArray (schema, code, name, externalSchema, fullSchema) {
         ${tmpRes.laterCode}`
       }
     }, result)
+    result.code += `
+    else {
+      throw new Error(\`Item at $\{i} does not match schema definition.\`)
+    }
+    `
   } else {
     result = nested(laterCode, name, '[i]', schema.items, externalSchema, fullSchema)
   }

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -112,3 +112,31 @@ buildTest({
     }
   }
 }, {ids: [1, 2]})
+
+buildTest({
+  'title': 'pattern properties array',
+  'type': 'object',
+  'properties': {
+    'args': {
+      'type': 'array',
+      'items': [
+        {
+          'type': 'object',
+          'patternProperties': {
+            '.*': {
+              'type': 'string'
+            }
+          }
+        },
+        {
+          'type': 'object',
+          'patternProperties': {
+            '.*': {
+              'type': 'number'
+            }
+          }
+        }
+      ]
+    }
+  }
+}, {args: [{a: 'test'}, {b: 1}]})

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -140,3 +140,27 @@ buildTest({
     }
   }
 }, {args: [{a: 'test'}, {b: 1}]})
+
+test('invalid items throw', (t) => {
+  t.plan(1)
+  const schema = {
+    'type': 'object',
+    'properties': {
+      'args': {
+        'type': 'array',
+        'items': [
+          {
+            'type': 'object',
+            'patternProperties': {
+              '.*': {
+                'type': 'string'
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+  const stringify = build(schema)
+  t.throws(() => stringify({args: ['invalid']}))
+})

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -94,3 +94,21 @@ buildTest({
 }, {
   ids: [null, 'test', 1, 1.1, true, {a: 'test'}, ['test']]
 })
+
+buildTest({
+  'title': 'repeated types',
+  'type': 'object',
+  'properties': {
+    'ids': {
+      'type': 'array',
+      'items': [
+        {
+          type: 'number'
+        },
+        {
+          type: 'number'
+        }
+      ]
+    }
+  }
+}, {ids: [1, 2]})


### PR DESCRIPTION
Fixes #44 

The problem with the repeated items in the stringified array was actually repeated types in the items array, not `patternProperties` specifically.

I have also updated the array item builder to throw an exception if the item in the array does not match the schema's definition. This resolves the problem with empty array items, e.g.

`[,{"foo":"1","bar":"foo"}]`