### PR TITLE
add float truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ fast-json-stringify obj x 13,537,123 ops/sec ±0.19% (95 runs sampled)
  - <a href="#anyof">`AnyOf`</a>
  - <a href="#ref">`Reuse - $ref`</a>
  - <a href="#long">`Long integers`</a>
+ - <a href="#integer">`Integers`</a>
  - <a href="#nullable">`Nullable`</a>
 - <a href="#security">`Security Notice`</a>
 - <a href="#acknowledgements">`Acknowledgements`</a>
@@ -532,6 +533,11 @@ const obj = {
 
 console.log(stringify(obj)) // '{"id":18446744073709551615}'
 ```
+
+<a name="integer"></a>
+#### Integers
+The `type: integer` property will be truncated if a floating point is provided.
+
 
 <a name="nullable"></a>
 #### Nullable

--- a/README.md
+++ b/README.md
@@ -537,6 +537,11 @@ console.log(stringify(obj)) // '{"id":18446744073709551615}'
 <a name="integer"></a>
 #### Integers
 The `type: integer` property will be truncated if a floating point is provided.
+You can customize this behaviour with the `rounding` option that will accept [`round`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round), [`ceil`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/ceil) or [`floor`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor):
+
+```js
+const stringify = fastJson(schema, { rounding: 'ceil' })
+```
 
 
 <a name="nullable"></a>

--- a/index.d.ts
+++ b/index.d.ts
@@ -145,6 +145,10 @@ declare namespace build {
      * Configure Ajv, which is used to evaluate conditional schemas and combined (anyOf) schemas
      */
     ajv?: AjvOptions
+    /**
+     * Optionally configure how the integer will be rounded
+     */
+    rounding?: 'ceil' | 'floor' | 'round'
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -83,7 +83,8 @@ function build (schema, options) {
     `
   } else {
     code += `
-      var $asInteger = $asNumber
+      var isLong = false
+      ${$asInteger.toString()}
     `
   }
 
@@ -239,8 +240,11 @@ function $asInteger (i) {
     return i.toString()
   } else if (typeof i === 'bigint') {
     return i.toString()
-  } else {
+  } else if (Number.isInteger(i)) {
     return $asNumber(i)
+  } else {
+    // if the output is NaN the type is coerced to int 0
+    return $asNumber(parseInt(i) || 0)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -54,6 +54,15 @@ function build (schema, options) {
     }
   }
 
