### PR TITLE
Dropped uglifier support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,15 @@ FJS creation x 8,951 ops/sec ±0.51% (92 runs sampled)
 
 JSON.stringify array x 5,146 ops/sec ±0.32% (97 runs sampled)
 fast-json-stringify array x 8,402 ops/sec ±0.62% (95 runs sampled)
-fast-json-stringify-uglified array x 8,474 ops/sec ±0.49% (93 runs sampled)
 
 JSON.stringify long string x 13,061 ops/sec ±0.25% (98 runs sampled)
 fast-json-stringify long string x 13,059 ops/sec ±0.21% (98 runs sampled)
-fast-json-stringify-uglified long string x 13,099 ops/sec ±0.14% (98 runs sampled)
 
 JSON.stringify short string x 6,295,988 ops/sec ±0.28% (98 runs sampled)
 fast-json-stringify short string x 43,335,575 ops/sec ±1.24% (86 runs sampled)
-fast-json-stringify-uglified short string x 40,042,871 ops/sec ±1.38% (93 runs sampled)
 
 JSON.stringify obj x 2,557,026 ops/sec ±0.20% (97 runs sampled)
 fast-json-stringify obj x 9,001,890 ops/sec ±0.48% (90 runs sampled)
-fast-json-stringify-uglified obj x 9,073,607 ops/sec ±0.41% (94 runs sampled)
 ```
 
 #### Table of contents:
@@ -40,7 +36,6 @@ fast-json-stringify-uglified obj x 9,073,607 ops/sec ±0.41% (94 runs sampled)
  - <a href="#anyof">`AnyOf`</a>
  - <a href="#ref">`Reuse - $ref`</a>
  - <a href="#long">`Long integers`</a>
- - <a href="#uglify">`Uglify`</a>
  - <a href="#nullable">`Nullable`</a>
 - <a href="#caveat">`Caveat`</a>
 - <a href="#acknowledgements">`Acknowledgements`</a>
@@ -427,30 +422,6 @@ const obj = {
 }
 
 console.log(stringify(obj)) // '{"id":18446744073709551615}'
-```
-
-<a name="uglify"></a>
-#### Uglify
-If you want to squeeze a little bit more performance out of the serialization at the cost of readability in the generated code, you can pass `uglify: true` as an option.
-Note that you have to manually install `uglify-es` in order for this to work. Only version 3 is supported.
-Example:
-
-Note that if you are using Node 8.3.0 or newer, there are no performance gains from using Uglify. See https://www.nearform.com/blog/node-js-is-getting-a-new-v8-with-turbofan/
-
-```javascript
-
-const stringify = fastJson({
-  title: 'Example Schema',
-  type: 'object',
-  properties: {
-    id: {
-      type: 'integer'
-    }
-  }
-}, { uglify: true })
-
-// stringify is now minified code
-console.log(stringify({ some: 'object' })) // '{"some":"object"}'
 ```
 
 <a name="nullable"></a>

--- a/bench.js
+++ b/bench.js
@@ -70,11 +70,8 @@ const CJSStringifyString = CJS({ type: 'string' })
 
 const FJS = require('.')
 const stringify = FJS(schema)
-const stringifyUgly = FJS(schema, { uglify: true })
 const stringifyArray = FJS(arraySchema)
-const stringifyArrayUgly = FJS(arraySchema, { uglify: true })
 const stringifyString = FJS({ type: 'string' })
