### PR TITLE
perf: speed up date formatting by 555x

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -50,22 +50,38 @@ const arraySchemaCJS = {
   items: schemaCJS
 }
 
+const dateFormatSchema = {
+  description: 'Date of birth',
+  type: 'string',
+  format: 'date'
+}
+
+const dateFormatSchemaCJS = {
+  description: 'Date of birth',
+  type: 'string',
+  format: 'date'
+}
+
 const obj = {
   firstName: 'Matteo',
   lastName: 'Collina',
   age: 32
 }
 
+const date = new Date()
+
 const multiArray = []
 
 const CJS = require('compile-json-stringify')
 const CJSStringify = CJS(schemaCJS)
 const CJSStringifyArray = CJS(arraySchemaCJS)
+const CJSStringifyDate = CJS(dateFormatSchemaCJS)
 const CJSStringifyString = CJS({ type: 'string' })
 
 const FJS = require('.')
 const stringify = FJS(schema)
 const stringifyArray = FJS(arraySchema)
+const stringifyDate = FJS(dateFormatSchema)
 const stringifyString = FJS({ type: 'string' })
 let str = ''
 
@@ -136,6 +152,18 @@ suite.add('fast-json-stringify obj', function () {
 
 suite.add('compile-json-stringify obj', function () {
   CJSStringify(obj)
+})
+
+suite.add('JSON stringify date', function () {
+  JSON.stringify(date)
+})
+
+suite.add('fast-json-stringify date format', function () {
+  stringifyDate(date)
+})
+
+suite.add('compile-json-stringify date format', function () {
+  CJSStringifyDate(date)
 })
 
 suite.on('cycle', cycle)

--- a/index.js
+++ b/index.js
@@ -285,10 +285,7 @@ function $asDatetime (date, skipQuotes) {
 function $asDate (date, skipQuotes) {
   const quotes = skipQuotes === true ? '' : '"'
   if (date instanceof Date) {
-    const year = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(date)
-    const month = new Intl.DateTimeFormat('en', { month: '2-digit' }).format(date)
-    const day = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(date)
-    return quotes + year + '-' + month + '-' + day + quotes
+    return quotes + new Date(date.getTime() - (date.getTimezoneOffset() * 60000 )).toISOString().slice(0, 10) + quotes
   } else if (date && typeof date.format === 'function') {
     return quotes + date.format('YYYY-MM-DD') + quotes
   } else {


### PR DESCRIPTION
The current version of date formatting is constructing a bunch of new objects using Intl and is comparetively slow. The simply `toISOString` and `splice` show a local speed up of up to 300x in terms of formatting and should yield the same results.

The date tests use momentjs formatting as comparison, which seems to respect time zones, thus, I also respected the time zones.

Before change
> fast-json-stringify date format x 2,900 ops/sec ±1.19% (82 runs sampled)

After change
> fast-json-stringify date format x 1,608,371 ops/sec ±1.30% (89 runs sampled)

**x 555 faster**

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
