### PR TITLE
Fix #60, root references requiring a hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -351,10 +351,13 @@ function refFinder (ref, schema, externalSchema) {
   if (ref[0]) {
     schema = externalSchema[ref[0]]
   }
-  var walk = ref[1].split('/')
   var code = 'return schema'
-  for (var i = 1; i < walk.length; i++) {
-    code += `['${walk[i]}']`
+  // If it has a path
+  if (ref[1]) {
+    var walk = ref[1].split('/')
+    for (var i = 1; i < walk.length; i++) {
+      code += `['${walk[i]}']`
+    }
   }
   return (new Function('schema', code))(schema)
 }

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -97,6 +97,9 @@ test('ref external - properties', (t) => {
           }
         }
       }
+    },
+    third: {
+      type: 'string'
     }
   }
 
@@ -109,6 +112,12 @@ test('ref external - properties', (t) => {
       },
       num: {
         $ref: 'second#/definitions/num'
+      },
+      strPlain: {
+        $ref: 'third'
+      },
+      strHash: {
+        $ref: 'third#'
       }
     }
   }
@@ -119,7 +128,9 @@ test('ref external - properties', (t) => {
     },
     num: {
       int: 42
-    }
+    },
+    strPlain: 'test',
+    strHash: 'test'
   }
 
   const stringify = build(schema, { schema: externalSchema })
@@ -132,7 +143,7 @@ test('ref external - properties', (t) => {
     t.fail()
   }
 
-  t.equal(output, '{"obj":{"str":"test"},"num":{"int":42}}')
+  t.equal(output, '{"obj":{"str":"test"},"num":{"int":42},"strPlain":"test","strHash":"test"}')
 })
 
 test('ref internal - patternProperties', (t) => {


### PR DESCRIPTION
This adds tests + a fix for #60 by adding a check to make sure there is a hash before doing the walk.