### PR TITLE
string type arrays handling dates

### DIFF
--- a/index.js
+++ b/index.js
@@ -670,12 +670,22 @@ function nested (laterCode, name, key, schema, externalSchema, fullSchema, subKe
         type.forEach((type, index) => {
           var tempSchema = {type: type}
           var nestedResult = nested(laterCode, name, key, tempSchema, externalSchema, fullSchema, subKey)
-          code += `
-            ${index === 0 ? 'if' : 'else if'}(ajv.validate(${require('util').inspect(tempSchema, {depth: null})}, obj${accessor}))
+          if (type === 'string') {
+            code += `
+              ${index === 0 ? 'if' : 'else if'}(obj${accessor} instanceof Date || ajv.validate(${require('util').inspect(tempSchema, {depth: null})}, obj${accessor}))
+                ${nestedResult.code}
+            `
+          } else {
+            code += `
+              ${index === 0 ? 'if' : 'else if'}(ajv.validate(${require('util').inspect(tempSchema, {depth: null})}, obj${accessor}))
               ${nestedResult.code}
-          `
+            `
+          }
           laterCode = nestedResult.laterCode
         })
+        code += `
+          else json+= null
+        `
       } else {
         throw new Error(`${type} unsupported`)
       }

--- a/test/typesArray.test.js
+++ b/test/typesArray.test.js
@@ -182,3 +182,22 @@ test('object with anyOf and multiple types', (t) => {
     t.fail()
   }
 })
+
+test('string type array can handle dates', (t) => {
+  t.plan(1)
+  const schema = {
+    type: 'object',
+    properties: {
+      date: { type: ['string'] }
+    }
+  }
+  const stringify = build(schema)
+  try {
+    const value = stringify({
+      date: new Date('2018-04-20T07:52:31.017Z')
+    })
+    t.is(value, '{"date":"2018-04-20T07:52:31.017Z"}')
+  } catch (e) {
+    t.fail()
+  }
+})


### PR DESCRIPTION
I was trying to add response schemas to a production app using nullable dates and fastify. I noticed that type arrays would not work with string for dates while it worked fine when not using type arrays.
```javascript
{                                                                  
   type: 'object',                                                 
   properties: {                                                  
     date: { type: 'string' }                                  
   }                                                            
}
```
works for dates and will produce
```javascript
function $main(obj) {
  var json = '{'
  var addComma = false
  if (obj['date'] !== undefined) {
    if (addComma) {
      json += ','
    }
    addComma = true
    json += '"date":'
    json += $asString(obj['date'])
  }
  json += '}'
  return json
}
``` 
while
```javascript
{                                                                  
   type: 'object',                                                 
   properties: {                                                  
     date: { type: ['string'] }                                  
   }                                                            
}
```
does not work and will produce
```javascript
function $main(obj) {
  var json = '{'
  var addComma = false
  if (obj['date'] !== undefined) {
    if (addComma) {
      json += ','
    }
    addComma = true
    json += '"date":'

    if (ajv.validate({ type: 'string'}, obj['date']))
      json += $asString(obj['date'])
  }
  json += '}'
  return json
}
```
since Date is of type object ```Ajv.validate({ type: 'string'}, someDate)``` will fail and not get passed to ```$asString```

With the fix the produced function looks like this:
```javascript
function $main(obj) {
  var json = '{'
  var addComma = false
  if (obj['date'] !== undefined) {
    if (addComma) {
      json += ','
    }
    addComma = true
    json += '"date":'
    if (obj['date'] instanceof Date || ajv.validate({ type: 'string' }, obj['date']))
      json += $asString(obj['date'])
    else json += null
  }
  json += '}'
  return json
}
```
I also added an else case so it will always produce valid json.

Benchmark before
```
JSON.stringify array x 2,712 ops/sec ±1.00% (84 runs sampled)
fast-json-stringify array x 3,440 ops/sec ±1.03% (87 runs sampled)
fast-json-stringify-uglified array x 3,466 ops/sec ±0.96% (88 runs sampled)
JSON.stringify long string x 11,898 ops/sec ±1.01% (85 runs sampled)
fast-json-stringify long string x 11,693 ops/sec ±1.55% (87 runs sampled)
fast-json-stringify-uglified long string x 11,703 ops/sec ±1.19% (87 runs sampled)
JSON.stringify short string x 3,984,047 ops/sec ±1.08% (87 runs sampled)
fast-json-stringify short string x 7,459,043 ops/sec ±0.84% (85 runs sampled)
fast-json-stringify-uglified short string x 7,442,658 ops/sec ±1.02% (87 runs sampled)
JSON.stringify obj x 1,204,803 ops/sec ±1.04% (86 runs sampled)
fast-json-stringify obj x 3,049,330 ops/sec ±1.08% (90 runs sampled)
fast-json-stringify-uglified obj x 3,101,949 ops/sec ±0.93% (89 runs sampled)
```

Benchmark after
```
JSON.stringify array x 2,713 ops/sec ±1.01% (86 runs sampled)
fast-json-stringify array x 3,454 ops/sec ±1.41% (89 runs sampled)
fast-json-stringify-uglified array x 3,482 ops/sec ±0.85% (87 runs sampled)
JSON.stringify long string x 11,848 ops/sec ±1.02% (87 runs sampled)
fast-json-stringify long string x 11,780 ops/sec ±0.79% (87 runs sampled)
fast-json-stringify-uglified long string x 11,724 ops/sec ±1.08% (85 runs sampled)
JSON.stringify short string x 3,954,375 ops/sec ±0.83% (88 runs sampled)
fast-json-stringify short string x 7,493,674 ops/sec ±0.81% (85 runs sampled)
fast-json-stringify-uglified short string x 7,417,784 ops/sec ±0.86% (87 runs sampled)
JSON.stringify obj x 1,204,706 ops/sec ±0.94% (86 runs sampled)
fast-json-stringify obj x 3,069,088 ops/sec ±1.05% (85 runs sampled)
fast-json-stringify-uglified obj x 3,095,127 ops/sec ±1.00% (85 runs sampled)
```