### PR TITLE
speed up creation time by 100x.

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -35,12 +35,13 @@ const obj = {
 
 const multiArray = []
 
-const stringify = require('.')(schema)
-const stringifyUgly = require('.')(schema, { uglify: true })
-const stringifyArray = require('.')(arraySchema)
-const stringifyArrayUgly = require('.')(arraySchema, { uglify: true })
-const stringifyString = require('.')({ type: 'string' })
-const stringifyStringUgly = require('.')({ type: 'string', uglify: true })
+const FJS = require('.')
+const stringify = FJS(schema)
+const stringifyUgly = FJS(schema, { uglify: true })
+const stringifyArray = FJS(arraySchema)
+const stringifyArrayUgly = FJS(arraySchema, { uglify: true })
+const stringifyString = FJS({ type: 'string' })
+const stringifyStringUgly = FJS({ type: 'string', uglify: true })
 var str = ''
 
 for (var i = 0; i < 10000; i++) {
@@ -55,6 +56,10 @@ Number(str)
 for (i = 0; i < 1000; i++) {
   multiArray.push(obj)
 }
+
+suite.add('FJS creation', function () {
+  FJS(schema)
+})
 
 suite.add('JSON.stringify array', function () {
   JSON.stringify(multiArray)

--- a/index.js
+++ b/index.js
@@ -2,6 +2,11 @@
 
 var Ajv = require('ajv')
 
+// This Ajv instance is used to validate that the passed schema
+// is valid json schema. We reuse the instance to avoid having to
+// pay the ajv creation cost more than once.
+var ajv = new Ajv()
+
 var uglify = null
 var isLong
 try {
@@ -730,13 +735,17 @@ function loadUglify () {
 }
 
 function isValidSchema (schema, externalSchema) {
-  const ajv = new Ajv()
   if (externalSchema) {
     Object.keys(externalSchema).forEach(key => {
       ajv.addSchema(externalSchema[key], key)
     })
   }
   ajv.compile(schema)
+  if (externalSchema) {
+    Object.keys(externalSchema).forEach(key => {
+      ajv.removeSchema(key)
+    })
+  }
 }
 
 module.exports = build


### PR DESCRIPTION
We cache a module-wide Ajv instance instead of creating a new one
to validate each schema and then throw it away.