### PR TITLE
Fix minimizer renaming functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,21 +72,7 @@ function build (schema, options) {
   `
 
   code += `
-    ${$pad2Zeros.toString()}
-    ${$asAny.toString()}
-    ${$asString.toString()}
-    ${$asStringNullable.toString()}
-    ${$asStringSmall.toString()}
-    ${$asDatetime.toString()}
-    ${$asDate.toString()}
-    ${$asTime.toString()}
-    ${$asNumber.toString()}
-    ${$asNumberNullable.toString()}
-    ${$asInteger.toString()}
-    ${$asIntegerNullable.toString()}
-    ${$asNull.toString()}
-    ${$asBoolean.toString()}
-    ${$asBooleanNullable.toString()}
+    ${asFunctions}
 
     var isLong = ${isLong ? isLong.toString() : false}
 
@@ -116,19 +102,19 @@ function build (schema, options) {
       code = buildObject(location, code, main)
       break
     case 'string':
-      main = schema.nullable ? $asStringNullable.name : getStringSerializer(schema.format)
+      main = schema.nullable ? '$asStringNullable' : getStringSerializer(schema.format)
       break
     case 'integer':
-      main = schema.nullable ? $asIntegerNullable.name : $asInteger.name
+      main = schema.nullable ? '$asIntegerNullable' : '$asInteger'
       break
     case 'number':
-      main = schema.nullable ? $asNumberNullable.name : $asNumber.name
+      main = schema.nullable ? '$asNumberNullable' : '$asNumber'
       break
     case 'boolean':
-      main = schema.nullable ? $asBooleanNullable.name : $asBoolean.name
+      main = schema.nullable ? '$asBooleanNullable' : '$asBoolean'
       break
     case 'null':
-      main = $asNull.name
+      main = '$asNull'
       break
     case 'array':
       main = '$main'
@@ -233,6 +219,7 @@ function getTestSerializer (format) {
   return stringSerializerMap[format]
 }
 
+const asFunctions = `
 function $pad2Zeros (num) {
   const s = '00' + num
   return s[s.length - 2] + s[s.length - 1]
@@ -372,7 +359,7 @@ function $asStringSmall (str) {
       surrogateFound = true
     }
     if (point === 34 || point === 92) {
-      result += str.slice(last, i) + '\\'
+      result += str.slice(last, i) + '\\\\'
       last = i
       found = true
     }
@@ -385,6 +372,7 @@ function $asStringSmall (str) {
   }
   return ((point < 32) || (surrogateFound === true)) ? JSON.stringify(str) : '"' + result + '"'
 }
+`
 
 function addPatternProperties (location) {
   const schema = location.schema
@@ -928,7 +916,7 @@ function buildObject (location, code, name) {
   if (schema.nullable) {
     code += `
       if(input === null) {
-        return '${$asNull()}';
+        return 'null';
       }
   `
   }
@@ -967,7 +955,7 @@ function buildArray (location, code, name, key = null) {
   if (schema.nullable) {
     code += `
       if(obj === null) {
-        return '${$asNull()}';
+        return 'null';
       }
     `
   }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "semver": "^7.1.0",
     "standard": "^16.0.1",
     "tap": "^15.0.0",
-    "typescript": "^4.0.2"
+    "typescript": "^4.0.2",
+    "webpack": "^5.40.0"
   },
   "dependencies": {
     "ajv": "^6.11.0",

--- a/test/webpack.test.js
+++ b/test/webpack.test.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const test = require('tap').test
+const webpack = require('webpack')
+const path = require('path')
+
+test('the library should work with webpack', async (t) => {
+  t.plan(1)
+  const targetdir = path.resolve(__dirname, '..', '.cache')
+  const targetname = path.join(targetdir, 'webpacktest.js')
+  const wopts = {
+    entry: path.resolve(__dirname, '..', 'index.js'),
+    mode: 'production',
+    target: 'node',
+    output: {
+      path: targetdir,
+      filename: 'webpacktest.js',
+      library: {
+        name: 'fastJsonStringify',
+        type: 'umd'
+      }
+    }
+  }
+  await new Promise((resolve, reject) => {
+    webpack(wopts, (err, stats) => {
+      if (err) { reject(err) } else { resolve(stats) };
+    })
+  })
+  const build = require(targetname)
+  const stringify = build({
+    title: 'webpack should not rename code to be executed',
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'string'
+      },
+      bar: {
+        type: 'boolean'
+      }
+    },
+    patternProperties: {
+      foo: {
+        type: 'number'
+      }
+    }
+  })
+
+  const obj = { foo: '42', bar: true }
+  t.equal(stringify(obj), '{"foo":"42","bar":true}')
+})


### PR DESCRIPTION
When running the code through a minimizer (e g through Webpack/Terser),
the minimizer renames functions such as "$asBoolean". However, when the
function is called, it's hard coded as the string "$asBoolean", so the
generated code fails with "$asBoolean is not defined".

Make sure that the original $asBoolean function is included, and not
a renamed version of it, by making $asBoolean and friends string constants.

Fixes: https://github.com/fastify/fast-json-stringify/issues/338

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included

~~No new tests or benchmarks.~~ The one added test causes the time to run the tests to increase from 2 to 7 seconds.

Benchmarks seem to go up or down a few percent, probably within the margin of error.

- [x] documentation is changed or added

N/A

- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
