### PR TITLE
Check for null value before using `in`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,6 +188,7 @@ function inferTypeByKeyword (schema) {
 }
 
 function hasAnyOf (schema) {
+  if (!schema) { return false }
   if ('anyOf' in schema) { return true }
 
   var objectKeys = Object.keys(schema)

--- a/test/anyof.test.js
+++ b/test/anyof.test.js
@@ -231,3 +231,20 @@ test('object with field with type union of multiple objects', (t) => {
     t.fail()
   }
 })
+
+test('null value in schema', (t) => {
+  t.plan(0)
+
+  const schema = {
+    title: 'schema with null child',
+    type: 'string',
+    nullable: true,
+    enum: [null]
+  }
+
+  try {
+    build(schema)
+  } catch (e) {
+    t.fail()
+  }
+})


### PR DESCRIPTION
Would it be possible to add a check for null values in this function?  The `in` operator is causing an error when `null` is found in the schema.  For example:

```javascript
 response: {
    200: {
      description: 'Success',
      type: 'string',
      nullable: true
      enum: [null] 
    }
  }
```

With JSON Schema, one could use `type: 'null'`, but I have a requirement to only use OAS 3.0 features, so I can't change the schema to use `type: 'null'`.
