### PR TITLE
Fix: Omit all Non-JSON schema applicable properties from codegen (#279)

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@
 var Ajv = require('ajv')
 var merge = require('deepmerge')
 
-var util = require('util')
 var validate = require('./schema-validator')
 var stringSimilarity = null
 
@@ -834,7 +833,7 @@ function addIfThenElse (location, name) {
   var mergedLocation = mergeLocation(location, { schema: merged })
 
   code += `
-    valid = ajv.validate(${util.inspect(i, { depth: null })}, obj)
+    valid = ajv.validate(${JSON.stringify(i)}, obj)
     if (valid) {
   `
   if (merged.if && merged.then) {

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -209,3 +209,44 @@ buildTest({
 }, {
   foo: [1, 'string', {}, null]
 })
+
+// https://github.com/fastify/fast-json-stringify/issues/279
+test('object array with anyOf and symbol', (t) => {
+  t.plan(1)
+  const schema = {
+    kind: Symbol('ArrayKind'),
+    type: 'array',
+    items: {
+      kind: Symbol('ObjectKind'),
+      type: 'object',
+      properties: {
+        name: {
+          kind: Symbol('StringKind'),
+          type: 'string'
+        },
+        option: {
+          kind: Symbol('UnionKind'),
+          anyOf: [
+            {
+              kind: Symbol('LiteralKind'),
+              type: 'string',
+              enum: ['Foo']
+            },
+            {
+              kind: Symbol('LiteralKind'),
+              type: 'string',
+              enum: ['Bar']
+            }
+          ]
+        }
+      },
+      required: ['name', 'option']
+    }
+  }
+  const stringify = build(schema)
+  const value = stringify([
+    { name: 'name-0', option: 'Foo' },
+    { name: 'name-1', option: 'Bar' }
+  ])
+  t.is(value, '[{"name":"name-0","option":"Foo"},{"name":"name-1","option":"Bar"}]')
+})

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -213,27 +213,33 @@ buildTest({
 // https://github.com/fastify/fast-json-stringify/issues/279
 test('object array with anyOf and symbol', (t) => {
   t.plan(1)
+  const ArrayKind = Symbol('ArrayKind')
+  const ObjectKind = Symbol('LiteralKind')
+  const UnionKind = Symbol('UnionKind')
+  const LiteralKind = Symbol('LiteralKind')
+  const StringKind = Symbol('StringKind')
+
   const schema = {
-    kind: Symbol('ArrayKind'),
+    kind: ArrayKind,
     type: 'array',
     items: {
-      kind: Symbol('ObjectKind'),
+      kind: ObjectKind,
       type: 'object',
       properties: {
         name: {
-          kind: Symbol('StringKind'),
+          kind: StringKind,
           type: 'string'
         },
         option: {
-          kind: Symbol('UnionKind'),
+          kind: UnionKind,
           anyOf: [
             {
-              kind: Symbol('LiteralKind'),
+              kind: LiteralKind,
               type: 'string',
               enum: ['Foo']
             },
             {
-              kind: Symbol('LiteralKind'),
+              kind: LiteralKind,
               type: 'string',
               enum: ['Bar']
             }


### PR DESCRIPTION
This PR follows on from PR https://github.com/fastify/fast-json-stringify/pull/272. It removes the last call to `util.inspect()` and leverages `JSON.stringify()` instead to omit all non-json and non-jsonschema properties in the `fast-json-stringify` codegen pass. This allows callers to add non-json metadata (with particular note to `Symbol` properties) to their schemas which will be ignored once passed to the `fast-json-stringify` API.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
