### PR TITLE
Omit Symbol properties for anyOf validation schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -1159,7 +1159,7 @@ function nested (laterCode, name, key, location, subKey, isArray) {
           // 2. `nested`, through `buildCode`, replaces any reference in object properties with the actual schema
           // (see https://github.com/fastify/fast-json-stringify/blob/6da3b3e8ac24b1ca5578223adedb4083b7adf8db/index.js#L631)
           code += `
-            ${index === 0 ? 'if' : 'else if'}(ajv.validate(${require('util').inspect(location.schema, { depth: null, maxArrayLength: null })}, obj${accessor}))
+            ${index === 0 ? 'if' : 'else if'}(ajv.validate(${JSON.stringify(location.schema)}, obj${accessor}))
               ${nestedResult.code}
           `
           laterCode = nestedResult.laterCode

--- a/test/anyof.test.js
+++ b/test/anyof.test.js
@@ -197,6 +197,36 @@ test('null value in schema', (t) => {
   build(schema)
 })
 
+test('symbol value in schema', (t) => {
+  t.plan(4)
+
+  const ObjectKind = Symbol('LiteralKind')
+  const UnionKind = Symbol('UnionKind')
+  const LiteralKind = Symbol('LiteralKind')
+
+  const schema = {
+    kind: ObjectKind,
+    type: 'object',
+    properties: {
+      value: {
+        kind: UnionKind,
+        anyOf: [
+          { kind: LiteralKind, type: 'string', enum: ['foo'] },
+          { kind: LiteralKind, type: 'string', enum: ['bar'] },
+          { kind: LiteralKind, type: 'string', enum: ['baz'] }
+        ]
+      }
+    },
+    required: ['value']
+  }
+
+  const stringify = build(schema)
+  t.is(stringify({ value: 'foo' }), '{"value":"foo"}')
+  t.is(stringify({ value: 'bar' }), '{"value":"bar"}')
+  t.is(stringify({ value: 'baz' }), '{"value":"baz"}')
+  t.is(stringify({ value: 'qux' }), '{"value":null}')
+})
+
 test('anyOf and $ref together', (t) => {
   t.plan(2)
 


### PR DESCRIPTION
This PR updates the `anyOf` code generation pass to omit Symbol properties for the AJV validation schema. This is done via `JSON.stringify()` which will automatically omit Symbols (and other non-JSON applicable types). This replaces the previous approach that used NodeJS's `util.inspect()`.

Fixes https://github.com/fastify/fast-json-stringify/issues/271.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
