### PR TITLE
Removed fast-safe-stringify, use plain JSON.stringify.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ console.log(stringify(obj)) // '{"matchfoo":"42","otherfoo":"str","matchnum":3,"
 *additionalProperties* will work only for the properties that are not explicitly listed in the *properties* and *patternProperties* objects.
 
 If *additionalProperties* is not present or is set to `false`, every property that is not explicitly listed in the *properties* and *patternProperties* objects,will be ignored, as described in <a href="#missingFields">Missing fields</a>.  
-If *additionalProperties* is set to `true`, it will be used by `fast-safe-stringify` to stringify the additional properties. If you want to achieve maximum performance, we strongly encourage you to use a fixed schema where possible.  
+If *additionalProperties* is set to `true`, it will be used by `JSON.stringify` to stringify the additional properties. If you want to achieve maximum performance, we strongly encourage you to use a fixed schema where possible.  
 Example:
 ```javascript
 const stringify = fastJson({

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-var fastSafeStringify = require('fast-safe-stringify')
 var Ajv = require('ajv')
 
 var uglify = null
@@ -91,10 +90,6 @@ function build (schema, options) {
 
   var dependencies = []
   var dependenciesName = []
-  if (hasAdditionalPropertiesTrue(schema)) {
-    dependencies.push(fastSafeStringify)
-    dependenciesName.push('fastSafeStringify')
-  }
   if (hasAnyOf(schema)) {
     dependencies.push(new Ajv())
     dependenciesName.push('ajv')
@@ -102,20 +97,6 @@ function build (schema, options) {
 
   dependenciesName.push(code)
   return (Function.apply(null, dependenciesName).apply(null, dependencies))
-}
-
-function hasAdditionalPropertiesTrue (schema) {
-  if (schema.additionalProperties === true) { return true }
-
-  var objectKeys = Object.keys(schema)
-  for (var i = 0; i < objectKeys.length; i++) {
-    var value = schema[objectKeys[i]]
-    if (typeof value === 'object') {
-      if (hasAdditionalPropertiesTrue(value)) { return true }
-    }
-  }
-
-  return false
 }
 
 function hasAnyOf (schema) {
@@ -280,7 +261,7 @@ function additionalProperty (schema, externalSchema, fullSchema) {
     return `
         if (obj[keys[i]] !== undefined) {
           ${addComma}
-          json += $asString(keys[i]) + ':' + fastSafeStringify(obj[keys[i]])
+          json += $asString(keys[i]) + ':' + JSON.stringify(obj[keys[i]])
         }
     `
   }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "uglify-es": "^3.2.2"
   },
   "dependencies": {
-    "ajv": "^6.0.0",
-    "fast-safe-stringify": "^1.2.1"
+    "ajv": "^6.0.0"
   }
 }


### PR DESCRIPTION
As titled. We removed it from fastify long ago anyway.