### PR TITLE
Removed all cached schemas

### DIFF
--- a/index.js
+++ b/index.js
@@ -802,11 +802,7 @@ function isValidSchema (schema, externalSchema) {
     })
   }
   ajv.compile(schema)
-  if (externalSchema) {
-    Object.keys(externalSchema).forEach(key => {
-      ajv.removeSchema(key)
-    })
-  }
+  ajv.removeSchema()
 }
 
 module.exports = build

--- a/test/clean-cache.test.js
+++ b/test/clean-cache.test.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const test = require('tap').test
+const build = require('..')
+
+test('Should clean the cache', (t) => {
+  t.plan(1)
+
+  const schema = {
+    $id: 'test',
+    type: 'string'
+  }
+
+  try {
+    build(schema)
+    build(schema)
+    t.pass()
+  } catch (err) {
+    t.fail(err)
+  }
+})
+
+test('Should clean the cache with external schemas', (t) => {
+  t.plan(1)
+
+  const schema = {
+    $id: 'test',
+    definitions: {
+      def: {
+        type: 'object',
+        properties: {
+          str: {
+            type: 'string'
+          }
+        }
+      }
+    },
+    type: 'object',
+    properties: {
+      obj: {
+        $ref: '#/definitions/def'
+      }
+    }
+  }
+
+  try {
+    build(schema)
+    build(schema)
+    t.pass()
+  } catch (err) {
+    t.fail(err)
+  }
+})


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify/issues/922.
I'll open a pr also in Fastify to test this behavior.

[Ajv docs](https://github.com/epoberezkin/ajv#removeschemaobject-schemastring-keystring-refregexp-pattern---ajv) for reference.