### PR TITLE
Fix/ref to

### DIFF
--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -433,3 +433,54 @@ test('ref internal - plain name fragment', (t) => {
 
   t.equal(output, '{"obj":{"str":"test"}}')
 })
+
+test('ref internal - multiple $ref format', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    definitions: {
+      one: {
+        type: 'string',
+        definitions: {
+          two: {
+            $id: '#twos',
+            type: 'string'
+          }
+        }
+      }
+    },
+    properties: {
+      zero: {
+        $id: '#three',
+        type: 'string'
+      },
+      a: { $ref: '#/definitions/one' },
+      b: { $ref: '#three' },
+      c: { $ref: '#/properties/zero' },
+      d: { $ref: '#twos' },
+      e: { $ref: '#/definitions/one/definitions/two' }
+    }
+  }
+
+  const object = {
+    zero: 'test',
+    a: 'test',
+    b: 'test',
+    c: 'test',
+    d: 'test',
+    e: 'test'
+  }
+
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal(output, '{"zero":"test","a":"test","b":"test","c":"test","d":"test","e":"test"}')
+})

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -389,3 +389,47 @@ test('ref internal - deepObject schema', (t) => {
 
   t.equal(output, '{"winter":{"is":{"coming":{"where":"to town"}}}}')
 })
+
+test('ref internal - plain name fragment', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with $ref',
+    definitions: {
+      def: {
+        $id: '#uri',
+        type: 'object',
+        properties: {
+          str: {
+            type: 'string'
+          }
+        },
+        required: ['str']
+      }
+    },
+    type: 'object',
+    properties: {
+      obj: {
+        $ref: '#uri'
+      }
+    }
+  }
+
+  const object = {
+    obj: {
+      str: 'test'
+    }
+  }
+
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal(output, '{"obj":{"str":"test"}}')
+})


### PR DESCRIPTION
Hi, this PR fixes #136 

I run the bench.js three times with Node 10.11. 
I don't expect any improvement or defect on overall performance because these changes should be executed only when a `$ref = '#customId'` is found.

master:

	FJS creation x 5,465 ops/sec ±5.09% (84 runs sampled)
	JSON.stringify array x 2,375 ops/sec ±1.04% (92 runs sampled)
	fast-json-stringify array x 5,698 ops/sec ±2.89% (90 runs sampled)
	fast-json-stringify-uglified array x 5,255 ops/sec ±3.61% (84 runs sampled)
	JSON.stringify long string x 9,292 ops/sec ±0.73% (91 runs sampled)
	fast-json-stringify long string x 9,155 ops/sec ±2.34% (92 runs sampled)
	fast-json-stringify-uglified long string x 9,315 ops/sec ±0.30% (95 runs sampled)
	JSON.stringify short string x 3,425,224 ops/sec ±6.24% (81 runs sampled)
	fast-json-stringify short string x 29,926,884 ops/sec ±1.38% (88 runs sampled)
	fast-json-stringify-uglified short string x 29,070,119 ops/sec ±1.53% (87 runs sampled)
	JSON.stringify obj x 1,304,634 ops/sec ±1.25% (92 runs sampled)
	fast-json-stringify obj x 5,742,953 ops/sec ±1.12% (89 runs sampled)
	fast-json-stringify-uglified obj x 5,716,443 ops/sec ±1.03% (91 runs sampled)


this branch:

	FJS creation x 5,498 ops/sec ±4.91% (84 runs sampled)
	JSON.stringify array x 2,217 ops/sec ±4.27% (86 runs sampled)
	fast-json-stringify array x 5,506 ops/sec ±4.50% (85 runs sampled)
	fast-json-stringify-uglified array x 5,455 ops/sec ±4.81% (83 runs sampled)
	JSON.stringify long string x 9,002 ops/sec ±2.77% (89 runs sampled)
	fast-json-stringify long string x 9,312 ops/sec ±0.51% (94 runs sampled)
	fast-json-stringify-uglified long string x 9,325 ops/sec ±0.34% (92 runs sampled)
	JSON.stringify short string x 3,898,407 ops/sec ±0.98% (92 runs sampled)
	fast-json-stringify short string x 28,256,237 ops/sec ±4.10% (82 runs sampled)
	fast-json-stringify-uglified short string x 29,507,831 ops/sec ±1.74% (86 runs sampled)
	JSON.stringify obj x 1,201,048 ops/sec ±7.02% (82 runs sampled)
	fast-json-stringify obj x 5,713,316 ops/sec ±1.04% (88 runs sampled)
	fast-json-stringify-uglified obj x 5,601,133 ops/sec ±1.63% (89 runs sampled)
