### PR TITLE
Implicit any type for array items #204

### DIFF
--- a/index.js
+++ b/index.js
@@ -909,6 +909,11 @@ function buildArray (schema, code, name, externalSchema, fullSchema) {
   `
   var laterCode = ''
 
+  // default to any items type
+  if (!schema.items) {
+    schema.items = {}
+  }
+
   if (schema.items.$ref) {
     schema.items = refFinder(schema.items.$ref, fullSchema, externalSchema)
   }

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -201,3 +201,15 @@ test('moment array', (t) => {
     t.fail(e)
   }
 })
+
+buildTest({
+  title: 'item types in array default to any',
+  type: 'object',
+  properties: {
+    foo: {
+      type: 'array'
+    }
+  }
+}, {
+  foo: [1, 'string', {}, null]
+})


### PR DESCRIPTION
#### Description

Makes sure when `Array`s don't explicitly specify items - they'll have `any` type

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
