### PR TITLE
Fastify issue 2990

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,7 +225,19 @@ function inferTypeByKeyword (schema) {
 
 function dependsOnAjv (schema) {
   const str = JSON.stringify(schema)
-  return (/"if":{.*"then":{|"(anyOf|oneOf)":\[|"const":/.test(str))
+  switch (true) {
+    case /"if":{.*"then":{/.test(str):
+    case /"(anyOf|oneOf)":\[/.test(str):
+    case /"const"/.test(str):
+    case /"\$ref"/.test(str):
+    {
+      return true
+    }
+
+    default: {
+      return false
+    }
+  }
 }
 
 const stringSerializerMap = {

--- a/test/requiresAjv.test.js
+++ b/test/requiresAjv.test.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const t = require('tap')
+const build = require('..')
+
+t.test('nested ref requires ajv', async t => {
+  const schemaA = {
+    $id: 'urn:schema:a',
+    definitions: {
+      foo: { anyOf: [{ type: 'string' }, { type: 'null' }] }
+    }
+  }
+
+  const schemaB = {
+    $id: 'urn:schema:b',
+    type: 'object',
+    properties: {
+      results: {
+        type: 'object',
+        properties: {
+          items: {
+            type: 'object',
+            properties: {
+              bar: {
+                type: 'array',
+                items: { $ref: 'urn:schema:a#/definitions/foo' }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const stringify = build(schemaB, {
+    schema: {
+      [schemaA.$id]: schemaA
+    }
+  })
+  const result = stringify({
+    results: {
+      items: {
+        bar: ['baz']
+      }
+    }
+  })
+  t.same(result, '{"results":{"items":{"bar":["baz"]}}}')
+})


### PR DESCRIPTION
This resolves https://github.com/fastify/fastify/issues/2990

I am _guessing_ that an AJV instance isn't passed to every validator as a memory optimization technique. Frankly, I think that's a bit extreme. I think it would be far simpler to rip out the `dependsOnAjv` check and simply:

```js
const dependencies = [new Ajv(options.ajv]
const dependenciesName = ['ajv']

dependenciesName.push(code)
```

But I didn't do that. Instead I added a new conditional check in the `dependsOnAjv` function. While I was at it, I split the regular expression up into its constituent parts. I had a really difficult time seeing the `|` operators in the expression, and it's clear this is just going to continue to grow.