### PR TITLE
fix if-then-else with deep nested structure

### DIFF
--- a/index.js
+++ b/index.js
@@ -518,12 +518,12 @@ function addIfThenElse (schema, name, externalSchema, fullSchema) {
     if (valid) {
   `
   if (merged.if && merged.then) {
-    innerR = addIfThenElse(merged, name, externalSchema, fullSchema)
+    innerR = addIfThenElse(merged, name + 'Then', externalSchema, fullSchema)
     code += innerR.code
     laterCode = innerR.laterCode
   }
 
-  r = buildInnerObject(merged, name, externalSchema, fullSchema)
+  r = buildInnerObject(merged, name + 'Then', externalSchema, fullSchema)
   code += r.code
   laterCode += r.laterCode
 
@@ -538,12 +538,12 @@ function addIfThenElse (schema, name, externalSchema, fullSchema) {
     `
 
     if (merged.if && merged.then) {
-      innerR = addIfThenElse(merged, name, externalSchema, fullSchema)
+      innerR = addIfThenElse(merged, name + 'Else', externalSchema, fullSchema)
       code += innerR.code
       laterCode += innerR.laterCode
     }
 
-    r = buildInnerObject(merged, name, externalSchema, fullSchema)
+    r = buildInnerObject(merged, name + 'Else', externalSchema, fullSchema)
     code += r.code
     laterCode += r.laterCode
 
@@ -555,8 +555,8 @@ function addIfThenElse (schema, name, externalSchema, fullSchema) {
 }
 
 function toJSON (variableName) {
-  return `typeof ${variableName}.toJSON === 'function' 
-    ? ${variableName}.toJSON() 
+  return `typeof ${variableName}.toJSON === 'function'
+    ? ${variableName}.toJSON()
     : ${variableName}
   `
 }

--- a/test/if-then-else.test.js
+++ b/test/if-then-else.test.js
@@ -33,7 +33,17 @@ const schema = {
     'properties': {
       'kind': { 'type': 'string', 'enum': ['greeting'] },
       'hi': { 'type': 'string' },
-      'hello': { 'type': 'number' }
+      'hello': { 'type': 'number' },
+      'list': {
+        'type': 'array',
+        'items': {
+          'type': 'object',
+          'properties': {
+            'name': { 'type': 'string' },
+            'value': { 'type': 'string' }
+          }
+        }
+      }
     }
   }
 }
@@ -134,6 +144,11 @@ const nestedElseSchema = {
   }
 }
 
+const nestedDeepElseSchema = {
+  'type': 'object',
+  'additionalProperties': schema
+}
+
 const fooBarInput = {
   kind: 'foobar',
   foo: 'FOO',
@@ -165,6 +180,9 @@ const alphabetInput = {
   a: 'A',
   b: 35
 }
+const deepFoobarInput = {
+  foobar: fooBarInput
+}
 const foobarOutput = JSON.stringify({
   kind: 'foobar',
   foo: 'FOO',
@@ -183,6 +201,9 @@ const alphabetOutput = JSON.stringify({
   kind: 'alphabet',
   a: 'A',
   b: 35
+})
+const deepFoobarOutput = JSON.stringify({
+  foobar: JSON.parse(foobarOutput)
 })
 
 t.test('if-then-else', t => {
@@ -234,6 +255,12 @@ t.test('if-then-else', t => {
       schema: nestedElseSchema,
       input: alphabetInput,
       expected: alphabetOutput
+    },
+    {
+      name: 'deep then - else',
+      schema: nestedDeepElseSchema,
+      input: deepFoobarInput,
+      expected: deepFoobarOutput
     }
   ]
 


### PR DESCRIPTION
The two functions created by fast-json-stringify to serialize the object throws with:
_Identifier * has already been declared_
when if-then-else statements is in a deep object structure