### PR TITLE
skip non-coerceable numbers

### DIFF
--- a/test/additionalProperties.test.js
+++ b/test/additionalProperties.test.js
@@ -93,7 +93,7 @@ test('additionalProperties - string coerce', (t) => {
   t.equal('{"foo":"true","ofoo":"42","arrfoo":"array,test","objfoo":"[object Object]"}', stringify(obj))
 })
 
-test('additionalProperties - number coerce', (t) => {
+test('additionalProperties - number skip', (t) => {
   t.plan(1)
   const stringify = build({
     title: 'check number coerce',
@@ -105,7 +105,7 @@ test('additionalProperties - number coerce', (t) => {
   })
 
   const obj = { foo: true, ofoo: '42', xfoo: 'string', arrfoo: [1, 2], objfoo: { num: 42 } }
-  t.equal('{"foo":1,"ofoo":42,"xfoo":null,"arrfoo":null,"objfoo":null}', stringify(obj))
+  t.equal(stringify(obj), '{"foo":1,"ofoo":42}')
 })
 
 test('additionalProperties - boolean coerce', (t) => {
@@ -120,7 +120,7 @@ test('additionalProperties - boolean coerce', (t) => {
   })
 
   const obj = { foo: 'true', ofoo: 0, arrfoo: [1, 2], objfoo: { a: true } }
-  t.equal('{"foo":true,"ofoo":false,"arrfoo":true,"objfoo":true}', stringify(obj))
+  t.equal(stringify(obj), '{"foo":true,"ofoo":false,"arrfoo":true,"objfoo":true}')
 })
 
 test('additionalProperties - object coerce', (t) => {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -246,6 +246,36 @@ buildTest({
   readonly: true
 })
 
+test('skip or coerce numbers and integers that are not numbers', (t) => {
+  const stringify = build({
+    'title': 'basic',
+    'type': 'object',
+    'properties': {
+      'age': {
+        'type': 'number'
+      },
+      'distance': {
+        'type': 'integer'
+      }
+    }
+  })
+
+  var result = stringify({
+    age: 'hello  ',
+    distance: 'long'
+  })
+
+  t.deepEqual(JSON.parse(result), {})
+
+  result = stringify({
+    age: '42',
+    distance: true
+  })
+
+  t.deepEqual(JSON.parse(result), { age: 42, distance: 1 })
+  t.end()
+})
+
 test('Should throw on invalid schema', t => {
   t.plan(1)
   try {

--- a/test/long.test.js
+++ b/test/long.test.js
@@ -44,7 +44,7 @@ test(`render an object with long as JSON`, (t) => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test(`render aan array with long as JSON`, (t) => {
+test(`render an array with long as JSON`, (t) => {
   t.plan(2)
 
   const schema = {
@@ -60,5 +60,26 @@ test(`render aan array with long as JSON`, (t) => {
   const output = stringify([Long.fromString('18446744073709551615', true)])
 
   t.equal(output, '[18446744073709551615]')
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})
+
+test(`render an object with a long additionalProperty as JSON`, (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with long',
+    type: 'object',
+    additionalProperties: {
+      type: 'integer'
+    }
+  }
+
+  const validate = validator(schema)
+  const stringify = build(schema)
+  const output = stringify({
+    num: Long.fromString('18446744073709551615', true)
+  })
+
+  t.equal(output, '{"num":18446744073709551615}')
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })

--- a/test/required.test.js
+++ b/test/required.test.js
@@ -40,3 +40,41 @@ test('object with required field', (t) => {
     t.pass()
   }
 })
+
+test('required numbers', (t) => {
+  t.plan(3)
+
+  const schema = {
+    title: 'object with required field',
+    type: 'object',
+    properties: {
+      str: {
+        type: 'string'
+      },
+      num: {
+        type: 'integer'
+      }
+    },
+    required: ['num']
+  }
+  const stringify = build(schema)
+
+  try {
+    stringify({
+      num: 42
+    })
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  try {
+    stringify({
+      num: 'aaa'
+    })
+    t.fail()
+  } catch (e) {
+    t.is(e.message, 'num is required!')
+    t.pass()
+  }
+})


### PR DESCRIPTION
This is an alternative to #69. Instead of throwing, it skips.

**master**:

```
JSON.stringify array x 3,379 ops/sec ±2.12% (86 runs sampled)
fast-json-stringify array x 6,406 ops/sec ±2.28% (84 runs sampled)
fast-json-stringify-uglified array x 6,283 ops/sec ±2.68% (83 runs sampled)
JSON.stringify long string x 9,841 ops/sec ±2.10% (86 runs sampled)
fast-json-stringify long string x 9,857 ops/sec ±2.14% (85 runs sampled)
fast-json-stringify-uglified long string x 9,862 ops/sec ±1.99% (85 runs sampled)
JSON.stringify short string x 4,071,077 ops/sec ±1.99% (83 runs sampled)
fast-json-stringify short string x 22,269,979 ops/sec ±2.17% (80 runs sampled)
fast-json-stringify-uglified short string x 23,330,578 ops/sec ±1.87% (85 runs sampled)
JSON.stringify obj x 1,670,370 ops/sec ±1.83% (86 runs sampled)
fast-json-stringify obj x 5,627,527 ops/sec ±2.15% (85 runs sampled)
fast-json-stringify-uglified obj x 5,726,660 ops/sec ±2.48% (87 runs sampled)
```

**no-numbers**:

```
JSON.stringify array x 3,460 ops/sec ±1.77% (89 runs sampled)
fast-json-stringify array x 6,622 ops/sec ±2.37% (87 runs sampled)
fast-json-stringify-uglified array x 6,590 ops/sec ±1.64% (89 runs sampled)
JSON.stringify long string x 9,932 ops/sec ±2.15% (84 runs sampled)
fast-json-stringify long string x 9,835 ops/sec ±2.46% (83 runs sampled)
fast-json-stringify-uglified long string x 9,859 ops/sec ±2.40% (85 runs sampled)
JSON.stringify short string x 4,236,321 ops/sec ±2.00% (88 runs sampled)
fast-json-stringify short string x 23,252,000 ops/sec ±2.10% (85 runs sampled)
fast-json-stringify-uglified short string x 22,688,699 ops/sec ±2.34% (83 runs sampled)
JSON.stringify obj x 1,620,479 ops/sec ±2.34% (83 runs sampled)
fast-json-stringify obj x 5,773,492 ops/sec ±1.87% (88 runs sampled)
fast-json-stringify-uglified obj x 5,749,619 ops/sec ±1.88% (86 runs sampled)
```

In order to maintain the throughput, I had to inline `$asNumber` and `$asInteger` in a couple of places, in fact making the generation **faster** when rendering arrays.

Please review carefully.

Related to fastify/fastify#693.