### PR TITLE
added support to additionalItems property in array object

### DIFF
--- a/test/array.test.js
+++ b/test/array.test.js
@@ -210,6 +210,69 @@ buildTest({
   foo: [1, 'string', {}, null]
 })
 
+test('array items is a list of schema and additionalItems is true, just the described item is validated', (t) => {
+  t.plan(1)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'array',
+        items: [
+          {
+            type: 'string'
+          }
+        ],
+        additionalItems: true
+      }
+    }
+  }
+
+  const stringify = build(schema)
+  const result = stringify({
+    foo: [
+      'foo',
+      'bar',
+      1
+    ]
+  })
+
+  t.equal(result, '{"foo":["foo","bar",1]}')
+})
+
+test('array items is a list of schema and additionalItems is false', (t) => {
+  t.plan(1)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'array',
+        items: [
+          {
+            type: 'string'
+          }
+        ],
+        additionalItems: false
+      }
+    }
+  }
+
+  const stringify = build(schema)
+
+  try {
+    stringify({
+      foo: [
+        'foo',
+        'bar'
+      ]
+    })
+    t.fail()
+  } catch (error) {
+    t.ok(/does not match schema definition./.test(error.message))
+  }
+})
+
 // https://github.com/fastify/fast-json-stringify/issues/279
 test('object array with anyOf and symbol', (t) => {
   t.plan(1)


### PR DESCRIPTION
It is the first time I saw the code of this lib, I am amazed by the idea and its implementation. 

So many compliments!

---
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

---

The PR is intended to fix the issue https://github.com/fastify/fast-json-stringify/issues/321

Brief explanation: when the 'items' property of an array object is described as array itself, only the schemas defined are admitted. However, with the property 'additionalItems' defined in the array definition, it should accept more, without validating the type.
