### PR TITLE
fix "isLong is not defined" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,10 +296,14 @@ function additionalProperty (schema, externalSchema, fullSchema) {
     code += `
         ${addComma}
         var t = Number(obj[keys[i]])
-        if (isLong && isLong(obj[keys[i]]) || !isNaN(t)) {
-          json += $asString(keys[i]) + ':' + $asInteger(obj[keys[i]])
-        }
     `
+    if (isLong) {
+      code += `
+          if (isLong(obj[keys[i]]) || !isNaN(t)) {
+            json += $asString(keys[i]) + ':' + $asInteger(obj[keys[i]])
+          }
+      `
+    }
   } else if (type === 'number') {
     code += `
         var t = Number(obj[keys[i]])
@@ -369,19 +373,33 @@ function buildCode (schema, code, laterCode, name, externalSchema, fullSchema) {
     } else if (type === 'integer') {
       code += `
           var rendered = false
-          if (isLong && isLong(obj['${key}'])) {
-            ${addComma}
-            json += '${$asString(key)}:' + obj['${key}'].toString()
-            rendered = true
-          } else {
+      `
+      if (isLong) {
+        code += `
+            if (isLong(obj['${key}'])) {
+              ${addComma}
+              json += '${$asString(key)}:' + obj['${key}'].toString()
+              rendered = true
+            } else {
+              var t = Number(obj['${key}'])
+              if (!isNaN(t)) {
+                ${addComma}
+                json += '${$asString(key)}:' + t
+                rendered = true
+              }
+            }
+        `
+      } else {
+        code += `
             var t = Number(obj['${key}'])
             if (!isNaN(t)) {
               ${addComma}
               json += '${$asString(key)}:' + t
               rendered = true
             }
-          }
-
+        `
+      }
+      code += `
           if (rendered) {
       `
     } else {

--- a/index.js
+++ b/index.js
@@ -294,13 +294,20 @@ function additionalProperty (schema, externalSchema, fullSchema) {
     `
   } else if (type === 'integer') {
     code += `
-        ${addComma}
         var t = Number(obj[keys[i]])
     `
     if (isLong) {
       code += `
           if (isLong(obj[keys[i]]) || !isNaN(t)) {
+            ${addComma}
             json += $asString(keys[i]) + ':' + $asInteger(obj[keys[i]])
+          }
+      `
+    } else {
+      code += `
+          if (!isNaN(t)) {
+            ${addComma}
+            json += $asString(keys[i]) + ':' + t
           }
       `
     }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "is-my-json-valid": "^2.17.1",
     "long": "^3.2.0",
     "pre-commit": "^1.2.2",
+    "proxyquire": "^1.8.0",
     "standard": "^10.0.3",
     "tap": "^11.0.0",
     "uglify-es": "^3.2.2"

--- a/test/integer.test.js
+++ b/test/integer.test.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const test = require('tap').test
+const validator = require('is-my-json-valid')
+const proxyquire = require('proxyquire')
+const build = proxyquire('..', { long: null })
+
+test(`render an integer as JSON`, (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'integer',
+    type: 'integer'
+  }
+
+  const validate = validator(schema)
+  const stringify = build(schema)
+  const output = stringify(1615)
+
+  t.equal(output, '1615')
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})
+
+test(`render an object with an integer as JSON`, (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with integer',
+    type: 'object',
+    properties: {
+      id: {
+        type: 'integer'
+      }
+    }
+  }
+
+  const validate = validator(schema)
+  const stringify = build(schema)
+  const output = stringify({
+    id: 1615
+  })
+
+  t.equal(output, '{"id":1615}')
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})
+
+test(`render an array with an integer as JSON`, (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'array with integer',
+    type: 'array',
+    items: {
+      type: 'integer'
+    }
+  }
+
+  const validate = validator(schema)
+  const stringify = build(schema)
+  const output = stringify([1615])
+
+  t.equal(output, '[1615]')
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})
+
+test(`render an object with an additionalProperty of type integer as JSON`, (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with integer',
+    type: 'object',
+    additionalProperties: {
+      type: 'integer'
+    }
+  }
+
+  const validate = validator(schema)
+  const stringify = build(schema)
+  const output = stringify({
+    num: 1615
+  })
+
+  t.equal(output, '{"num":1615}')
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})


### PR DESCRIPTION
After updating to version 1, I encountered an "isLong is not defined" error. I figured that was because I am not using the long package and it isn't installed at all in my package. Here is a little example to illustrate the problem.

```js
const fastJson = require('fast-json-stringify');

fastJson({
    "properties": {
        "x": {
            "type": "integer"
        }
    },
    "$schema": "http://json-schema.org/draft-07/schema#",
    "type": "object"
})({ x: 2 });
```

Running that code will trigger the error.

I fixed the problem by extracting the checks for `isLong` from the generated code. I'm not entirely sure if that's the way it should be done, but I can imagine that it will also bring some little speed improvements as it does not insert if statements anymore which are going to fail anyway.

Please let me know if you want me to make any changes.