### PR TITLE
fix: avoid unecessary concat calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -405,14 +405,12 @@ function addPatternProperties (location) {
         if (/${regex.replace(/\\*\//g, '\\/')}/.test(keys[i])) {
     `
     if (type === 'object') {
-      code += buildObject(ppLocation, '', 'buildObjectPP' + index)
-      code += `
+      code += `${buildObject(ppLocation, '', 'buildObjectPP' + index)}
           ${addComma}
           json += $asString(keys[i]) + ':' + buildObjectPP${index}(obj[keys[i]])
       `
     } else if (type === 'array') {
-      code += buildArray(ppLocation, '', 'buildArrayPP' + index)
-      code += `
+      code += `${buildArray(ppLocation, '', 'buildArrayPP' + index)}
           ${addComma}
           json += $asString(keys[i]) + ':' + buildArrayPP${index}(obj[keys[i]])
       `
@@ -483,14 +481,12 @@ function additionalProperty (location) {
   var format = ap.format
   var stringSerializer = getStringSerializer(format)
   if (type === 'object') {
-    code += buildObject(apLocation, '', 'buildObjectAP')
-    code += `
+    code += `${buildObject(apLocation, '', 'buildObjectAP')}
         ${addComma}
         json += $asString(keys[i]) + ':' + buildObjectAP(obj[keys[i]])
     `
   } else if (type === 'array') {
-    code += buildArray(apLocation, '', 'buildArrayAP')
-    code += `
+    code += `${buildArray(apLocation, '', 'buildArrayAP')}
         ${addComma}
         json += $asString(keys[i]) + ':' + buildArrayAP(obj[keys[i]])
     `
@@ -792,8 +788,7 @@ function buildCode (location, code, laterCode, name) {
       }
       code += `${JSON.stringify(required[i])}`
     }
-    code += ']'
-    code += `
+    code += `]
       for (var i = 0; i < required.length; i++) {
         if (obj[required[i]] === undefined) throw new Error('"' + required[i] + '" is required!')
       }
@@ -932,11 +927,10 @@ function buildObject (location, code, name) {
     r = buildInnerObject(location, name)
   }
 
-  code += r.code
   laterCode = r.laterCode
 
   // Removes the comma if is the last element of the string (in case there are not properties)
-  code += `
+  code += `${r.code}
       json += '}'
       return json
     }
@@ -1006,15 +1000,12 @@ function buildArray (location, code, name) {
       }
       ${result.code}
     }
+    json += ']'
+    return json
+  }
   `
 
   laterCode = result.laterCode
-
-  code += `
-      json += ']'
-      return json
-    }
-  `
 
   code += laterCode
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Because calling `+=` operand is cost effective, reducing the number of calls seems like a good move to improve performances.

Reference benchmark
```
FJS creation x 36,866 ops/sec ±3.36% (74 runs sampled)
JSTR creation x 103,618 ops/sec ±3.28% (78 runs sampled)
CJS creation x 110,871 ops/sec ±2.26% (85 runs sampled)
JSON.stringify array x 3,308 ops/sec ±3.92% (79 runs sampled)
fast-json-stringify array x 5,923 ops/sec ±1.13% (86 runs sampled)
json-strify array x 48,848,583 ops/sec ±0.61% (91 runs sampled)
compile-json-stringify array x 6,132 ops/sec ±1.49% (85 runs sampled)
JSON.stringify long string x 13,234 ops/sec ±0.48% (93 runs sampled)
fast-json-stringify long string x 13,205 ops/sec ±0.44% (92 runs sampled)
json-strify long string x 250,959 ops/sec ±1.04% (91 runs sampled)
compile-json-stringify long string x 12,778 ops/sec ±0.97% (87 runs sampled)
JSON.stringify short string x 4,270,730 ops/sec ±1.23% (86 runs sampled)
fast-json-stringify short string x 24,189,271 ops/sec ±0.92% (93 runs sampled)
json-strify short string x 46,922,094 ops/sec ±0.60% (91 runs sampled)
compile-json-stringify short string x 27,792,567 ops/sec ±0.61% (95 runs sampled)
JSON.stringify obj x 1,998,108 ops/sec ±0.88% (88 runs sampled)
fast-json-stringify obj x 6,616,125 ops/sec ±1.11% (90 runs sampled)
json-strify obj x 50,441,958 ops/sec ±0.94% (93 runs sampled)
compile-json-stringify obj x 6,978,942 ops/sec ±1.06% (93 runs sampled)
```

Updated code benchmark
```
FJS creation x 45,313 ops/sec ±1.79% (89 runs sampled)
JSTR creation x 133,403 ops/sec ±0.98% (92 runs sampled)
CJS creation x 133,050 ops/sec ±1.25% (93 runs sampled)
JSON.stringify array x 4,338 ops/sec ±0.49% (93 runs sampled)
fast-json-stringify array x 6,842 ops/sec ±0.13% (98 runs sampled)
json-strify array x 55,356,698 ops/sec ±0.66% (95 runs sampled)
compile-json-stringify array x 6,841 ops/sec ±0.88% (91 runs sampled)
JSON.stringify long string x 14,075 ops/sec ±0.59% (94 runs sampled)
fast-json-stringify long string x 14,324 ops/sec ±0.42% (94 runs sampled)
json-strify long string x 277,193 ops/sec ±0.43% (94 runs sampled)
compile-json-stringify long string x 14,400 ops/sec ±0.36% (97 runs sampled)
JSON.stringify short string x 5,062,643 ops/sec ±0.40% (94 runs sampled)
fast-json-stringify short string x 26,170,935 ops/sec ±0.76% (96 runs sampled)
json-strify short string x 51,178,502 ops/sec ±0.47% (89 runs sampled)
compile-json-stringify short string x 29,463,421 ops/sec ±0.91% (95 runs sampled)
JSON.stringify obj x 2,208,298 ops/sec ±0.53% (96 runs sampled)
fast-json-stringify obj x 6,983,039 ops/sec ±0.41% (96 runs sampled)
json-strify obj x 53,769,162 ops/sec ±0.87% (94 runs sampled)
compile-json-stringify obj x 7,359,243 ops/sec ±0.27% (97 runs sampled)
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
