### PR TITLE
Minor speed improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1247,39 +1247,46 @@ function nested (laterCode, name, key, location, subKey, isArray) {
         const nullIndex = type.indexOf('null')
         const sortedTypes = nullIndex !== -1 ? [type[nullIndex]].concat(type.slice(0, nullIndex)).concat(type.slice(nullIndex + 1)) : type
         sortedTypes.forEach((type, index) => {
+          const statement = index === 0 ? 'if' : 'else if'
           const tempSchema = Object.assign({}, schema, { type })
           const nestedResult = nested(laterCode, name, key, mergeLocation(location, { schema: tempSchema }), subKey, isArray)
-
-          if (type === 'string') {
-            code += `
-              ${index === 0 ? 'if' : 'else if'}(obj${accessor} === null || typeof obj${accessor} === "${type}" || obj${accessor} instanceof Date || typeof obj${accessor}.toISOString === "function" || obj${accessor} instanceof RegExp || (typeof obj${accessor} === "object" && Object.hasOwnProperty.call(obj${accessor}, "toString")))
-                ${nestedResult.code}
-            `
-          } else if (type === 'null') {
-            code += `
-              ${index === 0 ? 'if' : 'else if'}(obj${accessor} == null)
-              ${nestedResult.code}
-            `
-          } else if (type === 'array') {
-            code += `
-              ${index === 0 ? 'if' : 'else if'}(Array.isArray(obj${accessor}))
-              ${nestedResult.code}
-            `
-          } else if (type === 'integer') {
-            code += `
-              ${index === 0 ? 'if' : 'else if'}(Number.isInteger(obj${accessor}) || obj${accessor} === null)
-              ${nestedResult.code}
-            `
-          } else if (type === 'number') {
-            code += `
-              ${index === 0 ? 'if' : 'else if'}(isNaN(obj${accessor}) === false)
-              ${nestedResult.code}
-            `
-          } else {
-            code += `
-              ${index === 0 ? 'if' : 'else if'}(typeof obj${accessor} === "${type}")
-              ${nestedResult.code}
-            `
+          switch (type) {
+            case 'string':
+              code += `
+                ${statement}(obj${accessor} === null || typeof obj${accessor} === "${type}" || obj${accessor} instanceof Date || typeof obj${accessor}.toISOString === "function" || obj${accessor} instanceof RegExp || (typeof obj${accessor} === "object" && Object.hasOwnProperty.call(obj${accessor}, "toString")))
+                  ${nestedResult.code}
+              `
+              break
+            case 'null':
+              code += `
+                ${statement}(obj${accessor} == null)
+                  ${nestedResult.code}
+              `
+              break
+            case 'array':
+              code += `
+                ${statement}(Array.isArray(obj${accessor}))
+                  ${nestedResult.code}
+              `
+              break
+            case 'integer':
+              code += `
+                ${statement}(Number.isInteger(obj${accessor}) || obj${accessor} === null)
+                  ${nestedResult.code}
+              `
+              break
+            case 'number':
+              code += `
+                ${statement}(isNaN(obj${accessor}) === false)
+                  ${nestedResult.code}
+              `
+              break
+            default:
+              code += `
+                ${statement}(typeof obj${accessor} === "${type}")
+                  ${nestedResult.code}
+              `
+              break
           }
           laterCode = nestedResult.laterCode
         })

--- a/index.js
+++ b/index.js
@@ -20,8 +20,9 @@ try {
 const addComma = `
   if (addComma) {
     json += ','
+  } else {
+    addComma = true
   }
-  addComma = true
 `
 
 function isValidSchema (schema, name) {

--- a/index.js
+++ b/index.js
@@ -1252,42 +1252,48 @@ function nested (laterCode, name, key, location, subKey, isArray) {
           const tempSchema = Object.assign({}, schema, { type })
           const nestedResult = nested(laterCode, name, key, mergeLocation(location, { schema: tempSchema }), subKey, isArray)
           switch (type) {
-            case 'string':
+            case 'string': {
               code += `
                 ${statement}(obj${accessor} === null || typeof obj${accessor} === "${type}" || obj${accessor} instanceof Date || typeof obj${accessor}.toISOString === "function" || obj${accessor} instanceof RegExp || (typeof obj${accessor} === "object" && Object.hasOwnProperty.call(obj${accessor}, "toString")))
                   ${nestedResult.code}
               `
               break
-            case 'null':
+            }
+            case 'null': {
               code += `
                 ${statement}(obj${accessor} == null)
                   ${nestedResult.code}
               `
               break
-            case 'array':
+            }
+            case 'array': {
               code += `
                 ${statement}(Array.isArray(obj${accessor}))
                   ${nestedResult.code}
               `
               break
-            case 'integer':
+            }
+            case 'integer': {
               code += `
                 ${statement}(Number.isInteger(obj${accessor}) || obj${accessor} === null)
                   ${nestedResult.code}
               `
               break
-            case 'number':
+            }
+            case 'number': {
               code += `
                 ${statement}(isNaN(obj${accessor}) === false)
                   ${nestedResult.code}
               `
               break
-            default:
+            }
+            default: {
               code += `
                 ${statement}(typeof obj${accessor} === "${type}")
                   ${nestedResult.code}
               `
               break
+            }
           }
           laterCode = nestedResult.laterCode
         })


### PR DESCRIPTION
Moving the `if else if` chain to `switch` and adding an `else` statement in the `addComa` function seems to have a slightly improvement on the speed.

Before
```
FJS creation x 5,192 ops/sec ±1.50% (89 runs sampled)
CJS creation x 148,523 ops/sec ±1.81% (90 runs sampled)
JSON.stringify array x 3,917 ops/sec ±2.35% (91 runs sampled)
fast-json-stringify array x 7,702 ops/sec ±2.08% (88 runs sampled)
compile-json-stringify array x 6,930 ops/sec ±1.72% (87 runs sampled)
JSON.stringify long string x 12,647 ops/sec ±0.89% (90 runs sampled)
fast-json-stringify long string x 12,895 ops/sec ±0.18% (98 runs sampled)
compile-json-stringify long string x 12,874 ops/sec ±0.32% (97 runs sampled)
JSON.stringify short string x 10,725,098 ops/sec ±1.75% (93 runs sampled)
fast-json-stringify short string x 49,283,085 ops/sec ±1.04% (94 runs sampled)
compile-json-stringify short string x 37,667,861 ops/sec ±0.47% (94 runs sampled)
JSON.stringify obj x 2,246,372 ops/sec ±0.22% (92 runs sampled)
fast-json-stringify obj x 8,978,191 ops/sec ±0.70% (94 runs sampled)
compile-json-stringify obj x 18,693,845 ops/sec ±0.88% (92 runs sampled)

```
After
```
FJS creation x 5,390 ops/sec ±1.10% (88 runs sampled)
CJS creation x 165,814 ops/sec ±0.23% (95 runs sampled)
JSON.stringify array x 4,165 ops/sec ±0.32% (95 runs sampled)
fast-json-stringify array x 9,098 ops/sec ±0.26% (95 runs sampled)
compile-json-stringify array x 7,877 ops/sec ±0.29% (97 runs sampled)
JSON.stringify long string x 12,937 ops/sec ±0.12% (97 runs sampled)
fast-json-stringify long string x 12,869 ops/sec ±0.37% (94 runs sampled)
compile-json-stringify long string x 12,941 ops/sec ±0.08% (96 runs sampled)
JSON.stringify short string x 11,100,185 ops/sec ±0.13% (99 runs sampled)
fast-json-stringify short string x 49,561,549 ops/sec ±0.62% (95 runs sampled)
compile-json-stringify short string x 38,453,479 ops/sec ±0.61% (94 runs sampled)
JSON.stringify obj x 2,257,323 ops/sec ±0.17% (94 runs sampled)
fast-json-stringify obj x 9,705,539 ops/sec ±0.49% (91 runs sampled)
compile-json-stringify obj x 19,365,636 ops/sec ±0.44% (95 runs sampled)
```