### PR TITLE
fix: avoid side effect per oneOf and anyOf

### DIFF
--- a/index.js
+++ b/index.js
@@ -1191,7 +1191,7 @@ function nested (laterCode, name, key, location, subKey, isArray) {
 
           // see comment on anyOf about derefencing the schema before calling ajv.validate
           code += `
-            ${index === 0 ? 'if' : 'else if'}(ajv.validate(${require('util').inspect(location.schema, { depth: null, maxArrayLength: null })}, obj${accessor}))
+            ${index === 0 ? 'if' : 'else if'}(ajv.validate(${JSON.stringify(location.schema)}, obj${accessor}))
               ${nestedResult.code}
           `
           laterCode = nestedResult.laterCode
@@ -1205,7 +1205,7 @@ function nested (laterCode, name, key, location, subKey, isArray) {
         `
       } else if ('const' in schema) {
         code += `
-          if(ajv.validate(${require('util').inspect(schema, { depth: null })}, obj${accessor}))
+          if(ajv.validate(${require('util').inspect(schema, { depth: null, showHidden: false })}, obj${accessor}))
             json += '${JSON.stringify(schema.const)}'
           else
             throw new Error(\`Item $\{JSON.stringify(obj${accessor})} does not match schema definition.\`)

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@
 
 const Ajv = require('ajv')
 const merge = require('deepmerge')
+const clone = require('rfdc')({ proto: true })
+const fjsCloned = Symbol('fast-json-stringify.cloned')
 
 const validate = require('./schema-validator')
 let stringSimilarity = null
@@ -1059,6 +1061,12 @@ function buildArrayTypeCondition (type, accessor) {
 }
 
 function dereferenceOfRefs (location, type) {
+  if (!location.schema[fjsCloned]) {
+    const schemaClone = clone(location.schema)
+    schemaClone[fjsCloned] = true
+    location.schema = schemaClone
+  }
+
   const schema = location.schema
   const locations = []
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "index.d.ts",
   "scripts": {
     "benchmark": "node bench.js",
+    "lint:fix": "standard --fix",
     "test:lint": "standard",
     "test:typescript": "tsc --project ./test/types/tsconfig.json",
     "test:unit": "tap -J test/*.test.js test/**/*.test.js",
@@ -45,6 +46,7 @@
   "dependencies": {
     "ajv": "^6.11.0",
     "deepmerge": "^4.2.2",
+    "rfdc": "^1.2.0",
     "string-similarity": "^4.0.1"
   },
   "engines": {

--- a/test/side-effect.test.js
+++ b/test/side-effect.test.js
@@ -1,0 +1,123 @@
+'use strict'
+
+const { test } = require('tap')
+const clone = require('rfdc/default')
+const build = require('..')
+
+test('oneOf with $ref should not change the input schema', t => {
+  t.plan(2)
+
+  const referenceSchema = {
+    $id: 'externalId',
+    type: 'object',
+    properties: {
+      name: { type: 'string' }
+    }
+  }
+
+  const schema = {
+    $id: 'mainSchema',
+    type: 'object',
+    properties: {
+      people: {
+        oneOf: [{ $ref: 'externalId' }]
+      }
+    }
+  }
+  const clonedSchema = clone(schema)
+  const stringify = build(schema, {
+    schema: {
+      [referenceSchema.$id]: referenceSchema
+    }
+  })
+
+  const value = stringify({ people: { name: 'hello', foo: 'bar' } })
+  t.is(value, '{"people":{"name":"hello"}}')
+  t.deepEqual(schema, clonedSchema)
+})
+
+test('oneOf and anyOf with $ref should not change the input schema', t => {
+  t.plan(3)
+
+  const referenceSchema = {
+    $id: 'externalSchema',
+    type: 'object',
+    properties: {
+      name: { type: 'string' }
+    }
+  }
+
+  const schema = {
+    $id: 'rootSchema',
+    type: 'object',
+    properties: {
+      people: {
+        oneOf: [{ $ref: 'externalSchema' }]
+      },
+      love: {
+        anyOf: [
+          { $ref: '#/definitions/foo' },
+          { type: 'boolean' }
+        ]
+      }
+    },
+    definitions: {
+      foo: { type: 'string' }
+    }
+  }
+  const clonedSchema = clone(schema)
+  const stringify = build(schema, {
+    schema: {
+      [referenceSchema.$id]: referenceSchema
+    }
+  })
+
+  const valueAny1 = stringify({ people: { name: 'hello', foo: 'bar' }, love: 'music' })
+  const valueAny2 = stringify({ people: { name: 'hello', foo: 'bar' }, love: true })
+
+  t.equal(valueAny1, '{"people":{"name":"hello"},"love":"music"}')
+  t.equal(valueAny2, '{"people":{"name":"hello"},"love":true}')
+  t.deepEqual(schema, clonedSchema)
+})
+
+test('multiple $ref tree', t => {
+  t.plan(2)
+
+  const referenceDeepSchema = {
+    $id: 'deepId',
+    type: 'number'
+  }
+
+  const referenceSchema = {
+    $id: 'externalId',
+    type: 'object',
+    properties: {
+      name: { $ref: '#/definitions/foo' },
+      age: { $ref: 'deepId' }
+    },
+    definitions: {
+      foo: { type: 'string' }
+    }
+  }
+
+  const schema = {
+    $id: 'mainSchema',
+    type: 'object',
+    properties: {
+      people: {
+        oneOf: [{ $ref: 'externalId' }]
+      }
+    }
+  }
+  const clonedSchema = clone(schema)
+  const stringify = build(schema, {
+    schema: {
+      [referenceDeepSchema.$id]: referenceDeepSchema,
+      [referenceSchema.$id]: referenceSchema
+    }
+  })
+
+  const value = stringify({ people: { name: 'hello', foo: 'bar', age: 42 } })
+  t.is(value, '{"people":{"name":"hello","age":42}}')
+  t.deepEqual(schema, clonedSchema)
+})


### PR DESCRIPTION
Fixes #289 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
