### PR TITLE
Adds support for oneOf schemas

### DIFF
--- a/test/oneof.test.js
+++ b/test/oneof.test.js
@@ -1,0 +1,399 @@
+'use strict'
+
+const { test } = require('tap')
+const build = require('..')
+
+test('object with multiple types field', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with multiple types field',
+    type: 'object',
+    properties: {
+      str: {
+        oneOf: [{
+          type: 'string'
+        }, {
+          type: 'boolean'
+        }]
+      }
+    }
+  }
+  const stringify = build(schema)
+
+  try {
+    const value = stringify({
+      str: 'string'
+    })
+    t.is(value, '{"str":"string"}')
+  } catch (e) {
+    console.log('errorrrrr', e)
+    t.fail()
+  }
+
+  try {
+    const value = stringify({
+      str: true
+    })
+    t.is(value, '{"str":true}')
+  } catch (e) {
+    t.fail()
+  }
+})
+
+test('object with field of type object or null', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with field of type object or null',
+    type: 'object',
+    properties: {
+      prop: {
+        oneOf: [{
+          type: 'object',
+          properties: {
+            str: {
+              type: 'string'
+            }
+          }
+        }, {
+          type: 'null'
+        }]
+      }
+    }
+  }
+  const stringify = build(schema)
+
+  try {
+    const value = stringify({
+      prop: null
+    })
+    t.is(value, '{"prop":null}')
+  } catch (e) {
+    t.fail()
+  }
+
+  try {
+    const value = stringify({
+      prop: {
+        str: 'string'
+      }
+    })
+    t.is(value, '{"prop":{"str":"string"}}')
+  } catch (e) {
+    t.fail()
+  }
+})
+
+test('object with field of type object or array', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with field of type object or array',
+    type: 'object',
+    properties: {
+      prop: {
+        oneOf: [{
+          type: 'object',
+          properties: {},
+          additionalProperties: true
+        }, {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        }]
+      }
+    }
+  }
+  const stringify = build(schema)
+
+  try {
+    const value = stringify({
+      prop: {
+        str: 'string'
+      }
+    })
+    t.is(value, '{"prop":{"str":"string"}}')
+  } catch (e) {
+    t.fail()
+  }
+
+  try {
+    const value = stringify({
+      prop: ['string']
+    })
+    t.is(value, '{"prop":["string"]}')
+  } catch (e) {
+    t.fail()
+  }
+})
+
+test('object with field of type string and coercion disable ', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'object with field of type string',
+    type: 'object',
+    properties: {
+      str: {
+        oneOf: [{
+          type: 'string'
+        }]
+      }
+    }
+  }
+  const stringify = build(schema)
+
+  try {
+    const value = stringify({
+      str: 1
+    })
+    t.is(value, '{"str":null}')
+  } catch (e) {
+    t.fail()
+  }
+})
+
+test('object with field of type string and coercion enable ', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'object with field of type string',
+    type: 'object',
+    properties: {
+      str: {
+        oneOf: [{
+          type: 'string'
+        }]
+      }
+    }
+  }
+
+  const options = {
+    ajv: {
+      coerceTypes: true
+    }
+  }
+  const stringify = build(schema, options)
+
+  try {
+    const value = stringify({
+      str: 1
+    })
+    t.is(value, '{"str":"1"}')
+  } catch (e) {
+    t.fail()
+  }
+})
+
+test('object with field with type union of multiple objects', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with oneOf property value containing objects',
+    type: 'object',
+    properties: {
+      oneOfSchema: {
+        oneOf: [
+          {
+            type: 'object',
+            properties: {
+              baz: { type: 'number' }
+            },
+            required: ['baz']
+          },
+          {
+            type: 'object',
+            properties: {
+              bar: { type: 'string' }
+            },
+            required: ['bar']
+          }
+        ]
+      }
+    },
+    required: ['oneOfSchema']
+  }
+
+  const stringify = build(schema)
+
+  try {
+    const value = stringify({ oneOfSchema: { baz: 5 } })
+    t.is(value, '{"oneOfSchema":{"baz":5}}')
+  } catch (e) {
+    t.fail()
+  }
+
+  try {
+    const value = stringify({ oneOfSchema: { bar: 'foo' } })
+    t.is(value, '{"oneOfSchema":{"bar":"foo"}}')
+  } catch (e) {
+    t.fail()
+  }
+})
+
+test('null value in schema', (t) => {
+  t.plan(0)
+
+  const schema = {
+    title: 'schema with null child',
+    type: 'string',
+    nullable: true,
+    enum: [null]
+  }
+
+  try {
+    build(schema)
+  } catch (e) {
+    t.fail()
+  }
+})
+
+test('oneOf and $ref together', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      cs: {
+        oneOf: [
+          {
+            $ref: '#/definitions/Option'
+          },
+          {
+            type: 'boolean'
+          }
+        ]
+      }
+    },
+    definitions: {
+      Option: {
+        type: 'string'
+      }
+    }
+  }
+
+  const stringify = build(schema)
+
+  try {
+    const value = stringify({
+      cs: 'franco'
+    })
+    t.is(value, '{"cs":"franco"}')
+  } catch (e) {
+    t.fail()
+  }
+
+  try {
+    const value = stringify({
+      cs: true
+    })
+    t.is(value, '{"cs":true}')
+  } catch (e) {
+    t.fail()
+  }
+})
+
+test('oneOf and $ref: 2 levels are fine', (t) => {
+  t.plan(1)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      cs: {
+        oneOf: [
+          {
+            $ref: '#/definitions/Option'
+          },
+          {
+            type: 'boolean'
+          }
+        ]
+      }
+    },
+    definitions: {
+      Option: {
+        oneOf: [
+          {
+            type: 'number'
+          },
+          {
+            type: 'boolean'
+          }
+        ]
+      }
+    }
+  }
+
+  const stringify = build(schema)
+  try {
+    const value = stringify({
+      cs: 3
+    })
+    t.is(value, '{"cs":3}')
+  } catch (e) {
+    t.fail()
+  }
+})
+
+test('oneOf and $ref: multiple levels should throw at build.', (t) => {
+  t.plan(3)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      cs: {
+        oneOf: [
+          {
+            $ref: '#/definitions/Option'
+          },
+          {
+            type: 'boolean'
+          }
+        ]
+      }
+    },
+    definitions: {
+      Option: {
+        oneOf: [
+          {
+            $ref: '#/definitions/Option2'
+          },
+          {
+            type: 'string'
+          }
+        ]
+      },
+      Option2: {
+        type: 'number'
+      }
+    }
+  }
+
+  const stringify = build(schema)
+  try {
+    const value = stringify({
+      cs: 3
+    })
+    t.is(value, '{"cs":3}')
+  } catch (e) {
+    t.fail(e)
+  }
+  try {
+    const value = stringify({
+      cs: true
+    })
+    t.is(value, '{"cs":true}')
+  } catch (e) {
+    t.fail(e)
+  }
+  try {
+    const value = stringify({
+      cs: 'pippo'
+    })
+    t.is(value, '{"cs":"pippo"}')
+  } catch (e) {
+    t.fail(e)
+  }
+})

