### PR TITLE
Handle object property starting with `@` when the property is an array or object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1022,14 +1022,14 @@ function nested (laterCode, name, key, schema, externalSchema, fullSchema, subKe
       code += nullable ? `json += obj${accessor} === null ? null : $asBoolean(obj${accessor})` : `json += $asBoolean(obj${accessor})`
       break
     case 'object':
-      funcName = (name + key + subKey).replace(/[-.\[\] ]/g, '') // eslint-disable-line
+      funcName = (name + key + subKey).replace(/[-.\[\] ]/g, '').replace(/[@]/g, 'AT_SYMBOL') // eslint-disable-line
       laterCode = buildObject(schema, laterCode, funcName, externalSchema, fullSchema)
       code += `
         json += ${funcName}(obj${accessor})
       `
       break
     case 'array':
-      funcName = '$arr' + (name + key + subKey).replace(/[-.\[\] ]/g, '') // eslint-disable-line
+      funcName = '$arr' + (name + key + subKey).replace(/[-.\[\] ]/g, '').replace(/[@]/g, 'AT_SYMBOL') // eslint-disable-line
       laterCode = buildArray(schema, laterCode, funcName, externalSchema, fullSchema)
       code += `
         json += ${funcName}(obj${accessor})

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -142,6 +142,21 @@ buildTest({
   }
 }, { args: [{ a: 'test' }, { b: 1 }] })
 
+buildTest({
+  title: 'array with weird key',
+  type: 'object',
+  properties: {
+    '@data': {
+      type: 'array',
+      items: {
+        type: 'string'
+      }
+    }
+  }
+}, {
+  '@data': ['test']
+})
+
 test('invalid items throw', (t) => {
   t.plan(1)
   const schema = {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -130,6 +130,25 @@ buildTest({
 })
 
 buildTest({
+  title: 'deep object with weird keys of type object',
+  type: 'object',
+  properties: {
+    '@data': {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string'
+        }
+      }
+    }
+  }
+}, {
+  '@data': {
+    id: 'string'
+  }
+})
+
+buildTest({
   title: 'deep object with spaces in key',
   type: 'object',
   properties: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

This PR closes https://github.com/fastify/fast-json-stringify/issues/227

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

So tests pass but I couldn't get the typescript part passing, but I didn't touch that part so I thought it might just be my machine or something.