### PR TITLE
fix: unmatched type for value in oneOf should be ignored

### DIFF
--- a/index.js
+++ b/index.js
@@ -1023,9 +1023,11 @@ function buildArray (location, code, name, key = null) {
 
   code += `
     var l = obj.length
-    var w = l - 1
+
     for (var i = 0; i < l; i++) {
-      if (i > 0) {
+      var jsonLastChar = json.slice(-1)
+
+      if (i > 0 && jsonLastChar != '[' && jsonLastChar != ',') {
         json += ','
       }
       ${result.code}
@@ -1214,9 +1216,12 @@ function nested (laterCode, name, key, location, subKey, isArray) {
           `
           laterCode = nestedResult.laterCode
         })
-        code += `
-          else json+= null
-        `
+
+        if (!isArray) {
+          code += `
+            else json+= null
+          `
+        }
       } else if (isEmpty(schema)) {
         code += `
           json += JSON.stringify(obj${accessor})

--- a/index.js
+++ b/index.js
@@ -1025,9 +1025,9 @@ function buildArray (location, code, name, key = null) {
     var l = obj.length
 
     for (var i = 0; i < l; i++) {
-      var jsonLastChar = json.slice(-1)
+      var jsonLastChar = json[json.length - 1]
 
-      if (i > 0 && jsonLastChar != '[' && jsonLastChar != ',') {
+      if (i > 0 && jsonLastChar !== '[' && jsonLastChar !== ',') {
         json += ','
       }
       ${result.code}

--- a/test/oneof.test.js
+++ b/test/oneof.test.js
@@ -401,3 +401,105 @@ test('oneOf object with field of type string with format or null', (t) => {
     prop: toStringify
   }), `{"prop":"${toStringify.toISOString()}"}`)
 })
+
+test('one array item do not match oneOf types', (t) => {
+  t.plan(1)
+
+  const schema = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['data'],
+    properties: {
+      data: {
+        type: 'array',
+        minItems: 1,
+        items: {
+          oneOf: [
+            {
+              type: 'string'
+            },
+            {
+              type: 'number'
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  const stringify = build(schema)
+
+  const responseWithMappedType = stringify({
+    data: [false, 'foo']
+  })
+
+  t.equal('{"data":["foo"]}', responseWithMappedType)
+})
+
+test('some array items does not match oneOf types', (t) => {
+  t.plan(1)
+
+  const schema = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['data'],
+    properties: {
+      data: {
+        type: 'array',
+        minItems: 1,
+        items: {
+          oneOf: [
+            {
+              type: 'string'
+            },
+            {
+              type: 'number'
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  const stringify = build(schema)
+
+  const responseWithMappedTypes = stringify({
+    data: [false, 'foo', true, 5]
+  })
+
+  t.equal('{"data":["foo",5]}', responseWithMappedTypes)
+})
+
+test('all array items does not match oneOf types', (t) => {
+  t.plan(1)
+
+  const schema = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['data'],
+    properties: {
+      data: {
+        type: 'array',
+        minItems: 1,
+        items: {
+          oneOf: [
+            {
+              type: 'string'
+            },
+            {
+              type: 'number'
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  const stringify = build(schema)
+
+  const emptyResponse = stringify({
+    data: [null, false, true, undefined, [], {}]
+  })
+
+  t.equal('{"data":[]}', emptyResponse)
+})

--- a/test/oneof.test.js
+++ b/test/oneof.test.js
@@ -402,7 +402,7 @@ test('oneOf object with field of type string with format or null', (t) => {
   }), `{"prop":"${toStringify.toISOString()}"}`)
 })
 
-test('one array item do not match oneOf types', (t) => {
+test('one array item match oneOf types', (t) => {
   t.plan(1)
 
   const schema = {
@@ -436,7 +436,7 @@ test('one array item do not match oneOf types', (t) => {
   t.equal('{"data":["foo"]}', responseWithMappedType)
 })
 
-test('some array items does not match oneOf types', (t) => {
+test('some array items match oneOf types', (t) => {
   t.plan(1)
 
   const schema = {


### PR DESCRIPTION
#### Checklist
- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer’s Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Related issue: https://github.com/fastify/fast-json-stringify/issues/342