### PR TITLE
Fix: move `long` and `uglify-es` to `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
   "devDependencies": {
     "benchmark": "^2.1.4",
     "is-my-json-valid": "^2.19.0",
-    "long": "^4.0.0",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.0",
     "standard": "^12.0.1",
-    "tap": "^12.0.0",
-    "uglify-es": "^3.3.9"
+    "tap": "^12.0.0"
   },
   "dependencies": {
     "ajv": "^6.5.4",
-    "deepmerge": "^2.1.1"
+    "deepmerge": "^2.1.1",
+    "long": "^4.0.0",
+    "uglify-es": "^3.3.9"
   }
 }


### PR DESCRIPTION
To avoid errors after `[npm|yarn] install --production`, both `long` and `uglify-es` should be listed under `dependencies` instead of `devDependencies`.