### PR TITLE
Fix serialization of anyOf with both array and object types

### DIFF
--- a/index.js
+++ b/index.js
@@ -796,7 +796,7 @@ function nested (laterCode, name, key, schema, externalSchema, fullSchema, subKe
       `
       break
     case 'array':
-      funcName = (name + key + subKey).replace(/[-.\[\] ]/g, '') // eslint-disable-line
+      funcName = '$arr' + (name + key + subKey).replace(/[-.\[\] ]/g, '') // eslint-disable-line
       laterCode = buildArray(schema, laterCode, funcName, externalSchema, fullSchema)
       code += `
         json += ${funcName}(obj${accessor})

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "benchmark": "node bench.js",
     "lint": "standard",
-    "unit": "tap -j4 test/**/*.test.js",
+    "unit": "tap -j4 test/*.test.js test/**/*.test.js",
     "test": "npm run lint && npm run unit"
   },
   "precommit": "test",

--- a/test/anyof.test.js
+++ b/test/anyof.test.js
@@ -81,3 +81,43 @@ test('object with field of type object or null', (t) => {
     t.fail()
   }
 })
+
+test('object with field of type object or array', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with field of type object or array',
+    type: 'object',
+    properties: {
+      prop: {
+        anyOf: [{
+          type: 'object',
+          properties: {},
+          additionalProperties: true
+        }, {
+          type: 'array',
+          items: { type: 'string' }
+        }]
+      }
+    }
+  }
+  const stringify = build(schema)
+
+  try {
+    const value = stringify({
+      prop: { str: 'string' }
+    })
+    t.is(value, '{"prop":{"str":"string"}}')
+  } catch (e) {
+    t.fail()
+  }
+
+  try {
+    const value = stringify({
+      prop: ['string']
+    })
+    t.is(value, '{"prop":["string"]}')
+  } catch (e) {
+    t.fail()
+  }
+})


### PR DESCRIPTION
`anyOf` used with both a type `object` and `array` fails to serialize either of the type since the serialization functions are named the same. I added a prefix to the array one but I'm not sure it's the right way to go, if you have a better suggestion I can change.