-const stringifyStringUgly = FJS({ type: 'string', uglify: true })
 var str = ''
 
 for (var i = 0; i < 10000; i++) {
@@ -108,10 +105,6 @@ suite.add('fast-json-stringify array', function () {
   stringifyArray(multiArray)
 })
 
-suite.add('fast-json-stringify-uglified array', function () {
-  stringifyArrayUgly(multiArray)
-})
-
 suite.add('json-strify array', function () {
   JSTRArray(multiArray)
 })
@@ -126,10 +119,6 @@ suite.add('JSON.stringify long string', function () {
 
 suite.add('fast-json-stringify long string', function () {
   stringifyString(str)
-})
-
-suite.add('fast-json-stringify-uglified long string', function () {
-  stringifyStringUgly(str)
 })
 
 suite.add('json-strify long string', function () {
@@ -148,10 +137,6 @@ suite.add('fast-json-stringify short string', function () {
   stringifyString('hello world')
 })
 
-suite.add('fast-json-stringify-uglified short string', function () {
-  stringifyStringUgly('hello world')
-})
-
 suite.add('json-strify short string', function () {
   JSTRInstance('hello world')
 })
@@ -166,10 +151,6 @@ suite.add('JSON.stringify obj', function () {
 
 suite.add('fast-json-stringify obj', function () {
   stringify(obj)
-})
-
-suite.add('fast-json-stringify-uglified obj', function () {
-  stringifyUgly(obj)
 })
 
 suite.add('json-strify obj', function () {

--- a/index.d.ts
+++ b/index.d.ts
@@ -142,10 +142,6 @@ declare namespace build {
      */
     schema?: Record<string, Schema>
     /**
-     * Uglify the generated serialization function to get a performance increase on Node.js versions lower than 8.3.0
-     */
-    uglify?: boolean
-    /**
      * Configure Ajv, which is used to evaluate conditional schemas and combined (anyOf) schemas
      */
     ajv?: AjvOptions

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ var merge = require('deepmerge')
 var util = require('util')
 var validate = require('./schema-validator')
 
-var uglify = null
 var isLong
 try {
   isLong = require('long').isLong
@@ -118,10 +117,6 @@ function build (schema, options) {
     ;
      return ${main}
   `
-
-  if (options.uglify) {
-    code = uglifyCode(code)
-  }
 
   var dependencies = []
   var dependenciesName = []
@@ -992,38 +987,6 @@ function nested (laterCode, name, key, schema, externalSchema, fullSchema, subKe
   return {
     code,
     laterCode
-  }
-}
-
-function uglifyCode (code) {
-  if (!uglify) {
-    loadUglify()
-  }
-
-  var uglified = uglify.minify(code, { parse: { bare_returns: true } })
-
-  if (uglified.error) {
-    throw uglified.error
-  }
-
-  return uglified.code
-}
-
-function loadUglify () {
-  try {
-    uglify = require('uglify-es')
-    var uglifyVersion = require('uglify-es/package.json').version
-
-    if (uglifyVersion[0] !== '3') {
-      throw new Error('Only version 3 of uglify-es is supported')
-    }
-  } catch (e) {
-    uglify = null
-    if (e.code === 'MODULE_NOT_FOUND') {
-      throw new Error('In order to use uglify, you have to manually install `uglify-es`')
-    }
-
-    throw e
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "tap": "^12.6.5",
     "tap-mocha-reporter": "^3.0.9",
     "typescript": "^3.0.0",
-    "uglify-es": "^3.3.9",
     "compile-json-stringify": "^0.1.2",
     "json-strify": "^0.1.7"
   },

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -6,18 +6,14 @@ const build = require('..')
 
 function buildTest (schema, toStringify) {
   test(`render a ${schema.title} as JSON`, (t) => {
-    t.plan(5)
+    t.plan(3)
 
     const validate = validator(schema)
     const stringify = build(schema)
-    const stringifyUgly = build(schema, { uglify: true })
     const output = stringify(toStringify)
-    const outputUglify = stringifyUgly(toStringify)
 
     t.deepEqual(JSON.parse(output), toStringify)
-    t.deepEqual(JSON.parse(outputUglify), toStringify)
     t.equal(output, JSON.stringify(toStringify))
-    t.equal(outputUglify, JSON.stringify(toStringify))
     t.ok(validate(JSON.parse(output)), 'valid schema')
   })
 }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -6,18 +6,14 @@ const build = require('..')
 
 function buildTest (schema, toStringify) {
   test(`render a ${schema.title} as JSON`, (t) => {
-    t.plan(5)
+    t.plan(3)
 
     const validate = validator(schema)
     const stringify = build(schema)
-    const stringifyUgly = build(schema, { uglify: true })
     const output = stringify(toStringify)
-    const outputUglify = stringifyUgly(toStringify)
 
     t.deepEqual(JSON.parse(output), toStringify)
-    t.deepEqual(JSON.parse(outputUglify), toStringify)
     t.equal(output, JSON.stringify(toStringify))
-    t.equal(outputUglify, JSON.stringify(toStringify))
     t.ok(validate(JSON.parse(output)), 'valid schema')
   })
 }

--- a/test/defaults.test.js
+++ b/test/defaults.test.js
@@ -5,16 +5,13 @@ const build = require('..')
 
 function buildTest (schema, toStringify, expected) {
   test(`render a ${schema.title} with default as JSON`, (t) => {
-    t.plan(2)
+    t.plan(1)
 
     const stringify = build(schema)
 
-    const stringifyUgly = build(schema, { uglify: true })
     const output = stringify(toStringify)
-    const outputUglify = stringifyUgly(toStringify)
 
     t.strictEqual(output, JSON.stringify(expected))
-    t.strictEqual(outputUglify, JSON.stringify(expected))
   })
 }
 

--- a/test/if-then-else.test.js
+++ b/test/if-then-else.test.js
@@ -272,14 +272,6 @@ t.test('if-then-else', t => {
       const serialized = stringify(test.input)
       t.equal(serialized, test.expected)
     })
-
-    t.test(test.name + ' - uglify', t => {
-      t.plan(1)
-
-      const stringify = build(JSON.parse(JSON.stringify(test.schema)), { uglify: true })
-      const serialized = stringify(test.input)
-      t.equal(serialized, test.expected)
-    })
   })
 
   t.end()

--- a/test/inferType.test.js
+++ b/test/inferType.test.js
@@ -6,18 +6,14 @@ const build = require('..')
 
 function buildTest (schema, toStringify) {
   test(`render a ${schema.title} as JSON`, (t) => {
-    t.plan(5)
+    t.plan(3)
 
     const validate = validator(schema)
     const stringify = build(schema)
-    const stringifyUgly = build(schema, { uglify: true })
     const output = stringify(toStringify)
-    const outputUglify = stringifyUgly(toStringify)
 
     t.deepEqual(JSON.parse(output), toStringify)
-    t.deepEqual(JSON.parse(outputUglify), toStringify)
     t.equal(output, JSON.stringify(toStringify))
-    t.equal(outputUglify, JSON.stringify(toStringify))
     t.ok(validate(JSON.parse(output)), 'valid schema')
   })
 }

--- a/test/types/test.ts
+++ b/test/types/test.ts
@@ -134,14 +134,3 @@ const schema11: Schema = {
 }
 
 build(schema11)({ something: 'a string', somethingElse: 42 })
-
-// With options
-const schema12: Schema = {
-  title: 'Some Schema',
-  type: 'object',
-  properties: {
-    str: { $ref: '#/definitions/string' }
-  }
-}
-
-build(schema12, { schema: { string: { type: 'string' } }, uglify: true, ajv: { jsonPointers: true } })


### PR DESCRIPTION
As far as I understand the issue #97, uglify-es was added to improve throughput in Node.js 6 which is [EOL](https://github.com/nodejs/Release#end-of-life-releases) nowadays and I guess it can be safety dropped now.
One more point to drop support is that uglify-es is [no longer maintained](https://github.com/mishoo/UglifyJS2/issues/3156#issuecomment-392943058)

Closes #97 