### PR TITLE
Fix relative ref resolving issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -479,6 +479,8 @@ function idFinder (schema, searchedId) {
 }
 
 function refFinder (ref, schema, externalSchema) {
+  if (externalSchema && externalSchema[ref]) return externalSchema[ref]
+
   // Split file from walk
   ref = ref.split('#')
 

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -846,3 +846,33 @@ test('ref to nested ref definition', (t) => {
 
   t.equal(output, '{"foo":"foo"}')
 })
+
+test('ref in definition with exact match', (t) => {
+  t.plan(2)
+
+  const externalSchema = {
+    '#/definitions/foo': {
+      type: 'string'
+    }
+  }
+
+  const schema = {
+    type: 'object',
+    properties: {
+      foo: { $ref: '#/definitions/foo' }
+    }
+  }
+
+  const object = { foo: 'foo' }
+  const stringify = build(schema, { schema: externalSchema })
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal(output, '{"foo":"foo"}')
+})


### PR DESCRIPTION
The following case I have met in fastify-swagger - the following reference is not working in fields, where fast-json-stringify is used, but works fine with ajv parser.

```
const fastJsonStringify = require('fast-json-stringify')
fastJsonStringify(
  { type: 'object',
  description: 'test',
  properties: { param: { $ref: '#/definitions/test' } } },
  { schema: { '#/definitions/test': { type: 'string' } } }
)
```

With version 1.15.6 it raises following error:

```
return schema['definitions']['test']
                            ^
TypeError: Cannot read property 'test' of undefined
```

#### Checklist

- tests
```
$ npm run test

> fast-json-stringify@1.15.6 test /home/mgolovanov/work/pulls/fast-json-stringify
> npm run test:lint && npm run test:unit && npm run test:typescript


> fast-json-stringify@1.15.6 test:lint /home/mgolovanov/work/pulls/fast-json-stringify
> standard


> fast-json-stringify@1.15.6 test:unit /home/mgolovanov/work/pulls/fast-json-stringify
> tap -J test/*.test.js test/**/*.test.js

test/additionalProperties.test.js ................... 13/13
test/allof.test.js .................................... 7/7
test/any.test.js ...................................... 5/5
test/anyof.test.js .................................. 11/11
test/array.test.js .................................. 26/26
test/basic.test.js ................................ 102/102
test/clean-cache.test.js .............................. 2/2
test/date.test.js ..................................... 2/2
test/defaults.test.js ............................... 20/20
test/if-then-else.test.js ........................... 18/18
test/inferType.test.js .............................. 25/25
test/integer.test.js .................................. 8/8
test/invalidSchema.test.js ............................ 2/2
test/long.test.js ..................................... 8/8
test/missing-values.test.js ........................... 7/7
test/nestedObjects.test.js ............................ 1/1 496ms
test/nullable.test.js ................................. 8/8
test/patternProperties.test.js ........................ 7/7
test/ref.test.js .................................... 33/33
test/regex.test.js .................................... 3/3
test/required.test.js ................................. 6/6
test/sanitize.test.js ................................. 3/3
test/surrogate.test.js ................................ 8/8
test/toJSON.test.js ................................... 7/7
test/typesArray.test.js ............................. 22/22
test/unknownFormats.test.js ........................... 1/1 472ms
test/json-schema-test-suite/draft4.test.js ............ 3/3
test/json-schema-test-suite/draft6.test.js ............ 4/4
test/json-schema-test-suite/draft7.test.js ............ 4/4
total ............................................. 366/366

  366 passing (5s)

  ok

> fast-json-stringify@1.15.6 test:typescript /home/mgolovanov/work/pulls/fast-json-stringify
> tsc --project ./test/types/tsconfig.json
```

- benchmark
```
$ npm run benchmark

> fast-json-stringify@1.15.6 benchmark /home/mgolovanov/work/pulls/fast-json-stringify
> node bench.js

FJS creation x 50,621 ops/sec ±0.61% (92 runs sampled)
JSTR creation x 170,852 ops/sec ±0.79% (89 runs sampled)
CJS creation x 170,860 ops/sec ±0.72% (88 runs sampled)
JSON.stringify array x 3,802 ops/sec ±2.62% (87 runs sampled)
fast-json-stringify array x 5,110 ops/sec ±2.02% (86 runs sampled)
fast-json-stringify-uglified array x 4,888 ops/sec ±4.54% (82 runs sampled)
json-strify array x 45,972,854 ops/sec ±1.01% (89 runs sampled)
compile-json-stringify array x 5,081 ops/sec ±2.12% (85 runs sampled)
JSON.stringify long string x 10,959 ops/sec ±1.07% (86 runs sampled)
fast-json-stringify long string x 11,114 ops/sec ±1.44% (86 runs sampled)
fast-json-stringify-uglified long string x 11,231 ops/sec ±1.23% (86 runs sampled)
json-strify long string x 197,905 ops/sec ±2.07% (81 runs sampled)
compile-json-stringify long string x 11,037 ops/sec ±1.25% (89 runs sampled)
JSON.stringify short string x 9,079,988 ops/sec ±3.70% (80 runs sampled)
fast-json-stringify short string x 25,669,806 ops/sec ±1.80% (90 runs sampled)
fast-json-stringify-uglified short string x 25,453,254 ops/sec ±1.21% (92 runs sampled)
json-strify short string x 32,084,443 ops/sec ±4.44% (75 runs sampled)
compile-json-stringify short string x 15,810,853 ops/sec ±5.06% (75 runs sampled)
JSON.stringify obj x 1,646,258 ops/sec ±7.82% (73 runs sampled)
fast-json-stringify obj x 7,246,742 ops/sec ±6.28% (69 runs sampled)
fast-json-stringify-uglified obj x 7,393,462 ops/sec ±3.81% (72 runs sampled)
json-strify obj x 41,101,758 ops/sec ±2.59% (84 runs sampled)
compile-json-stringify obj x 13,241,153 ops/sec ±0.63% (89 runs sampled)
```