### PR TITLE
Make null handling for integer and number consistent

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,6 +195,8 @@ function $asNull () {
 }
 
 function $asInteger (i) {
+  if (i === null) return $asNull()
+
   if (isLong && isLong(i)) {
     return i.toString()
   } else {
@@ -203,6 +205,8 @@ function $asInteger (i) {
 }
 
 function $asNumber (i) {
+  if (i === null) return $asNull()
+
   var num = Number(i)
   if (isNaN(num)) {
     return 'null'
@@ -477,7 +481,7 @@ function buildCode (schema, code, laterCode, name, externalSchema, fullSchema) {
     var type = schema.properties[key].type
     if (type === 'number') {
       code += `
-          var t = Number(obj['${key}'])
+          var t = obj['${key}'] !== null ? Number(obj['${key}']) : ${$asNull()}
           if (!isNaN(t)) {
             ${addComma}
             json += '${$asString(key)}:' + t
@@ -493,7 +497,7 @@ function buildCode (schema, code, laterCode, name, externalSchema, fullSchema) {
               json += '${$asString(key)}:' + obj['${key}'].toString()
               rendered = true
             } else {
-              var t = Number(obj['${key}'])
+              var t = obj['${key}'] !== null ? Number(obj['${key}']) : ${$asNull()}
               if (!isNaN(t)) {
                 ${addComma}
                 json += '${$asString(key)}:' + t
@@ -503,7 +507,7 @@ function buildCode (schema, code, laterCode, name, externalSchema, fullSchema) {
         `
       } else {
         code += `
-            var t = Number(obj['${key}'])
+            var t = obj['${key}'] !== null ? Number(obj['${key}']) : ${$asNull()}
             if (!isNaN(t)) {
               ${addComma}
               json += '${$asString(key)}:' + t

--- a/test/missing-values.test.js
+++ b/test/missing-values.test.js
@@ -41,3 +41,33 @@ test('handle null when value should be string', (t) => {
 
   t.equal('{"str":""}', stringify({ str: null }))
 })
+
+test('handle null when value should be number', (t) => {
+  t.plan(1)
+
+  const stringify = build({
+    type: 'object',
+    properties: {
+      num: {
+        type: 'number'
+      }
+    }
+  })
+
+  t.equal('{"num":null}', stringify({ num: null }))
+})
+
+test('handle null when value should be integer', (t) => {
+  t.plan(1)
+
+  const stringify = build({
+    type: 'object',
+    properties: {
+      int: {
+        type: 'integer'
+      }
+    }
+  })
+
+  t.equal('{"int":null}', stringify({ int: null }))
+})


### PR DESCRIPTION
Since `['integer']` and `['number']` types are nullable, we should make 'integer' and 'number' types nullable by default as well.

Should we throw if a `null` value is given to a `required` property?