### PR TITLE
chore: add benchmark setup

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,111 @@
+name: Benchmark
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  benchmark:
+    if: ${{ github.event.label.name == 'benchmark' }}
+    runs-on: ubuntu-latest
+    outputs:
+      PR-BENCH-12: ${{ steps.benchmark-pr.outputs.BENCH_RESULT12 }}
+      PR-BENCH-14: ${{ steps.benchmark-pr.outputs.BENCH_RESULT14 }}
+      PR-BENCH-16: ${{ steps.benchmark-pr.outputs.BENCH_RESULT16 }}
+      MAIN-BENCH-12: ${{ steps.benchmark-main.outputs.BENCH_RESULT12 }}
+      MAIN-BENCH-14: ${{ steps.benchmark-main.outputs.BENCH_RESULT14 }}
+      MAIN-BENCH-16: ${{ steps.benchmark-main.outputs.BENCH_RESULT16 }}
+    strategy:
+      matrix:
+        node-version: [12, 14, 16]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install
+        run: |
+          npm install --ignore-scripts
+
+      - name: Run benchmark
+        id: benchmark-pr
+        run: |
+          npm run --silent benchmark > ./bench-result
+          content=$(cat ./bench-result)
+          content="${content//'%'/'%25'}"
+          content="${content//$'\n'/'%0A'}"
+          content="${content//$'\r'/'%0D'}"
+          echo "::set-output name=BENCH_RESULT${{matrix.node-version}}::$content"
+
+      # main benchmark
+      - uses: actions/checkout@v2
+        with:
+          ref: 'master'
+
+      - name: Install
+        run: |
+          npm install --ignore-scripts
+
+      - name: Run benchmark
+        id: benchmark-master
+        run: |
+          npm run --silent benchmark > ./bench-result
+          content=$(cat ./bench-result)
+          content="${content//'%'/'%25'}"
+          content="${content//$'\n'/'%0A'}"
+          content="${content//$'\r'/'%0D'}"
+          echo "::set-output name=BENCH_RESULT${{matrix.node-version}}::$content"
+
+  output-benchmark:
+    needs: [benchmark]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          message: |
+            **Node**: 12
+            **PR**:
+            ```
+            ${{ needs.benchmark.outputs.PR-BENCH-12 }}
+            ```
+            **MAIN**:
+            ```
+            ${{ needs.benchmark.outputs.MAIN-BENCH-12 }}
+            ```
+            
+            ---
+            
+            **Node**: 14
+            **PR**:
+            ```
+            ${{ needs.benchmark.outputs.PR-BENCH-14 }}
+            ```
+            **MAIN**:
+            ```
+            ${{ needs.benchmark.outputs.MAIN-BENCH-14 }}
+            ```
+            
+            ---
+            
+            **Node**: 16
+            **PR**:
+            ```
+            ${{ needs.benchmark.outputs.PR-BENCH-16 }}
+            ```
+            **MAIN**:
+            ```
+            ${{ needs.benchmark.outputs.MAIN-BENCH-16 }}
+            ```
+            
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: |
+            benchmark
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I did the tests in my fork: https://github.com/RafaelGSS/fast-json-stringify/pull/3. 

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
