### PR TITLE
Attempt to fix 333

### DIFF
--- a/index.js
+++ b/index.js
@@ -254,9 +254,8 @@ function $asInteger (i) {
   } else if (Number.isInteger(i)) {
     return $asNumber(i)
   } else {
-    // if the output is NaN the type is coerced to int 0
     /* eslint no-undef: "off" */
-    return $asNumber(parseInteger(i) || 0)
+    return $asNumber(parseInteger(i))
   }
 }
 

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -93,7 +93,7 @@ test('render a date in a string when format is time as kk:mm:ss', (t) => {
   validate(JSON.parse(output))
   t.equal(validate.errors, null)
 
-  t.equal(output, `"${moment(toStringify).format('kk:mm:ss')}"`)
+  t.equal(output, `"${moment(toStringify).format('HH:mm:ss')}"`)
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -76,7 +76,7 @@ test('verify padding for rendered date in a string when format is date', (t) => 
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render a date in a string when format is time as HH:mm:ss', (t) => {
+test('render a date in a string when format is time as kk:mm:ss', (t) => {
   t.plan(3)
 
   const schema = {
@@ -93,7 +93,7 @@ test('render a date in a string when format is time as HH:mm:ss', (t) => {
   validate(JSON.parse(output))
   t.equal(validate.errors, null)
 
-  t.equal(output, `"${moment(toStringify).format('HH:mm:ss')}"`)
+  t.equal(output, `"${moment(toStringify).format('kk:mm:ss')}"`)
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 

--- a/test/integer.test.js
+++ b/test/integer.test.js
@@ -6,6 +6,7 @@ const semver = require('semver')
 const validator = require('is-my-json-valid')
 const proxyquire = require('proxyquire')
 const build = proxyquire('..', { long: null })
+const ROUNDING_TYPES = ['ceil', 'floor', 'round']
 
 test('render an integer as JSON', (t) => {
   t.plan(2)
@@ -157,7 +158,7 @@ test('should round integer object parameter', t => {
 test('should not stringify a property if it does not exist', t => {
   t.plan(2)
 
-  const schema = { type: 'object', properties: { magic: { type: 'integer' } } }
+  const schema = { title: 'Example Schema', type: 'object', properties: { age: { type: 'integer' } } }
   const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({})
@@ -166,38 +167,16 @@ test('should not stringify a property if it does not exist', t => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('should not stringify a property if it does not exist (rounding: ceil)', t => {
-  t.plan(2)
+ROUNDING_TYPES.forEach((rounding) => {
+  test(`should not stringify a property if it does not exist (rounding: ${rounding})`, t => {
+    t.plan(2)
 
-  const schema = { type: 'object', properties: { magic: { type: 'integer' } } }
-  const validate = validator(schema)
-  const stringify = build(schema, { rounding: 'ceil' })
-  const output = stringify({})
+    const schema = { type: 'object', properties: { magic: { type: 'integer' } } }
+    const validate = validator(schema)
+    const stringify = build(schema, { rounding })
+    const output = stringify({})
 
-  t.equal(output, '{}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
-})
-
-test('should not stringify a property if it does not exist (rounding: floor)', t => {
-  t.plan(2)
-
-  const schema = { type: 'object', properties: { magic: { type: 'integer' } } }
-  const validate = validator(schema)
-  const stringify = build(schema, { rounding: 'floor' })
-  const output = stringify({})
-
-  t.equal(output, '{}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
-})
-
-test('should not stringify a property if it does not exist (rounding: round)', t => {
-  t.plan(2)
-
-  const schema = { type: 'object', properties: { magic: { type: 'integer' } } }
-  const validate = validator(schema)
-  const stringify = build(schema, { rounding: 'round' })
-  const output = stringify({})
-
-  t.equal(output, '{}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+    t.equal(output, '{}')
+    t.ok(validate(JSON.parse(output)), 'valid schema')
+  })
 })

--- a/test/integer.test.js
+++ b/test/integer.test.js
@@ -40,6 +40,10 @@ test('render a float as an integer', (t) => {
   const cases = [
     { input: Math.PI, output: '3' },
     { input: 5.0, output: '5' },
+    { input: null, output: '0' },
+    { input: 0, output: '0' },
+    { input: 0.0, output: '0' },
+    { input: 42, output: '42' },
     { input: 1.99999, output: '1' },
     { input: -45.05, output: '-45' },
     { input: 0.95, output: '1', rounding: 'ceil' },
@@ -138,7 +142,7 @@ if (semver.gt(process.versions.node, '10.3.0')) {
   t.end()
 }
 
-test('should round interger object parameter ', t => {
+test('should round integer object parameter', t => {
   t.plan(2)
 
   const schema = { type: 'object', properties: { magic: { type: 'integer' } } }
@@ -147,5 +151,17 @@ test('should round interger object parameter ', t => {
   const output = stringify({ magic: 4.2 })
 
   t.equal(output, '{"magic":5}')
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})
+
+test('should not stringify a property if it does not exist', t => {
+  t.plan(2)
+
+  const schema = { type: 'object', properties: { magic: { type: 'integer' } } }
+  const validate = validator(schema)
+  const stringify = build(schema)
+  const output = stringify({})
+
+  t.equal(output, '{}')
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })

--- a/test/integer.test.js
+++ b/test/integer.test.js
@@ -165,3 +165,39 @@ test('should not stringify a property if it does not exist', t => {
   t.equal(output, '{}')
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
+
+test('should not stringify a property if it does not exist (rounding: ceil)', t => {
+  t.plan(2)
+
+  const schema = { type: 'object', properties: { magic: { type: 'integer' } } }
+  const validate = validator(schema)
+  const stringify = build(schema, { rounding: 'ceil' })
+  const output = stringify({})
+
+  t.equal(output, '{}')
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})
+
+test('should not stringify a property if it does not exist (rounding: floor)', t => {
+  t.plan(2)
+
+  const schema = { type: 'object', properties: { magic: { type: 'integer' } } }
+  const validate = validator(schema)
+  const stringify = build(schema, { rounding: 'floor' })
+  const output = stringify({})
+
+  t.equal(output, '{}')
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})
+
+test('should not stringify a property if it does not exist (rounding: round)', t => {
+  t.plan(2)
+
+  const schema = { type: 'object', properties: { magic: { type: 'integer' } } }
+  const validate = validator(schema)
+  const stringify = build(schema, { rounding: 'round' })
+  const output = stringify({})
+
+  t.equal(output, '{}')
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Fixes #333 (I think?)

Hi, I tried to fix the problem in #333 by removing the default value introduced by @Eomm  [here](https://github.com/fastify/fast-json-stringify/pull/278/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R250).

I've added a few more tests and all _seems_ to be ok but I'm not sure this is the right approach as it's the first time I've taken a look at this library.

#332 calls `asInteger` instead of `Number` but `asInteger` has a fallback case that will inevitably convert a null value to 0. Removing that line fixes the issue and at the same time the tests in #332 (as a well as a few more added by me) also pass but again, I'm afraid some situations could be affected by this.