### PR TITLE
Serialize additional properties at the end of the json

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ console.log(stringify(obj)) // '{"matchfoo":"42","otherfoo":"str","matchnum":3,"
 If *additionalProperties* is not present or is set to `false`, every property that is not explicitly listed in the *properties* and *patternProperties* objects,will be ignored, as described in <a href="#missingFields">Missing fields</a>.
 Missing fields are ignored to avoid having to rewrite objects before serializing. However, other schema rules would throw in similar situations.
 If *additionalProperties* is set to `true`, it will be used by `JSON.stringify` to stringify the additional properties. If you want to achieve maximum performance, we strongly encourage you to use a fixed schema where possible.
+The additional properties will always be serialzied at the end of the object.
 Example:
 ```javascript
 const stringify = fastJson({
@@ -252,7 +253,7 @@ const obj = {
   nomatchint: 313
 }
 
-console.log(stringify(obj)) // '{"matchfoo":"42","otherfoo":"str","matchnum":3,"nomatchstr":"valar morghulis",nomatchint:"313","nickname":"nick"}'
+console.log(stringify(obj)) // '{"nickname":"nick","matchfoo":"42","otherfoo":"str","matchnum":3,"nomatchstr":"valar morghulis",nomatchint:"313"}'
 ```
 
 #### AnyOf

--- a/index.js
+++ b/index.js
@@ -685,15 +685,13 @@ function buildCodeWithAllOfs (schema, code, laterCode, name, externalSchema, ful
 }
 
 function buildInnerObject (schema, name, externalSchema, fullSchema) {
-  var laterCode = ''
-  var code = ''
+  var result = buildCodeWithAllOfs(schema, '', '', name, externalSchema, fullSchema)
   if (schema.patternProperties) {
-    code += addPatternProperties(schema, externalSchema, fullSchema)
+    result.code += addPatternProperties(schema, externalSchema, fullSchema)
   } else if (schema.additionalProperties && !schema.patternProperties) {
-    code += addAdditionalProperties(schema, externalSchema, fullSchema)
+    result.code += addAdditionalProperties(schema, externalSchema, fullSchema)
   }
-
-  return buildCodeWithAllOfs(schema, code, laterCode, name, externalSchema, fullSchema)
+  return result
 }
 
 function addIfThenElse (schema, name, externalSchema, fullSchema) {

--- a/test/additionalProperties.test.js
+++ b/test/additionalProperties.test.js
@@ -19,7 +19,7 @@ test('additionalProperties', (t) => {
   })
 
   const obj = { str: 'test', foo: 42, ofoo: true, foof: 'string', objfoo: { a: true } }
-  t.equal('{"foo":"42","ofoo":"true","foof":"string","objfoo":"[object Object]","str":"test"}', stringify(obj))
+  t.equal('{"str":"test","foo":"42","ofoo":"true","foof":"string","objfoo":"[object Object]"}', stringify(obj))
 })
 
 test('additionalProperties should not change properties', (t) => {
@@ -38,7 +38,7 @@ test('additionalProperties should not change properties', (t) => {
   })
 
   const obj = { foo: '42', ofoo: 42 }
-  t.equal('{"ofoo":42,"foo":"42"}', stringify(obj))
+  t.equal('{"foo":"42","ofoo":42}', stringify(obj))
 })
 
 test('additionalProperties should not change properties and patternProperties', (t) => {
@@ -62,7 +62,7 @@ test('additionalProperties should not change properties and patternProperties', 
   })
 
   const obj = { foo: '42', ofoo: 42, test: '42' }
-  t.equal('{"ofoo":"42","test":42,"foo":"42"}', stringify(obj))
+  t.equal('{"foo":"42","ofoo":"42","test":42}', stringify(obj))
 })
 
 test('additionalProperties set to true, use of fast-safe-stringify', (t) => {

--- a/test/patternProperties.test.js
+++ b/test/patternProperties.test.js
@@ -21,7 +21,7 @@ test('patternProperties', (t) => {
   })
 
   const obj = { str: 'test', foo: 42, ofoo: true, foof: 'string', objfoo: { a: true }, notMe: false }
-  t.equal(stringify(obj), '{"foo":"42","ofoo":"true","foof":"string","objfoo":"[object Object]","str":"test"}')
+  t.equal(stringify(obj), '{"str":"test","foo":"42","ofoo":"true","foof":"string","objfoo":"[object Object]"}')
 })
 
 test('patternProperties should not change properties', (t) => {
@@ -42,7 +42,7 @@ test('patternProperties should not change properties', (t) => {
   })
 
   const obj = { foo: '42', ofoo: 42 }
-  t.equal(stringify(obj), '{"ofoo":42,"foo":"42"}')
+  t.equal(stringify(obj), '{"foo":"42","ofoo":42}')
 })
 
 test('patternProperties - string coerce', (t) => {


### PR DESCRIPTION
In some cases, the order of the keys is important, it might be for readability or other reasons. With the current implementation, every additional property is added at the beginning of the json, making it very hard to guarantee the order of the keys if you don't know them in advance.
This pr fixes this and serialize additional/pattern properties at the end of a json string.

Not sure if we should consider this a breaking change, as usually people test their code with `JSON.parse`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)