### PR TITLE
fix: ajv is not defined when oneOf/allOf in external schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,7 @@ function build (schema, options) {
     case 'array':
       main = '$main'
       code = buildArray(location, code, main)
+      schema = location.schema
       break
     case undefined:
       main = '$asAny'
@@ -980,7 +981,8 @@ function buildArray (location, code, name, key = null) {
 
   if (schema.items.$ref) {
     if (!schema[fjsCloned]) {
-      schema = clone(location.schema)
+      location.schema = clone(location.schema)
+      schema = location.schema
       schema[fjsCloned] = true
     }
     location = refFinder(schema.items.$ref, location)


### PR DESCRIPTION
Regression of https://github.com/fastify/fast-json-stringify/pull/302

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
