### PR TITLE
Support nested $ref-erences

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,38 @@ const externalSchema = {
 
 const stringify = fastJson(schema, { schema: externalSchema })
 ```
+External definitions can also reference each other.
+Example:
+```javascript
+const schema = {
+  title: 'Example Schema',
+  type: 'object',
+  properties: {
+    foo: {
+      $ref: 'strings#/definitions/foo'
+    }
+  }
+}
+
+const externalSchema = {
+  strings: {
+    definitions: {
+      foo: {
+        $ref: 'things#/definitions/foo'
+      }
+    }
+  },
+  things: {
+    definitions: {
+      foo: {
+        type: 'string'
+      }
+    }
+  }
+}
+
+const stringify = fastJson(schema, { schema: externalSchema })
+```
 
 <a name="long"></a>
 #### Long integers

--- a/index.js
+++ b/index.js
@@ -310,7 +310,7 @@ function addPatternProperties (schema, externalSchema, fullSchema) {
   `
   Object.keys(pp).forEach((regex, index) => {
     if (pp[regex].$ref) {
-      pp[regex] = refFinder(pp[regex].$ref, fullSchema, externalSchema, fullSchema)
+      pp[regex] = refFinder(pp[regex].$ref, fullSchema, externalSchema)
     }
     var type = pp[regex].type
     code += `
@@ -513,7 +513,8 @@ function refFinder (ref, schema, externalSchema) {
       }
     }
   }
-  return (new Function('schema', code))(schema)
+  const result = (new Function('schema', code))(schema)
+  return result.$ref ? refFinder(result.$ref, schema, externalSchema) : result
 }
 
 function sanitizeKey (key) {

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -804,3 +804,45 @@ test('ref external to relative definition', (t) => {
 
   t.equal(output, '{"fooParent":{"foo":"bar"}}')
 })
+
+test('ref to nested ref definition', (t) => {
+  t.plan(2)
+
+  const externalSchema = {
+    'a:b:c1': {
+      $id: 'a:b:c1',
+      type: 'object',
+      definitions: {
+        foo: { $ref: 'a:b:c2#/definitions/foo' }
+      }
+    },
+    'a:b:c2': {
+      $id: 'a:b:c2',
+      type: 'object',
+      definitions: {
+        foo: { type: 'string' }
+      }
+    }
+  }
+
+  const schema = {
+    type: 'object',
+    required: ['foo'],
+    properties: {
+      foo: { $ref: 'a:b:c1#/definitions/foo' }
+    }
+  }
+
+  const object = { foo: 'foo' }
+  const stringify = build(schema, { schema: externalSchema })
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal(output, '{"foo":"foo"}')
+})


### PR DESCRIPTION
PR to implement #187:

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

Tests all pass. Benchmark results:

```
FJS creation x 52,630 ops/sec ±1.80% (89 runs sampled)
JSTR creation x 131,478 ops/sec ±0.73% (90 runs sampled)
CJS creation x 135,084 ops/sec ±1.18% (95 runs sampled)
JSON.stringify array x 4,790 ops/sec ±0.36% (95 runs sampled)
fast-json-stringify array x 7,638 ops/sec ±1.75% (88 runs sampled)
fast-json-stringify-uglified array x 8,054 ops/sec ±1.22% (96 runs sampled)
json-strify array x 80,063,937 ops/sec ±0.88% (95 runs sampled)
compile-json-stringify array x 7,661 ops/sec ±1.37% (92 runs sampled)
JSON.stringify long string x 13,349 ops/sec ±1.23% (88 runs sampled)
fast-json-stringify long string x 13,721 ops/sec ±0.64% (96 runs sampled)
fast-json-stringify-uglified long string x 13,727 ops/sec ±1.18% (91 runs sampled)
json-strify long string x 252,577 ops/sec ±1.45% (92 runs sampled)
compile-json-stringify long string x 13,750 ops/sec ±0.44% (93 runs sampled)
JSON.stringify short string x 4,654,121 ops/sec ±1.62% (93 runs sampled)
fast-json-stringify short string x 40,933,907 ops/sec ±0.22% (92 runs sampled)
fast-json-stringify-uglified short string x 43,341,318 ops/sec ±1.55% (92 runs sampled)
json-strify short string x 52,442,560 ops/sec ±3.45% (82 runs sampled)
compile-json-stringify short string x 34,217,287 ops/sec ±1.37% (90 runs sampled)
JSON.stringify obj x 2,063,192 ops/sec ±0.97% (89 runs sampled)
fast-json-stringify obj x 7,696,734 ops/sec ±1.78% (88 runs sampled)
fast-json-stringify-uglified obj x 7,657,235 ops/sec ±1.46% (86 runs sampled)
json-strify obj x 77,268,859 ops/sec ±0.60% (90 runs sampled)
compile-json-stringify obj x 8,163,418 ops/sec ±0.79% (95 runs sampled)
```