### PR TITLE
feat: ignore unknown formats when compiling schemas

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,18 @@ var merge = require('deepmerge')
 // This Ajv instance is used to validate that the passed schema
 // is valid json schema. We reuse the instance to avoid having to
 // pay the ajv creation cost more than once.
-var ajv = new Ajv()
+var ajv = new Ajv({
+  // Ignore any unknown formats as they aren't used.
+  unknownFormats: 'ignore',
+
+  // Ignoring unknown formats emits warnings, but we don't need to hear about
+  // them.
+  logger: {
+    log: console.log,
+    warn: function () {},
+    error: console.error
+  }
+})
 
 var uglify = null
 var isLong

--- a/test/unknownFormats.test.js
+++ b/test/unknownFormats.test.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const test = require('tap').test
+const build = require('..')
+
+test('object with custom format field', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'object with custom format field',
+    type: 'object',
+    properties: {
+      str: {
+        type: 'string',
+        format: 'test-format'
+      }
+    }
+  }
+
+  const stringify = build(schema)
+
+  try {
+    stringify({
+      str: 'string'
+    })
+
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+})


### PR DESCRIPTION
Resolves #115 

This allows schemas that may have custom formats to be used.

As part of this change I've disabled warning log messages as when setting
`unknownFormats: "ignore"` warning messages are emitted everytime a schema
with unknown formats is compiled.

I have not disabled standard or error log messages.