### PR TITLE
Fix serialization of nested objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,11 +24,7 @@ function build (schema, options) {
   var code = `
     'use strict'
   `
-  // used to support patternProperties and additionalProperties
-  // they need to check if a field belongs to the properties in the schema
-  code += `
-    var properties = ${JSON.stringify(schema.properties)} || {}
-  `
+
   code += `
     ${$asString.toString()}
     ${$asStringSmall.toString()}
@@ -218,6 +214,7 @@ function $asStringSmall (str) {
 function addPatternProperties (schema, externalSchema, fullSchema) {
   var pp = schema.patternProperties
   var code = `
+      var properties = ${JSON.stringify(schema.properties)} || {}
       var keys = Object.keys(obj)
       for (var i = 0; i < keys.length; i++) {
         if (properties[keys[i]]) continue
@@ -368,6 +365,7 @@ function additionalProperty (schema, externalSchema, fullSchema) {
 
 function addAdditionalProperties (schema, externalSchema, fullSchema) {
   return `
+      var properties = ${JSON.stringify(schema.properties)} || {}
       var keys = Object.keys(obj)
       for (var i = 0; i < keys.length; i++) {
         if (properties[keys[i]]) continue

--- a/test/nestedObjects.test.js
+++ b/test/nestedObjects.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const test = require('tap').test
+const build = require('..')
+
+test('nested objects with same properties', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'nested objects with same properties',
+    type: 'object',
+    properties: {
+      stringProperty: {
+        type: 'string'
+      },
+      objectProperty: {
+        type: 'object',
+        additionalProperties: true
+      }
+    }
+  }
+  const stringify = build(schema)
+
+  try {
+    const value = stringify({
+      stringProperty: 'string1',
+      objectProperty: {
+        stringProperty: 'string2',
+        numberProperty: 42
+      }
+    })
+    t.is(value, '{"stringProperty":"string1","objectProperty":{"stringProperty":"string2","numberProperty":42}}')
+  } catch (e) {
+    t.fail()
+  }
+})


### PR DESCRIPTION
This fixes the serialization of nested objects when the contain the same properties as the parent, but use additionalProperties or patternProperties. Fixes #79.

**Benchmark before**
```
JSON.stringify array x 4,626 ops/sec ±0.36% (95 runs sampled)
fast-json-stringify array x 8,244 ops/sec ±0.66% (90 runs sampled)
fast-json-stringify-uglified array x 8,290 ops/sec ±0.51% (88 runs sampled)
JSON.stringify long string x 17,645 ops/sec ±0.36% (96 runs sampled)
fast-json-stringify long string x 17,400 ops/sec ±0.95% (94 runs sampled)
fast-json-stringify-uglified long string x 17,371 ops/sec ±1.10% (93 runs sampled)
JSON.stringify short string x 5,758,694 ops/sec ±0.15% (94 runs sampled)
fast-json-stringify short string x 32,446,046 ops/sec ±0.35% (96 runs sampled)
fast-json-stringify-uglified short string x 32,126,762 ops/sec ±0.22% (92 runs sampled)
JSON.stringify obj x 2,165,489 ops/sec ±0.44% (95 runs sampled)
fast-json-stringify obj x 7,150,784 ops/sec ±0.47% (95 runs sampled)
fast-json-stringify-uglified obj x 7,092,883 ops/sec ±0.73% (89 runs sampled)
```

**Benchmark after**
```
JSON.stringify array x 4,628 ops/sec ±0.37% (94 runs sampled)
fast-json-stringify array x 8,244 ops/sec ±0.78% (88 runs sampled)
fast-json-stringify-uglified array x 8,132 ops/sec ±0.60% (88 runs sampled)
JSON.stringify long string x 17,656 ops/sec ±0.32% (94 runs sampled)
fast-json-stringify long string x 17,661 ops/sec ±0.16% (95 runs sampled)
fast-json-stringify-uglified long string x 17,615 ops/sec ±0.47% (95 runs sampled)
JSON.stringify short string x 5,748,825 ops/sec ±0.21% (98 runs sampled)
fast-json-stringify short string x 27,898,277 ops/sec ±0.58% (93 runs sampled)
fast-json-stringify-uglified short string x 33,354,991 ops/sec ±0.26% (93 runs sampled)
JSON.stringify obj x 2,115,439 ops/sec ±0.62% (94 runs sampled)
fast-json-stringify obj x 7,024,289 ops/sec ±0.43% (93 runs sampled)
fast-json-stringify-uglified obj x 7,155,966 ops/sec ±0.68% (93 runs sampled)
```