+  var intParseFunctionName = 'trunc'
+  if (options.rounding) {
+    if (['floor', 'ceil', 'round'].includes(options.rounding)) {
+      intParseFunctionName = options.rounding
+    } else {
+      throw new Error(`Unsupported integer rounding method ${options.rounding}`)
+    }
+  }
+
   /* eslint no-new-func: "off" */
   var code = `
     'use strict'
@@ -76,6 +85,8 @@ function build (schema, options) {
     ${$asBooleanNullable.toString()}
 
     var isLong = ${isLong ? isLong.toString() : false}
+
+    function parseInteger(int) { return Math.${intParseFunctionName}(int) }
     `
 
   var location = {
@@ -213,7 +224,8 @@ const stringSerializerMap = {
 }
 
 function getStringSerializer (format) {
-  return stringSerializerMap[format] || '$asString'
+  return stringSerializerMap[format] ||
+  '$asString'
 }
 
 function $pad2Zeros (num) {
@@ -234,7 +246,8 @@ function $asInteger (i) {
     return $asNumber(i)
   } else {
     // if the output is NaN the type is coerced to int 0
-    return $asNumber(parseInt(i) || 0)
+    /* eslint no-undef: "off" */
+    return $asNumber(parseInteger(i) || 0)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -69,24 +69,14 @@ function build (schema, options) {
     ${$asTime.toString()}
     ${$asNumber.toString()}
     ${$asNumberNullable.toString()}
+    ${$asInteger.toString()}
     ${$asIntegerNullable.toString()}
     ${$asNull.toString()}
     ${$asBoolean.toString()}
     ${$asBooleanNullable.toString()}
-  `
 
-  // only handle longs if the module is used
-  if (isLong) {
-    code += `
-      var isLong = ${isLong.toString()}
-      ${$asInteger.toString()}
+    var isLong = ${isLong ? isLong.toString() : false}
     `
-  } else {
-    code += `
-      var isLong = false
-      ${$asInteger.toString()}
-    `
-  }
 
   var location = {
     schema,

--- a/test/integer.test.js
+++ b/test/integer.test.js
@@ -27,20 +27,27 @@ test('render a float as an integer', (t) => {
   const cases = [
     { input: Math.PI, output: '3' },
     { input: 5.0, output: '5' },
-    { input: 1.99999, output: '1' }
+    { input: 1.99999, output: '1' },
+    { input: -45.05, output: '-45' },
+    { input: 0.95, output: '1', rounding: 'ceil' },
+    { input: 0.2, output: '1', rounding: 'ceil' },
+    { input: 45.95, output: '45', rounding: 'floor' },
+    { input: -45.05, output: '-46', rounding: 'floor' },
+    { input: 45.44, output: '45', rounding: 'round' },
+    { input: 45.95, output: '46', rounding: 'round' }
   ]
 
   t.plan(cases.length * 2)
   cases.forEach(checkInteger)
 
-  function checkInteger ({ input, output }) {
+  function checkInteger ({ input, output, rounding }) {
     const schema = {
       title: 'float as integer',
       type: 'integer'
     }
 
     const validate = validator(schema)
-    const stringify = build(schema)
+    const stringify = build(schema, { rounding })
     const str = stringify(input)
 
     t.equal(str, output)

--- a/test/integer.test.js
+++ b/test/integer.test.js
@@ -23,6 +23,31 @@ test('render an integer as JSON', (t) => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
+test('render a float as an integer', (t) => {
+  const cases = [
+    { input: Math.PI, output: '3' },
+    { input: 5.0, output: '5' },
+    { input: 1.99999, output: '1' }
+  ]
+
+  t.plan(cases.length * 2)
+  cases.forEach(checkInteger)
+
+  function checkInteger ({ input, output }) {
+    const schema = {
+      title: 'float as integer',
+      type: 'integer'
+    }
+
+    const validate = validator(schema)
+    const stringify = build(schema)
+    const str = stringify(input)
+
+    t.equal(str, output)
+    t.ok(validate(JSON.parse(str)), 'valid schema')
+  }
+})
+
 test('render an object with an integer as JSON', (t) => {
   t.plan(2)
 

--- a/test/integer.test.js
+++ b/test/integer.test.js
@@ -24,6 +24,19 @@ test('render an integer as JSON', (t) => {
 })
 
 test('render a float as an integer', (t) => {
+  t.plan(2)
+  try {
+    build({
+      title: 'float as integer',
+      type: 'integer'
+    }, { rounding: 'foobar' })
+  } catch (error) {
+    t.ok(error)
+    t.equals(error.message, 'Unsupported integer rounding method foobar')
+  }
+})
+
+test('render a float as an integer', (t) => {
   const cases = [
     { input: Math.PI, output: '3' },
     { input: 5.0, output: '5' },

--- a/test/types/test.ts
+++ b/test/types/test.ts
@@ -66,6 +66,7 @@ const schema9: Schema = {
 
 build(schema8)({})
 build(schema9)({ foo: 'bar' })
+build(schema9, { rounding: 'floor' })({ foo: 'bar' })
 
 // Reference schemas
 const schema10: Schema = {


### PR DESCRIPTION
Fix #277 

Note that to implement a `rounding` input option the most straightforward way is to generate the output function calling a global named function.

```js
  let customAsInteger = $asInteger.toString()
  if (options.rounding) {
    customAsInteger = customAsInteger.replace('parseInt', options.rounding)
  }
```

In this case the input would be the ugly (note the Math.round as 'string`):

```
const debugCompiled = fastJson(schema, { debugMode: true, rounding: 'Math.round' })
```

Or:

```
function round(in){ return Math.round(in) }
const debugCompiled = fastJson(schema, { debugMode: true, rounding: round })
```

Where

```diff
-  customAsInteger = customAsInteger.replace('parseInt', options.rounding)
+ customAsInteger = customAsInteger.replace('parseInt', options.rounding.name)
```

Which one do you think would be better? Or do you see nicest solutions?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
