### PR TITLE
Fix relative json paths in external schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -642,11 +642,15 @@ function refFinder (ref, location) {
     findBadKey(schema, walk.slice(1))
   }
 
-  return result.$ref ? refFinder(result.$ref, {
-    schema: schema,
-    root: root,
-    externalSchema: externalSchema
-  }) : {
+  if (result.$ref) {
+    return refFinder(result.$ref, {
+      schema: schema,
+      root: root,
+      externalSchema: externalSchema
+    })
+  }
+
+  return {
     schema: result,
     root: root,
     externalSchema: externalSchema

--- a/test/anyof.test.js
+++ b/test/anyof.test.js
@@ -397,6 +397,66 @@ test('anyOf and $ref: multiple levels should throw at build.', (t) => {
   }
 })
 
+test('anyOf and $ref - multiple external $ref', (t) => {
+  t.plan(2)
+
+  const externalSchema = {
+    external: {
+      definitions: {
+        def: {
+          type: 'object',
+          properties: {
+            prop: { anyOf: [{ $ref: 'external2#/definitions/other' }] }
+          }
+        }
+      }
+    },
+    external2: {
+      definitions: {
+        internal: {
+          type: 'string'
+        },
+        other: {
+          type: 'object',
+          properties: {
+            prop2: { $ref: '#/definitions/internal' }
+          }
+        }
+      }
+    }
+  }
+
+  const schema = {
+    title: 'object with $ref',
+    type: 'object',
+    properties: {
+      obj: {
+        $ref: 'external#/definitions/def'
+      }
+    }
+  }
+
+  const object = {
+    obj: {
+      prop: {
+        prop2: 'test'
+      }
+    }
+  }
+
+  const stringify = build(schema, { schema: externalSchema })
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal(output, '{"obj":{"prop":{"prop2":"test"}}}')
+})
+
 test('anyOf looks for all of the array items', (t) => {
   t.plan(1)
 

--- a/test/oneof.test.js
+++ b/test/oneof.test.js
@@ -398,6 +398,66 @@ test('oneOf and $ref: multiple levels should throw at build.', (t) => {
   }
 })
 
+test('oneOf and $ref - multiple external $ref', (t) => {
+  t.plan(2)
+
+  const externalSchema = {
+    external: {
+      definitions: {
+        def: {
+          type: 'object',
+          properties: {
+            prop: { oneOf: [{ $ref: 'external2#/definitions/other' }] }
+          }
+        }
+      }
+    },
+    external2: {
+      definitions: {
+        internal: {
+          type: 'string'
+        },
+        other: {
+          type: 'object',
+          properties: {
+            prop2: { $ref: '#/definitions/internal' }
+          }
+        }
+      }
+    }
+  }
+
+  const schema = {
+    title: 'object with $ref',
+    type: 'object',
+    properties: {
+      obj: {
+        $ref: 'external#/definitions/def'
+      }
+    }
+  }
+
+  const object = {
+    obj: {
+      prop: {
+        prop2: 'test'
+      }
+    }
+  }
+
+  const stringify = build(schema, { schema: externalSchema })
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal(output, '{"obj":{"prop":{"prop2":"test"}}}')
+})
+
 test('oneOf with enum with more than 100 entries', (t) => {
   t.plan(1)
 

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -685,6 +685,52 @@ test('ref internal - multiple $ref format', (t) => {
   t.equal(output, '{"zero":"test","a":"test","b":"test","c":"test","d":"test","e":"test"}')
 })
 
+test('ref external - external schema with internal ref', (t) => {
+  t.plan(2)
+
+  const externalSchema = {
+    external: {
+      definitions: {
+        internal: { type: 'string' },
+        def: {
+          type: 'object',
+          properties: {
+            prop: { $ref: '#/definitions/internal' }
+          }
+        }
+      }
+    }
+  }
+
+  const schema = {
+    title: 'object with $ref',
+    type: 'object',
+    properties: {
+      obj: {
+        $ref: 'external#/definitions/def'
+      }
+    }
+  }
+
+  const object = {
+    obj: {
+      prop: 'test'
+    }
+  }
+
+  const stringify = build(schema, { schema: externalSchema })
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal(output, '{"obj":{"prop":"test"}}')
+})
+
 test('ref in root internal', (t) => {
   t.plan(2)
 

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -685,7 +685,7 @@ test('ref internal - multiple $ref format', (t) => {
   t.equal(output, '{"zero":"test","a":"test","b":"test","c":"test","d":"test","e":"test"}')
 })
 
-test('ref external - external schema with internal ref', (t) => {
+test('ref external - external schema with internal ref (object property)', (t) => {
   t.plan(2)
 
   const externalSchema = {
@@ -707,6 +707,140 @@ test('ref external - external schema with internal ref', (t) => {
     type: 'object',
     properties: {
       obj: {
+        $ref: 'external#/definitions/def'
+      }
+    }
+  }
+
+  const object = {
+    obj: {
+      prop: 'test'
+    }
+  }
+
+  const stringify = build(schema, { schema: externalSchema })
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal(output, '{"obj":{"prop":"test"}}')
+})
+
+test('ref external - external schema with internal ref (array items)', (t) => {
+  t.plan(2)
+
+  const externalSchema = {
+    external: {
+      definitions: {
+        internal: { type: 'string' },
+        def: {
+          type: 'object',
+          properties: {
+            prop: { $ref: '#/definitions/internal' }
+          }
+        }
+      }
+    }
+  }
+
+  const schema = {
+    title: 'object with $ref',
+    type: 'object',
+    properties: {
+      arr: {
+        type: 'array',
+        items: {
+          $ref: 'external#/definitions/def'
+        }
+      }
+    }
+  }
+
+  const object = {
+    arr: [{
+      prop: 'test'
+    }]
+  }
+
+  const stringify = build(schema, { schema: externalSchema })
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal(output, '{"arr":[{"prop":"test"}]}')
+})
+
+test('ref external - external schema with internal ref (root)', (t) => {
+  t.plan(2)
+
+  const externalSchema = {
+    external: {
+      definitions: {
+        internal: { type: 'string' },
+        def: {
+          type: 'object',
+          properties: {
+            prop: { $ref: '#/definitions/internal' }
+          }
+        }
+      }
+    }
+  }
+
+  const schema = {
+    title: 'object with $ref',
+    $ref: 'external#/definitions/def'
+  }
+
+  const object = {
+    prop: 'test'
+  }
+
+  const stringify = build(schema, { schema: externalSchema })
+  const output = stringify(object)
+
+  try {
+    JSON.parse(output)
+    t.pass()
+  } catch (e) {
+    t.fail()
+  }
+
+  t.equal(output, '{"prop":"test"}')
+})
+
+test('ref external - external schema with internal ref (pattern properties)', (t) => {
+  t.plan(2)
+
+  const externalSchema = {
+    external: {
+      definitions: {
+        internal: { type: 'string' },
+        def: {
+          type: 'object',
+          patternProperties: {
+            '^p': { $ref: '#/definitions/internal' }
+          }
+        }
+      }
+    }
+  }
+
+  const schema = {
+    title: 'object with $ref',
+    type: 'object',
+    patternProperties: {
+      '^o': {
         $ref: 'external#/definitions/def'
       }
     }


### PR DESCRIPTION

This PR is intended to fix https://github.com/fastify/fast-json-stringify/issues/238.

The problem in the current implementation is that relative JSON pointers in `$ref`s like `#/definitions/def` always search in the main schema, even if the `$ref` is found in an external schema.

With this change the code will keep track of the current parent (or "context", if you will) so that subsequent `$ref`s will search in the appropriate schema.

There was an original attempt to fix this in https://github.com/fastify/fast-json-stringify/pull/185/files, but that was limited to some special conditions (i.e. only in object properties).
Also the assumptions in https://github.com/fastify/fast-json-stringify/pull/185/files#diff-168726dbe96b3ce427e7fedce31bb0bcR537 about existence of `schema.definitions` is wrong as using `definitions` is customary, but not mandatory (see https://json-schema.org/understanding-json-schema/structuring.html#reuse).

With this PR I hope to provide a comprehensive solution that correctly handle relative pointers in `$ref` for all scenarios.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
