### PR TITLE
Fix object and null possible type handling.

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -11,7 +11,7 @@ const schema = {
       'type': 'string'
     },
     'lastName': {
-      'type': 'string'
+      'type': ['string', 'null']
     },
     'age': {
       'description': 'Age in years',

--- a/index.js
+++ b/index.js
@@ -733,7 +733,7 @@ function nested (laterCode, name, key, schema, externalSchema, fullSchema, subKe
         const nullIndex = type.indexOf('null')
         const sortedTypes = nullIndex !== -1 ? [type[nullIndex]].concat(type.slice(0, nullIndex)).concat(type.slice(nullIndex + 1)) : type
         sortedTypes.forEach((type, index) => {
-          var tempSchema = {...schema, type}
+          var tempSchema = Object.assign({}, schema, {type})
           var nestedResult = nested(laterCode, name, key, tempSchema, externalSchema, fullSchema, subKey)
           if (type === 'string') {
             code += `

--- a/test/typesArray.test.js
+++ b/test/typesArray.test.js
@@ -3,15 +3,20 @@
 const test = require('tap').test
 const build = require('..')
 
-test('simple object with multi-type property', (t) => {
-  t.plan(2)
+test('possibly null object with multi-type property', (t) => {
+  t.plan(3)
 
   const schema = {
     title: 'simple object with multi-type property',
     type: 'object',
     properties: {
-      stringOrNumber: {
-        type: ['string', 'number']
+      objectOrNull: {
+        type: ['object', 'null'],
+        properties: {
+          stringOrNumber: {
+            type: ['string', 'number']
+          }
+        }
       }
     }
   }
@@ -19,39 +24,61 @@ test('simple object with multi-type property', (t) => {
 
   try {
     const value = stringify({
-      stringOrNumber: 'string'
+      objectOrNull: {
+        stringOrNumber: 'string'
+      }
     })
-    t.is(value, '{"stringOrNumber":"string"}')
+    t.is(value, '{"objectOrNull":{"stringOrNumber":"string"}}')
   } catch (e) {
     t.fail()
   }
 
   try {
     const value = stringify({
-      stringOrNumber: 42
+      objectOrNull: {
+        stringOrNumber: 42
+      }
     })
-    t.is(value, '{"stringOrNumber":42}')
+    t.is(value, '{"objectOrNull":{"stringOrNumber":42}}')
+  } catch (e) {
+    t.fail()
+  }
+  try {
+    const value = stringify({
+      objectOrNull: null
+    })
+    t.is(value, '{"objectOrNull":null}')
   } catch (e) {
     t.fail()
   }
 })
 
-test('object with array of multiple types', (t) => {
-  t.plan(3)
+test('object with possibly null array of multiple types', (t) => {
+  t.plan(5)
 
   const schema = {
     title: 'object with array of multiple types',
     type: 'object',
     properties: {
       arrayOfStringsAndNumbers: {
-        type: 'array',
+        type: ['array', 'null'],
         items: {
-          type: ['string', 'number']
+          type: ['string', 'number', 'null']
         }
       }
     }
   }
   const stringify = build(schema)
+
+  try {
+    const value = stringify({
+      arrayOfStringsAndNumbers: null
+    })
+    t.is(value, '{"arrayOfStringsAndNumbers":null}')
+  } catch (e) {
+    console.log(e)
+    t.fail()
+  }
 
   try {
     const value = stringify({
@@ -77,6 +104,14 @@ test('object with array of multiple types', (t) => {
       arrayOfStringsAndNumbers: ['string1', 42, 7, 'string2']
     })
     t.is(value, '{"arrayOfStringsAndNumbers":["string1",42,7,"string2"]}')
+  } catch (e) {
+    t.fail()
+  }
+  try {
+    const value = stringify({
+      arrayOfStringsAndNumbers: ['string1', null, 42, 7, 'string2', null]
+    })
+    t.is(value, '{"arrayOfStringsAndNumbers":["string1",null,42,7,"string2",null]}')
   } catch (e) {
     t.fail()
   }


### PR DESCRIPTION
Remove ajv for multiple type handling.

The removal of ajv was not related with this fix but its need is showcased by the edited benchmark.

Before:
```
JSON.stringify obj x 1,624,624 ops/sec ±0.72% (91 runs sampled)
fast-json-stringify obj x 729,975 ops/sec ±0.96% (92 runs sampled)
fast-json-stringify-uglified obj x 730,695 ops/sec ±0.73% (93 runs sampled)
```
After:
```
JSON.stringify obj x 1,638,558 ops/sec ±1.08% (91 runs sampled)
fast-json-stringify obj x 6,023,692 ops/sec ±0.82% (92 runs sampled)
fast-json-stringify-uglified obj x 5,895,250 ops/sec ±0.91% (93 runs sampled)
```