### PR TITLE
handle enum property when type is not specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,8 +167,7 @@ const objectKeywords = [
   'properties',
   'patternProperties',
   'additionalProperties',
-  'dependencies',
-  'enum'
+  'dependencies'
 ]
 
 const arrayKeywords = [
@@ -1130,10 +1129,6 @@ function nested (laterCode, name, key, location, subKey, isArray) {
     const inferredType = inferTypeByKeyword(schema)
     if (inferredType) {
       schema.type = inferredType
-
-      if (inferredType === 'object' && schema.enum && !Object.hasOwnProperty.call(schema, 'additionalProperties')) {
-        schema.additionalProperties = true
-      }
     }
   }
 

--- a/test/enum.test.js
+++ b/test/enum.test.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const test = require('tap').test
+const build = require('..')
+
+test('use enum without type', (t) => {
+  t.plan(1)
+  const stringify = build({
+    title: 'Example Schema',
+    type: 'object',
+    properties: {
+      order: {
+        type: 'string',
+        enum: ['asc', 'desc']
+      }
+    }
+  })
+
+  const obj = { order: 'asc' }
+  t.equal('{"order":"asc"}', stringify(obj))
+})
+
+test('use enum without type', (t) => {
+  t.plan(1)
+  const stringify = build({
+    title: 'Example Schema',
+    type: 'object',
+    properties: {
+      order: {
+        enum: ['asc', 'desc']
+      }
+    }
+  })
+
+  const obj = { order: 'asc' }
+  t.equal('{"order":"asc"}', stringify(obj))
+})


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

@mcollina @Eomm 

As mentioned in https://github.com/fastify/fast-json-stringify/issues/274, I just revert the changes of https://github.com/fastify/fast-json-stringify/pull/254 and everything works, the test cases introduced in 254 and the case mentioned in the issue (I also added it in the enum.test.js).

Anyway, I don't know if I missed something, or better, why enum was introduced as object keywords.