### PR TITLE
Adds test case for anyOf with multiple array items

### DIFF
--- a/index.js
+++ b/index.js
@@ -1024,9 +1024,9 @@ function nested (laterCode, name, key, schema, externalSchema, fullSchema, subKe
   }
 
   if (schema.type === undefined) {
-    var inferedType = inferTypeByKeyword(schema)
-    if (inferedType) {
-      schema.type = inferedType
+    var inferredType = inferTypeByKeyword(schema)
+    if (inferredType) {
+      schema.type = inferredType
     }
   }
 

--- a/test/anyof.test.js
+++ b/test/anyof.test.js
@@ -396,3 +396,42 @@ test('anyOf and $ref: multiple levels should throw at build.', (t) => {
     t.fail(e)
   }
 })
+
+test('anyOf looks for all of the array items', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'type array that may have any of declared items',
+    type: 'array',
+    items: {
+      anyOf: [
+        {
+          type: 'object',
+          properties: {
+            savedId: {
+              type: 'string'
+            }
+          },
+          required: ['savedId']
+        },
+        {
+          type: 'object',
+          properties: {
+            error: {
+              type: 'string'
+            }
+          },
+          required: ['error']
+        }
+      ]
+    }
+  }
+  const stringify = build(schema)
+
+  try {
+    const value = stringify([{ savedId: 'great' }, { error: 'oops' }])
+    t.is(value, '[{"savedId":"great"},{"error":"oops"}]')
+  } catch (e) {
+    t.fail()
+  }
+})


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)

I don't think #230 is technically an issue, I think it's just how AJV's `properties` validation keyword works.

### Explanation

Assume we have this schema:

```js
{
  title: 'type array that may have any of declared items',
  type: 'array',
  items: {
    anyOf: [
      {
        type: 'object',
        properties: {
          savedId: {
            type: 'string'
          }
        }
      },
      {
        type: 'object',
        properties: {
          error: {
            type: 'string'
          }
        }
      }
    ]
  }
}
```

and test array:
```js
[{ savedId: 'great' }, { error: 'oops' }]
```

If we `build` the schema it'll correctly precompile it with the following `validate` calls to AJV:

<img width="1636" alt="debug" src="https://user-images.githubusercontent.com/1319181/85360943-99903a80-b4e8-11ea-9618-c725d2dbd8f5.png">

but AJV's docs on `properties` say:

> properties keyword does not require that the properties mentioned in it are present in the object
> -- https://ajv.js.org/keywords.html#properties

Because of that:
- first `ajv.validate` call matches any object
- only the first precompiled [buildObject](https://github.com/fastify/fast-json-stringify/blob/master/index.js#L854) function is ever called
- call to incorrect `BuildObject` function results in `{}`
- we get `[{"savedId":"great"},{}]`

### Solution ?

```js
// ...
anyOf: [
{
  type: 'object',
  properties: {
    savedId: {
      type: 'string'
    }
  },
  required: ['savedId']
},
// ...
```

Adding `required` keyword to `anyOf` objects certainly works but is this the only solution?



