### PR TITLE
pass full schema to buildObject if $ref is defined at the top level

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,7 @@ function build (schema, options) {
     `
   }
 
+  const fullSchema = schema
   if (schema.$ref) {
     schema = refFinder(schema.$ref, schema, options.schema)
   }
@@ -90,7 +91,7 @@ function build (schema, options) {
   switch (schema.type) {
     case 'object':
       main = '$main'
-      code = buildObject(schema, code, main, options.schema, schema)
+      code = buildObject(schema, code, main, options.schema, fullSchema)
       break
     case 'string':
       main = schema.nullable ? $asStringNullable.name : $asString.name

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -685,6 +685,41 @@ test('ref internal - multiple $ref format', (t) => {
   t.equal(output, '{"zero":"test","a":"test","b":"test","c":"test","d":"test","e":"test"}')
 })
 
+test('ref in root internal', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with $ref in root schema',
+    $ref: '#/definitions/num',
+    definitions: {
+      num: {
+        type: 'object',
+        properties: {
+          int: {
+            $ref: '#/definitions/int'
+          }
+        }
+      },
+      int: {
+        type: 'integer'
+      }
+    }
+  }
+
+  const object = { int: 42 }
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal(output, '{"int":42}')
+})
+
 test('ref in root external', (t) => {
   t.plan(2)
 


### PR DESCRIPTION
Was getting the error `Cannot find reference 'definitions'` and it is because the `schema` variable is replaced on line 80, so the original schema definition is lost.

Adding results of benchmark run:
```
FJS creation x 45,686 ops/sec ±2.46% (80 runs sampled)
JSTR creation x 122,116 ops/sec ±1.14% (89 runs sampled)
CJS creation x 123,350 ops/sec ±1.10% (91 runs sampled)
JSON.stringify array x 3,565 ops/sec ±2.88% (83 runs sampled)
fast-json-stringify array x 5,443 ops/sec ±2.29% (81 runs sampled)
fast-json-stringify-uglified array x 5,363 ops/sec ±2.79% (79 runs sampled)
json-strify array x 49,040,148 ops/sec ±1.25% (91 runs sampled)
compile-json-stringify array x 5,675 ops/sec ±2.28% (82 runs sampled)
JSON.stringify long string x 12,497 ops/sec ±1.91% (86 runs sampled)
fast-json-stringify long string x 12,755 ops/sec ±1.51% (87 runs sampled)
fast-json-stringify-uglified long string x 13,061 ops/sec ±0.69% (93 runs sampled)
json-strify long string x 234,092 ops/sec ±1.34% (90 runs sampled)
compile-json-stringify long string x 13,186 ops/sec ±0.50% (93 runs sampled)
JSON.stringify short string x 4,441,831 ops/sec ±1.63% (91 runs sampled)
fast-json-stringify short string x 24,149,449 ops/sec ±0.99% (90 runs sampled)
fast-json-stringify-uglified short string x 24,403,066 ops/sec ±0.31% (92 runs sampled)
json-strify short string x 46,378,790 ops/sec ±1.35% (88 runs sampled)
compile-json-stringify short string x 26,290,438 ops/sec ±1.51% (91 runs sampled)
JSON.stringify obj x 1,816,270 ops/sec ±1.56% (89 runs sampled)
fast-json-stringify obj x 6,093,148 ops/sec ±2.48% (84 runs sampled)
fast-json-stringify-uglified obj x 6,450,704 ops/sec ±1.99% (88 runs sampled)
json-strify obj x 44,277,015 ops/sec ±2.70% (85 runs sampled)
compile-json-stringify obj x 6,507,869 ops/sec ±1.47% (89 runs sampled)
```

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
