### PR TITLE
feat: make long dependency configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,12 @@ const stringify = fastJson(schema, { schema: externalSchema })
 #### Long integers
 By default the library will handle automatically [BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) from Node.js v10.3 and above.
 If you can't use BigInts in your environment, long integers (64-bit) are also supported using the [long](https://github.com/dcodeIO/long.js) module.
+
+In order to use long integers you have to:
+
+1. Install `long` dependency
+1. Pass `{useLong: true}` option when building schema
+
 Example:
 ```javascript
 // => using native BigInt
@@ -524,7 +530,7 @@ const stringify = fastJson({
       type: 'integer'
     }
   }
-})
+}, {useLong: true})
 
 const obj = {
   id: Long.fromString('18446744073709551615', true)

--- a/index.js
+++ b/index.js
@@ -8,13 +8,6 @@ const merge = require('deepmerge')
 const validate = require('./schema-validator')
 let stringSimilarity = null
 
-let isLong
-try {
-  isLong = require('long').isLong
-} catch (e) {
-  isLong = null
-}
-
 const addComma = `
   if (addComma) {
     json += ','
@@ -44,8 +37,15 @@ function mergeLocation (source, dest) {
   }
 }
 
+let isLong
+
 function build (schema, options) {
   options = options || {}
+
+  if (options.useLong) {
+    isLong = require('long').isLong
+  }
+
   isValidSchema(schema)
   if (options.schema) {
     // eslint-disable-next-line
@@ -411,6 +411,11 @@ function addPatternProperties (location) {
       code += `
           ${addComma}
           json += $asString(keys[i]) + ':' + ${stringSerializer}(obj[keys[i]])
+      `
+    } else if (type === 'integer' && isLong) {
+      code += `
+          ${addComma}
+          json += $asString(keys[i]) + ':' + $asInteger(obj[keys[i]])
       `
     } else if (type === 'integer') {
       code += `

--- a/test/long.test.js
+++ b/test/long.test.js
@@ -14,7 +14,7 @@ test('render a long as JSON', (t) => {
   }
 
   const validate = validator(schema)
-  const stringify = build(schema)
+  const stringify = build(schema, { useLong: true })
   const output = stringify(Long.fromString('18446744073709551615', true))
 
   t.equal(output, '18446744073709551615')
@@ -35,7 +35,7 @@ test('render an object with long as JSON', (t) => {
   }
 
   const validate = validator(schema)
-  const stringify = build(schema)
+  const stringify = build(schema, { useLong: true })
   const output = stringify({
     id: Long.fromString('18446744073709551615', true)
   })
@@ -56,7 +56,7 @@ test('render an array with long as JSON', (t) => {
   }
 
   const validate = validator(schema)
-  const stringify = build(schema)
+  const stringify = build(schema, { useLong: true })
   const output = stringify([Long.fromString('18446744073709551615', true)])
 
   t.equal(output, '[18446744073709551615]')
@@ -75,7 +75,7 @@ test('render an object with a long additionalProperty as JSON', (t) => {
   }
 
   const validate = validator(schema)
-  const stringify = build(schema)
+  const stringify = build(schema, { useLong: true })
   const output = stringify({
     num: Long.fromString('18446744073709551615', true)
   })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Benchmark

```
FJS creation x 62,633 ops/sec ±0.99% (91 runs sampled)
CJS creation x 166,758 ops/sec ±1.18% (89 runs sampled)
JSON.stringify array x 5,083 ops/sec ±1.22% (92 runs sampled)
fast-json-stringify array x 7,234 ops/sec ±1.00% (90 runs sampled)
compile-json-stringify array x 6,601 ops/sec ±1.45% (88 runs sampled)
JSON.stringify long string x 13,391 ops/sec ±1.01% (88 runs sampled)
fast-json-stringify long string x 13,245 ops/sec ±1.06% (89 runs sampled)
compile-json-stringify long string x 13,358 ops/sec ±1.08% (89 runs sampled)
JSON.stringify short string x 10,635,798 ops/sec ±1.36% (88 runs sampled)
fast-json-stringify short string x 31,372,088 ops/sec ±1.23% (89 runs sampled)
compile-json-stringify short string x 28,003,490 ops/sec ±1.00% (89 runs sampled)
JSON.stringify obj x 2,347,149 ops/sec ±1.56% (86 runs sampled)
fast-json-stringify obj x 6,576,019 ops/sec ±1.01% (88 runs sampled)
compile-json-stringify obj x 15,935,888 ops/sec ±0.93% (90 runs sampled)
```
