### PR TITLE
Fix: Support for empty schemas in additionalProperties

### DIFF
--- a/index.js
+++ b/index.js
@@ -442,6 +442,11 @@ function addPatternProperties (location) {
           ${addComma}
           json += $asString(keys[i]) + ':' + $asBoolean(obj[keys[i]])
       `
+    } else if (type === undefined) {
+      code += `
+          ${addComma}
+          json += $asString(keys[i]) + ':' + $asAny(obj[keys[i]])
+      `
     } else {
       code += `
         throw new Error('Cannot coerce ' + obj[keys[i]] + ' to ' + ${JSON.stringify(type)})
@@ -534,6 +539,11 @@ function additionalProperty (location) {
     code += `
         ${addComma}
         json += $asString(keys[i]) + ':' + $asBoolean(obj[keys[i]])
+    `
+  } else if (type === undefined) {
+    code += `
+        ${addComma}
+        json += $asString(keys[i]) + ':' + $asAny(obj[keys[i]])
     `
   } else {
     code += `

--- a/test/additionalProperties.test.js
+++ b/test/additionalProperties.test.js
@@ -161,6 +161,31 @@ test('additionalProperties - array coerce', (t) => {
   t.equal('{"foo":["t","r","u","e"],"ofoo":[],"arrfoo":["1","2"],"objfoo":[]}', stringify(obj))
 })
 
+test('additionalProperties with empty schema', (t) => {
+  t.plan(1)
+  const stringify = build({
+    type: 'object',
+    additionalProperties: {}
+  })
+
+  const obj = { a: 1, b: true, c: null }
+  t.equal('{"a":1,"b":true,"c":null}', stringify(obj))
+})
+
+test('additionalProperties with nested empty schema', (t) => {
+  t.plan(1)
+  const stringify = build({
+    type: 'object',
+    properties: {
+      data: { type: 'object', additionalProperties: {} }
+    },
+    required: ['data']
+  })
+
+  const obj = { data: { a: 1, b: true, c: null } }
+  t.equal('{"data":{"a":1,"b":true,"c":null}}', stringify(obj))
+})
+
 test('nested additionalProperties', (t) => {
   t.plan(1)
   const stringify = build({


### PR DESCRIPTION
This PR should resolve issue https://github.com/fastify/fast-json-stringify/issues/293. It carries out additional `type === undefined` checks on the `additionalProperties: {}` code path resolving to `$asAny` in these cases. This enables support for empty `additionalProperties: {}` schemas.

#### Notes

The check on line 543 was all that was necessary to resolve this issue. The preceding check on line 445 was added as `$asAny` seemed appropriate (both code paths are virtually identical), however I've not implemented any specific tests for this code path as I'm not certain what conditions trigger it. Feel free to remove if necessary.

#### Benchmark
```
FJS creation x 55,526 ops/sec ±0.32% (95 runs sampled)
CJS creation x 157,538 ops/sec ±0.36% (92 runs sampled)
JSON.stringify array x 3,709 ops/sec ±0.22% (94 runs sampled)
fast-json-stringify array x 8,293 ops/sec ±0.32% (95 runs sampled)
compile-json-stringify array x 7,437 ops/sec ±0.98% (88 runs sampled)
JSON.stringify long string x 10,064 ops/sec ±0.09% (98 runs sampled)
fast-json-stringify long string x 10,056 ops/sec ±0.12% (98 runs sampled)
compile-json-stringify long string x 10,093 ops/sec ±0.08% (96 runs sampled)
JSON.stringify short string x 9,359,647 ops/sec ±0.30% (94 runs sampled)
fast-json-stringify short string x 52,095,769 ops/sec ±0.29% (97 runs sampled)
compile-json-stringify short string x 38,945,526 ops/sec ±0.22% (96 runs sampled)
JSON.stringify obj x 1,918,121 ops/sec ±0.15% (95 runs sampled)
fast-json-stringify obj x 8,553,618 ops/sec ±0.36% (93 runs sampled)
compile-json-stringify obj x 20,126,548 ops/sec ±1.39% (92 runs sampled)
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
