### PR TITLE
Fix: Prevent buildObject to create recursive call without base condition #378

### DIFF
--- a/index.js
+++ b/index.js
@@ -909,7 +909,7 @@ function buildObject (location, code, name) {
   `
   }
 
-  if (objectReferenceSerializersMap.has(schema)) {
+  if (objectReferenceSerializersMap.has(schema) && objectReferenceSerializersMap.get(schema) !== name) {
     code += `
       return ${objectReferenceSerializersMap.get(schema)}(input)
     }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/fastify/fast-json-stringify#readme",
   "devDependencies": {
+    "@sinclair/typebox": "^0.23.3",
     "benchmark": "^2.1.4",
     "compile-json-stringify": "^0.1.2",
     "is-my-json-valid": "^2.20.0",
@@ -43,7 +44,6 @@
     "webpack": "^5.40.0"
   },
   "dependencies": {
-    "@sinclair/typebox": "^0.23.3",
     "ajv": "^8.6.2",
     "ajv-formats": "^2.1.1",
     "deepmerge": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "webpack": "^5.40.0"
   },
   "dependencies": {
+    "@sinclair/typebox": "^0.23.3",
     "ajv": "^8.6.2",
     "ajv-formats": "^2.1.1",
     "deepmerge": "^4.2.2",

--- a/test/typebox.test.js
+++ b/test/typebox.test.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const test = require('tap').test
+const build = require('..')
+
+test('nested object in pattern properties for typebox', (t) => {
+  const { Type } = require('@sinclair/typebox')
+
+  t.plan(1)
+
+  const nestedSchema = Type.Object({
+    nestedKey1: Type.String()
+  })
+
+  const RootSchema = Type.Object({
+    key1: Type.Record(Type.String(), nestedSchema),
+    key2: Type.Record(Type.String(), nestedSchema)
+  })
+
+  const schema = RootSchema
+  const stringify = build(schema)
+
+  const value = stringify({
+    key1: {
+      nestedKey: {
+        nestedKey1: 'value1'
+      }
+    },
+    key2: {
+      nestedKey: {
+        nestedKey1: 'value2'
+      }
+    }
+  })
+  t.equal(value, '{"key1":{"nestedKey":{"nestedKey1":"value1"}},"key2":{"nestedKey":{"nestedKey1":"value2"}}}')
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This PR is exactly what https://github.com/fastify/fast-json-stringify/pull/378 does but without any unwanted linting /whitespace changes. 

@suyash-thakur, @mcollina 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
