### PR TITLE
Moving "long" to dependency from dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "benchmark": "^2.1.4",
     "compile-json-stringify": "^0.1.2",
     "is-my-json-valid": "^2.20.0",
-    "long": "^4.0.0",
     "moment": "^2.24.0",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",
@@ -46,6 +45,7 @@
   "dependencies": {
     "ajv": "^6.11.0",
     "deepmerge": "^4.2.2",
+    "long": "^4.0.0",
     "rfdc": "^1.2.0",
     "string-similarity": "^4.0.1"
   },


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Description
package 'long' is present in dev dependency. But is used in https://github.com/fastify/fast-json-stringify/blob/master/index.js#L15 this causes error when package using `fast-json-stringify` is installed as dependency