### PR TITLE
Fix error being thrown because of spaces in key

### DIFF
--- a/index.js
+++ b/index.js
@@ -532,14 +532,14 @@ function nested (laterCode, name, key, schema, externalSchema, fullSchema, subKe
       `
       break
     case 'object':
-      funcName = (name + key + subKey).replace(/[-.\[\]]/g, '') // eslint-disable-line
+      funcName = (name + key + subKey).replace(/[-.\[\] ]/g, '') // eslint-disable-line
       laterCode = buildObject(schema, laterCode, funcName, externalSchema, fullSchema)
       code += `
         json += ${funcName}(obj${accessor})
       `
       break
     case 'array':
-      funcName = (name + key + subKey).replace(/[-.\[\]]/g, '') // eslint-disable-line
+      funcName = (name + key + subKey).replace(/[-.\[\] ]/g, '') // eslint-disable-line
       laterCode = buildArray(schema, laterCode, funcName, externalSchema, fullSchema)
       code += `
         json += ${funcName}(obj${accessor})

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -130,6 +130,25 @@ buildTest({
 })
 
 buildTest({
+  'title': 'deep object with spaces in key',
+  'type': 'object',
+  'properties': {
+    'spaces in key': {
+      'type': 'object',
+      'properties': {
+        'something': {
+          'type': 'integer'
+        }
+      }
+    }
+  }
+}, {
+  'spaces in key': {
+    'something': 1
+  }
+})
+
+buildTest({
   'title': 'with null',
   'type': 'object',
   'properties': {


### PR DESCRIPTION
This PR fixes an error being thrown when building a stringify function from a schema with a property of type object whose key contains spaces:

```
SyntaxError: Unexpected token in
at Function (<anonymous>)
at build (/fast-json-stringify/index.js:104:20)
...
```

The error is thrown because the `nested()` function generates function names containing spaces.  