--- a/test/oneof.test.js
+++ b/test/oneof.test.js
@@ -75,7 +75,8 @@ test('object with field of type object or null', (t) => {
   try {
     const value = stringify({
       prop: {
-        str: 'string'
+        str: 'string',
+        remove: 'this'
       }
     })
     t.is(value, '{"prop":{"str":"string"}}')

--- a/test/oneof.test.js
+++ b/test/oneof.test.js
@@ -27,8 +27,7 @@ test('object with multiple types field', (t) => {
     })
     t.is(value, '{"str":"string"}')
   } catch (e) {
-    console.log('errorrrrr', e)
-    t.fail()
+    t.fail(e.message)
   }
 
   try {


### PR DESCRIPTION
Working on fastify schemas I found that it lacks support for `oneOf`. I tried both, writing manually the schema and using fluent and typebox. 
```
FastifyError [FST_ERR_SCH_BUILD]: FST_ERR_SCH_BUILD: Failed building the schema for GET: /api/v1/channels, due error undefined unsupported
    at Object.afterRouteAdded (/Users/maksim/Projects/evologi/orderpod-backend/node_modules/fastify/lib/route.js:239:37)
    at /Users/maksim/Projects/evologi/orderpod-backend/node_modules/fastify/lib/route.js:160:29
    at Object._encapsulateThreeParam (/Users/maksim/Projects/evologi/orderpod-backend/node_modules/avvio/boot.js:422:7)
    at Boot.callWithCbOrNextTick (/Users/maksim/Projects/evologi/orderpod-backend/node_modules/avvio/boot.js:344:5)
    at Boot._after (/Users/maksim/Projects/evologi/orderpod-backend/node_modules/avvio/boot.js:235:26)
    at Plugin.exec (/Users/maksim/Projects/evologi/orderpod-backend/node_modules/avvio/plugin.js:89:17)
    at Boot.loadPlugin (/Users/maksim/Projects/evologi/orderpod-backend/node_modules/avvio/plugin.js:187:10)
    at Task.release (/Users/maksim/Projects/evologi/orderpod-backend/node_modules/fastq/queue.js:127:16)
    at worked (/Users/maksim/Projects/evologi/orderpod-backend/node_modules/fastq/queue.js:169:10)
    at /Users/maksim/Projects/evologi/orderpod-backend/node_modules/avvio/plugin.js:190:7 {
  name: 'FastifyError [FST_ERR_SCH_BUILD]',
  code: 'FST_ERR_SCH_BUILD',
  message: 'FST_ERR_SCH_BUILD: Failed building the schema for GET: /api/v1/channels, due error undefined unsupported',
  statusCode: 500
}
```
After some digging I found that the problem was inside this package:
```
Error: undefined unsupported
    at nested (/Users/maksim/Projects/evologi/orderpod-backend/node_modules/fast-json-stringify/index.js:1014:15)
    at /Users/maksim/Projects/evologi/orderpod-backend/node_modules/fast-json-stringify/index.js:998:30
    at Array.forEach (<anonymous>)
    at nested (/Users/maksim/Projects/evologi/orderpod-backend/node_modules/fast-json-stringify/index.js:997:22)
    at /Users/maksim/Projects/evologi/orderpod-backend/node_modules/fast-json-stringify/index.js:638:20
    at Array.forEach (<anonymous>)
    at buildCode (/Users/maksim/Projects/evologi/orderpod-backend/node_modules/fast-json-stringify/index.js:567:40)
    at buildCodeWithAllOfs (/Users/maksim/Projects/evologi/orderpod-backend/node_modules/fast-json-stringify/index.js:679:21)
    at buildInnerObject (/Users/maksim/Projects/evologi/orderpod-backend/node_modules/fast-json-stringify/index.js:689:16)
    at buildObject (/Users/maksim/Projects/evologi/orderpod-backend/node_modules/fast-json-stringify/index.js:786:9)
```

This PR fixes the problem adding support for `oneOf` schema.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
