### PR TITLE
Support for empty schemas #255

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,6 +58,9 @@ declare namespace build {
      */
     $ref: string;
   }
+  
+  export interface AnySchema extends BaseSchema {
+  }
 
   export interface StringSchema extends BaseSchema {
     type: "string";
@@ -153,6 +156,7 @@ declare namespace build {
  * @param schema The schema used to stringify values
  * @param options The options to use (optional)
  */
+declare function build(schema: build.AnySchema, options?: build.Options): (doc: any) => any;
 declare function build(schema: build.StringSchema, options?: build.Options): (doc: string) => string;
 declare function build(schema: build.IntegerSchema | build.NumberSchema, options?: build.Options): (doc: number) => string;
 declare function build(schema: build.NullSchema, options?: build.Options): (doc: null) => "null";

--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ function build (schema, options) {
 
   code += `
     ${$pad2Zeros.toString()}
+    ${$asAny.toString()}
     ${$asString.toString()}
     ${$asStringNullable.toString()}
     ${$asStringSmall.toString()}
@@ -127,6 +128,9 @@ function build (schema, options) {
     case 'array':
       main = '$main'
       code = buildArray(location, code, main)
+      break
+    case undefined:
+      main = '$asAny'
       break
     default:
       throw new Error(`${schema.type} unsupported`)
@@ -232,6 +236,10 @@ function getStringSerializer (format) {
 function $pad2Zeros (num) {
   const s = '00' + num
   return s[s.length - 2] + s[s.length - 1]
+}
+
+function $asAny (i) {
+  return JSON.stringify(i)
 }
 
 function $asNull () {
@@ -883,7 +891,7 @@ function addIfThenElse (location, name) {
 }
 
 function toJSON (variableName) {
-  return `typeof ${variableName}.toJSON === 'function'
+  return `(${variableName} && typeof ${variableName}.toJSON === 'function')
     ? ${variableName}.toJSON()
     : ${variableName}
   `
@@ -1186,6 +1194,10 @@ function nested (laterCode, name, key, location, subKey, isArray) {
             json += '${JSON.stringify(schema.const)}'
           else
             throw new Error(\`Item $\{JSON.stringify(obj${accessor})} does not match schema definition.\`)
+        `
+      } else if (schema.type === undefined) {
+        code += `
+          json += JSON.stringify(obj${accessor})
         `
       } else {
         throw new Error(`${schema.type} unsupported`)

--- a/test/any.test.js
+++ b/test/any.test.js
@@ -63,3 +63,92 @@ test('array with random items', (t) => {
   const value = stringify([1, 'string', null])
   t.is(value, '[1,"string",null]')
 })
+
+test('empty schema', (t) => {
+  t.plan(7)
+
+  const schema = { }
+
+  const stringify = build(schema)
+
+  t.is(stringify(null), 'null')
+  t.is(stringify(1), '1')
+  t.is(stringify(true), 'true')
+  t.is(stringify('hello'), '"hello"')
+  t.is(stringify({}), '{}')
+  t.is(stringify({ x: 10 }), '{"x":10}')
+  t.is(stringify([true, 1, 'hello']), '[true,1,"hello"]')
+})
+
+test('empty schema on nested object', (t) => {
+  t.plan(7)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      x: {}
+    }
+  }
+
+  const stringify = build(schema)
+
+  t.is(stringify({ x: null }), '{"x":null}')
+  t.is(stringify({ x: 1 }), '{"x":1}')
+  t.is(stringify({ x: true }), '{"x":true}')
+  t.is(stringify({ x: 'hello' }), '{"x":"hello"}')
+  t.is(stringify({ x: {} }), '{"x":{}}')
+  t.is(stringify({ x: { x: 10 } }), '{"x":{"x":10}}')
+  t.is(stringify({ x: [true, 1, 'hello'] }), '{"x":[true,1,"hello"]}')
+})
+
+test('empty schema on array', (t) => {
+  t.plan(1)
+
+  const schema = {
+    type: 'array',
+    items: {}
+  }
+
+  const stringify = build(schema)
+
+  t.is(stringify([1, true, 'hello', [], { x: 1 }]), '[1,true,"hello",[],{"x":1}]')
+})
+
+test('empty schema on anyOf', (t) => {
+  t.plan(4)
+
+  // any on Foo codepath.
+  const schema = {
+    anyOf: [
+      {
+        type: 'object',
+        properties: {
+          kind: {
+            type: 'string',
+            enum: ['Foo']
+          },
+          value: {}
+        }
+      },
+      {
+        type: 'object',
+        properties: {
+          kind: {
+            type: 'string',
+            enum: ['Bar']
+          },
+          value: {
+            type: 'number'
+          }
+        }
+      }
+    ]
+  }
+
+  const stringify = build(schema)
+
+  t.is(stringify({ kind: 'Bar', value: 1 }), '{"kind":"Bar","value":1}')
+  t.is(stringify({ kind: 'Foo', value: 1 }), '{"kind":"Foo","value":1}')
+  t.is(stringify({ kind: 'Foo', value: true }), '{"kind":"Foo","value":true}')
+  t.is(stringify({ kind: 'Foo', value: 'hello' }), '{"kind":"Foo","value":"hello"}')
+})


### PR DESCRIPTION
This PR adds support for empty `{}` `any` schemas to resolve issue #255. This update checks for the existence of a `type` property on the schema, and if not found, defaults to a `JSON.stringify()` for serialization. 

Have added a few tests to `any.test.js` and updated `index.d.ts` accordingly. Submitting this PR for review. 

### benchmark
```
cpu  AMD Ryzen 7 3700X 8-Core Processor
ram  32GB 
node v12.18.2

FJS creation x 56,104 ops/sec ±0.26% (92 runs sampled)
CJS creation x 162,430 ops/sec ±0.27% (98 runs sampled)

JSON.stringify array x 3,320 ops/sec ±0.33% (91 runs sampled)
fast-json-stringify array x 8,465 ops/sec ±0.37% (90 runs sampled)

compile-json-stringify array x 7,756 ops/sec ±0.75% (94 runs sampled)
JSON.stringify long string x 10,028 ops/sec ±0.17% (95 runs sampled)

fast-json-stringify long string x 10,098 ops/sec ±0.13% (96 runs sampled)
compile-json-stringify long string x 10,108 ops/sec ±0.10% (99 runs sampled)

JSON.stringify short string x 8,700,507 ops/sec ±0.46% (91 runs sampled)
fast-json-stringify short string x 47,164,570 ops/sec ±0.21% (96 runs sampled)

compile-json-stringify short string x 40,127,602 ops/sec ±0.38% (97 runs sampled)
JSON.stringify obj x 1,827,988 ops/sec ±0.12% (96 runs sampled)

fast-json-stringify obj x 17,418,215 ops/sec ±0.39% (95 runs sampled)
compile-json-stringify obj x 24,095,360 ops/sec ±0.23% (95 runs sampled)
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
