### PR TITLE
 Improve the debugging experience in case of a bad reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   },
   "dependencies": {
     "ajv": "^6.10.2",
-    "deepmerge": "^4.0.0"
+    "deepmerge": "^4.0.0",
+    "string-similarity": "^4.0.1"
   },
   "standard": {
     "ignore": [

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -876,3 +876,202 @@ test('ref in definition with exact match', (t) => {
 
   t.equal(output, '{"foo":"foo"}')
 })
+
+test('Bad key', t => {
+  t.test('Find match', t => {
+    t.plan(1)
+    try {
+      build({
+        definitions: {
+          projectId: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer' }
+            }
+          }
+        },
+        type: 'object',
+        properties: {
+          data: {
+            $ref: '#/definitions/porjectId'
+          }
+        }
+      })
+      t.fail('Should throw')
+    } catch (err) {
+      t.is(err.message, "Cannot find reference 'porjectId', did you mean 'projectId'?")
+    }
+  })
+
+  t.test('No match', t => {
+    t.plan(1)
+    try {
+      build({
+        definitions: {
+          projectId: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer' }
+            }
+          }
+        },
+        type: 'object',
+        properties: {
+          data: {
+            $ref: '#/definitions/foobar'
+          }
+        }
+      })
+      t.fail('Should throw')
+    } catch (err) {
+      t.is(err.message, "Cannot find reference 'foobar'")
+    }
+  })
+
+  t.test('Find match (external schema)', t => {
+    t.plan(1)
+    try {
+      build({
+        type: 'object',
+        properties: {
+          data: {
+            $ref: 'external#/definitions/porjectId'
+          }
+        }
+      }, {
+        schema: {
+          external: {
+            definitions: {
+              projectId: {
+                type: 'object',
+                properties: {
+                  id: { type: 'integer' }
+                }
+              }
+            }
+          }
+        }
+      })
+      t.fail('Should throw')
+    } catch (err) {
+      t.is(err.message, "Cannot find reference 'porjectId', did you mean 'projectId'?")
+    }
+  })
+
+  t.test('No match (external schema)', t => {
+    t.plan(1)
+    try {
+      build({
+        type: 'object',
+        properties: {
+          data: {
+            $ref: 'external#/definitions/foobar'
+          }
+        }
+      }, {
+        schema: {
+          external: {
+            definitions: {
+              projectId: {
+                type: 'object',
+                properties: {
+                  id: { type: 'integer' }
+                }
+              }
+            }
+          }
+        }
+      })
+      t.fail('Should throw')
+    } catch (err) {
+      t.is(err.message, "Cannot find reference 'foobar'")
+    }
+  })
+
+  t.test('Find match (external definitions typo)', t => {
+    t.plan(1)
+    try {
+      build({
+        type: 'object',
+        properties: {
+          data: {
+            $ref: 'external#/deifnitions/projectId'
+          }
+        }
+      }, {
+        schema: {
+          external: {
+            definitions: {
+              projectId: {
+                type: 'object',
+                properties: {
+                  id: { type: 'integer' }
+                }
+              }
+            }
+          }
+        }
+      })
+      t.fail('Should throw')
+    } catch (err) {
+      t.is(err.message, "Cannot find reference 'deifnitions', did you mean 'definitions'?")
+    }
+  })
+
+  t.test('Find match (definitions typo)', t => {
+    t.plan(1)
+    try {
+      build({
+        definitions: {
+          projectId: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer' }
+            }
+          }
+        },
+        type: 'object',
+        properties: {
+          data: {
+            $ref: '#/deifnitions/projectId'
+          }
+        }
+      })
+      t.fail('Should throw')
+    } catch (err) {
+      t.is(err.message, "Cannot find reference 'deifnitions', did you mean 'definitions'?")
+    }
+  })
+
+  t.test('Find match (external schema typo)', t => {
+    t.plan(1)
+    try {
+      build({
+        type: 'object',
+        properties: {
+          data: {
+            $ref: 'extrenal#/definitions/projectId'
+          }
+        }
+      }, {
+        schema: {
+          external: {
+            definitions: {
+              projectId: {
+                type: 'object',
+                properties: {
+                  id: { type: 'integer' }
+                }
+              }
+            }
+          }
+        }
+      })
+      t.fail('Should throw')
+    } catch (err) {
+      t.is(err.message, "Cannot find reference 'extrenal', did you mean 'external'?")
+    }
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Hello folks!
Typos are a significant pain point in programming, especially with JSON schemas.
This pr introduces a better debugging experience to help the user figure out what's going wrong.

To improve the experience even further, I've used [string-similarity](https://github.com/aceakash/string-similarity), a library that uses the Dice's Coefficient to figure out if two strings are similar. I think this approach can be reused in Fastify as well.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)