### PR TITLE
feat: add support for better handling with large arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ const stringify = fastJson(mySchema, {
 - `schema`: external schemas references by $ref property. [More details](#ref)
 - `ajv`: [ajv v8 instance's settings](https://ajv.js.org/options.html) for those properties that require `ajv`. [More details](#anyof)
 - `rounding`: setup how the `integer` types will be rounded when not integers. [More details](#integer)
-- `largeArrayMechanism`: settle the mechanism that should be used to handle large (over `20000` items) arrays. [More details](#largearrays)
+- `largeArrayMechanism`: set the mechanism that should be used to handle large (`20000` or more items) arrays. [More details](#largearrays)
 
 
 <a name="api"></a>
@@ -597,16 +597,15 @@ to slow overall executions.
 In order to improve that the user can set the `largeArrayMechanism` option with
 one of the following values:
 
-- `default` - Default behavior
+- `default` - This option is a compromise between performance and feature set by
+still providing the expected functionality out of this lib but giving up some
+possible performance gain. With this option set, **large arrays** would be
+stringified by joining their stringified elements using `Array.join` instead of
+string concatenation for better performance
 - `json-stringify` - This option will remove support for schema validation
 within **large arrays** completely. By doing so the overhead previously
 mentioned is nulled, greatly improving execution time. Mind there's no change
 in behavior for arrays with less than `20000` items
-- `array-join` - This option is a compromise between the last two.
-`fastify-json-stringify` works by concatenating lots of string pieces into the
-final JSON string. With this option set, **large arrays** would be stringified
-by joining their elements' stringified versions using `Array.join`, instead
-of string concatenation
 
 ##### Benchmarks
 
@@ -620,7 +619,6 @@ mechanisms. Benchmarks conducted on an old machine.
 JSON.stringify large array x 157 ops/sec ±0.73% (86 runs sampled)
 fast-json-stringify large array default x 48.72 ops/sec ±4.92% (48 runs sampled)
 fast-json-stringify large array json-stringify x 157 ops/sec ±0.76% (86 runs sampled)
-fast-json-stringify large array array-join x 69.04 ops/sec ±4.47% (53 runs sampled)
 compile-json-stringify large array x 175 ops/sec ±4.47% (79 runs sampled)
 AJV Serialize large array x 58.76 ops/sec ±4.59% (60 runs sampled)
 ```

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ const stringify = fastJson(mySchema, {
 - `schema`: external schemas references by $ref property. [More details](#ref)
 - `ajv`: [ajv v8 instance's settings](https://ajv.js.org/options.html) for those properties that require `ajv`. [More details](#anyof)
 - `rounding`: setup how the `integer` types will be rounded when not integers. [More details](#integer)
-- `largeArrayMechanism`: set the mechanism that should be used to handle large (`20000` or more items) arrays. [More details](#largearrays)
+- `largeArrayMechanism`: set the mechanism that should be used to handle large
+(by default `20000` or more items) arrays. [More details](#largearrays)
 
 
 <a name="api"></a>
@@ -587,15 +588,20 @@ Otherwise, instead of raising an error, null values will be coerced as follows:
 <a name="largearrays"></a>
 #### Large Arrays
 
-Large arrays are, for the scope of this document, defined as arrays containing
-`20000` items or more.
+Large arrays are, for the scope of this document, defined as arrays containing,
+by default, `20000` elements or more. That value can be adjusted via the option
+parameter `largeArraySize`.
 
 At some point the overhead caused by the default mechanism used by
 `fast-json-stringify` to handle arrays starts increasing exponentially, leading
 to slow overall executions.
 
-In order to improve that the user can set the `largeArrayMechanism` option with
-one of the following values:
+##### Settings
+
+In order to improve that the user can set the `largeArrayMechanism` and
+`largeArraySize` options.
+
+`largeArrayMechanism`'s default value is `default`. Valid values for it are:
 
 - `default` - This option is a compromise between performance and feature set by
 still providing the expected functionality out of this lib but giving up some
@@ -605,7 +611,16 @@ string concatenation for better performance
 - `json-stringify` - This option will remove support for schema validation
 within **large arrays** completely. By doing so the overhead previously
 mentioned is nulled, greatly improving execution time. Mind there's no change
-in behavior for arrays with less than `20000` items
+in behavior for arrays not considered _large_
+
+`largeArraySize`'s default value is `20000`. Valid values for it are
+integer-like values, such as:
+
+- `20000`
+- `2e4`
+- `'20000'`
+- `'2e4'` - _note this will be converted to `2`, not `20000`_
+- `1.5` - _note this will be converted to `1`_
 
 ##### Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ of string concatenation
 For reference, here goes some benchmarks for comparison over the three
 mechanisms. Benchmarks conducted on an old machine.
 
-- Machine: `ST1000LM024 HN-M 1TB HDD, Intel Core i7-3610QM @ 2.3Ghz, 12GB RAM, 4C/8T`.
+- Machine: `ST1000LM024 HN-M 1TB HDD, Intel Core i7-3610QM @ 2.3GHz, 12GB RAM, 4C/8T`.
 - Node.js `v16.13.1`
 
 ```

--- a/bench.js
+++ b/bench.js
@@ -108,9 +108,6 @@ const stringifyArrayDefault = FJS(arraySchema)
 const stringifyArrayJSONStringify = FJS(arraySchema, {
   largeArrayMechanism: 'json-stringify'
 })
-const stringifyArrayArrayJoin = FJS(arraySchema, {
-  largeArrayMechanism: 'array-join'
-})
 const stringifyDate = FJS(dateFormatSchema)
 const stringifyString = FJS({ type: 'string' })
 let str = ''
@@ -187,10 +184,6 @@ suite.add('fast-json-stringify array json-stringify', function () {
   stringifyArrayJSONStringify(multiArray)
 })
 
-suite.add('fast-json-stringify array array-join', function () {
-  stringifyArrayArrayJoin(multiArray)
-})
-
 suite.add('compile-json-stringify array', function () {
   CJSStringifyArray(multiArray)
 })
@@ -209,10 +202,6 @@ suite.add('fast-json-stringify large array default', function () {
 
 suite.add('fast-json-stringify large array json-stringify', function () {
   stringifyArrayJSONStringify(largeArray)
-})
-
-suite.add('fast-json-stringify large array array-join', function () {
-  stringifyArrayArrayJoin(largeArray)
 })
 
 suite.add('compile-json-stringify large array', function () {

--- a/bench.js
+++ b/bench.js
@@ -3,6 +3,10 @@
 const benchmark = require('benchmark')
 const suite = new benchmark.Suite()
 
+const STR_LEN = 1e4
+const LARGE_ARRAY_SIZE = 2e4
+const MULTI_ARRAY_LENGHT = 1e3
+
 const schema = {
   title: 'Example Schema',
   type: 'object',
@@ -89,7 +93,8 @@ const obj = {
 
 const date = new Date()
 
-const multiArray = []
+const multiArray = new Array(MULTI_ARRAY_LENGHT)
+const largeArray = new Array(LARGE_ARRAY_SIZE)
 
 const CJS = require('compile-json-stringify')
 const CJSStringify = CJS(schemaCJS)
@@ -99,7 +104,13 @@ const CJSStringifyString = CJS({ type: 'string' })
 
 const FJS = require('.')
 const stringify = FJS(schema)
-const stringifyArray = FJS(arraySchema)
+const stringifyArrayDefault = FJS(arraySchema)
+const stringifyArrayJSONStringify = FJS(arraySchema, {
+  largeArrayMechanism: 'json-stringify'
+})
+const stringifyArrayArrayJoin = FJS(arraySchema, {
+  largeArrayMechanism: 'array-join'
+})
 const stringifyDate = FJS(dateFormatSchema)
 const stringifyString = FJS({ type: 'string' })
 let str = ''
@@ -110,18 +121,48 @@ const ajvSerialize = ajv.compileSerializer(schemaAJVJTD)
 const ajvSerializeArray = ajv.compileSerializer(arraySchemaAJVJTD)
 const ajvSerializeString = ajv.compileSerializer({ type: 'string' })
 
+const getRandomString = (length) => {
+  if (!Number.isInteger(length)) {
+    throw new Error('Expected integer length')
+  }
+
+  const validCharacters = 'abcdefghijklmnopqrstuvwxyz'
+  const nValidCharacters = 26
+
+  let result = ''
+  for (let i = 0; i < length; ++i) {
+    result += validCharacters[Math.floor(Math.random() * nValidCharacters)]
+  }
+
+  return result[0].toUpperCase() + result.slice(1)
+}
+
 // eslint-disable-next-line
-for (var i = 0; i < 10000; i++) {
+for (let i = 0; i < STR_LEN; i++) {
+  largeArray[i] = {
+    firstName: getRandomString(8),
+    lastName: getRandomString(6),
+    age: Math.ceil(Math.random() * 99)
+  }
+
   str += i
   if (i % 100 === 0) {
     str += '"'
   }
 }
 
+for (let i = STR_LEN; i < LARGE_ARRAY_SIZE; ++i) {
+  largeArray[i] = {
+    firstName: getRandomString(10),
+    lastName: getRandomString(4),
+    age: Math.ceil(Math.random() * 99)
+  }
+}
+
 Number(str)
 
-for (i = 0; i < 1000; i++) {
-  multiArray.push(obj)
+for (let i = 0; i < MULTI_ARRAY_LENGHT; i++) {
+  multiArray[i] = obj
 }
 
 suite.add('FJS creation', function () {
@@ -138,8 +179,16 @@ suite.add('JSON.stringify array', function () {
   JSON.stringify(multiArray)
 })
 
-suite.add('fast-json-stringify array', function () {
-  stringifyArray(multiArray)
+suite.add('fast-json-stringify array default', function () {
+  stringifyArrayDefault(multiArray)
+})
+
+suite.add('fast-json-stringify array json-stringify', function () {
+  stringifyArrayJSONStringify(multiArray)
+})
+
+suite.add('fast-json-stringify array array-join', function () {
+  stringifyArrayArrayJoin(multiArray)
 })
 
 suite.add('compile-json-stringify array', function () {
@@ -148,6 +197,30 @@ suite.add('compile-json-stringify array', function () {
 
 suite.add('AJV Serialize array', function () {
   ajvSerializeArray(multiArray)
+})
+
+suite.add('JSON.stringify large array', function () {
+  JSON.stringify(largeArray)
+})
+
+suite.add('fast-json-stringify large array default', function () {
+  stringifyArrayDefault(largeArray)
+})
+
+suite.add('fast-json-stringify large array json-stringify', function () {
+  stringifyArrayJSONStringify(largeArray)
+})
+
+suite.add('fast-json-stringify large array array-join', function () {
+  stringifyArrayArrayJoin(largeArray)
+})
+
+suite.add('compile-json-stringify large array', function () {
+  CJSStringifyArray(largeArray)
+})
+
+suite.add('AJV Serialize large array', function () {
+  ajvSerializeArray(largeArray)
 })
 
 suite.add('JSON.stringify long string', function () {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,14 @@ const fjsCloned = Symbol('fast-json-stringify.cloned')
 const { randomUUID } = require('crypto')
 
 const validate = require('./schema-validator')
+
 let stringSimilarity = null
+let largeArrayMechanism = 'default'
+const validLargeArrayMechanisms = [
+  'default',
+  'json-stringify',
+  'array-join'
+]
 
 const addComma = `
   if (addComma) {
@@ -70,6 +77,14 @@ function build (schema, options) {
       intParseFunctionName = options.rounding
     } else {
       throw new Error(`Unsupported integer rounding method ${options.rounding}`)
+    }
+  }
+
+  if (options.largeArrayMechanism) {
+    if (validLargeArrayMechanisms.includes(options.largeArrayMechanism)) {
+      largeArrayMechanism = options.largeArrayMechanism
+    } else {
+      throw new Error(`Unsupported large array mechanism ${options.rounding}`)
     }
   }
 
@@ -1028,7 +1043,9 @@ function buildArray (location, code, name, key = null) {
   }
 
   code += `
-    var l = obj.length
+    var l = obj.length`
+
+  const concatSnippet = `
     var jsonOutput= ''
     for (var i = 0; i < l; i++) {
       var json = ''
@@ -1040,7 +1057,32 @@ function buildArray (location, code, name, key = null) {
       }
     }
     return \`[\${jsonOutput}]\`
+  }`
+
+  switch (largeArrayMechanism) {
+    case 'default':
+      break
+
+    case 'json-stringify':
+      code += `
+      if (l && l >= 20000) {
+        return JSON.stringify(obj)
+      }`
+      break
+
+    case 'array-join':
+      code += `
+      if (l && l >= 20000) {
+        return \`[\${obj.map(${result.mapFnName}).join(',')}]\`
+      }`
+      break
+
+    default:
+      throw new Error(`Unsupported large array mechanism ${largeArrayMechanism}`)
   }
+
+  code += `
+  ${concatSnippet}
   ${result.laterCode}
   `
 
@@ -1148,22 +1190,27 @@ function nested (laterCode, name, key, location, subKey, isArray) {
 
   switch (type) {
     case 'null':
+      funcName = '$asNull'
       code += `
         json += $asNull()
       `
       break
     case 'string': {
+      funcName = '$asString'
       const stringSerializer = getStringSerializer(schema.format)
       code += nullable ? `json += obj${accessor} === null ? null : ${stringSerializer}(obj${accessor})` : `json += ${stringSerializer}(obj${accessor})`
       break
     }
     case 'integer':
+      funcName = '$asInteger'
       code += nullable ? `json += obj${accessor} === null ? null : $asInteger(obj${accessor})` : `json += $asInteger(obj${accessor})`
       break
     case 'number':
+      funcName = '$asNumber'
       code += nullable ? `json += obj${accessor} === null ? null : $asNumber(obj${accessor})` : `json += $asNumber(obj${accessor})`
       break
     case 'boolean':
+      funcName = '$asBoolean'
       code += nullable ? `json += obj${accessor} === null ? null : $asBoolean(obj${accessor})` : `json += $asBoolean(obj${accessor})`
       break
     case 'object':
@@ -1181,6 +1228,7 @@ function nested (laterCode, name, key, location, subKey, isArray) {
       `
       break
     case undefined:
+      funcName = '$asNull'
       if ('anyOf' in schema) {
         // beware: dereferenceOfRefs has side effects and changes schema.anyOf
         const anyOfLocations = dereferenceOfRefs(location, 'anyOf')
@@ -1319,7 +1367,8 @@ function nested (laterCode, name, key, location, subKey, isArray) {
 
   return {
     code,
-    laterCode
+    laterCode,
+    mapFnName: funcName
   }
 }
 
@@ -1334,6 +1383,8 @@ function isEmpty (schema) {
 }
 
 module.exports = build
+
+module.exports.validLargeArrayMechanisms = validLargeArrayMechanisms
 
 module.exports.restore = function ({ code, ajv }) {
   // eslint-disable-next-line

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const { randomUUID } = require('crypto')
 
 const validate = require('./schema-validator')
 
+let largeArraySize = 2e4
 let stringSimilarity = null
 let largeArrayMechanism = 'default'
 const validLargeArrayMechanisms = [
@@ -84,6 +85,14 @@ function build (schema, options) {
       largeArrayMechanism = options.largeArrayMechanism
     } else {
       throw new Error(`Unsupported large array mechanism ${options.rounding}`)
+    }
+  }
+
+  if (options.largeArraySize) {
+    if (!Number.isNaN(Number.parseInt(options.largeArraySize, 10))) {
+      largeArraySize = options.largeArraySize
+    } else {
+      throw new Error(`Unsupported large array size. Expected integer-like, got ${options.largeArraySize}`)
     }
   }
 
@@ -1043,7 +1052,7 @@ function buildArray (location, code, name, key = null) {
 
   code += `
     var l = obj.length
-    if (l && l >= 20000) {`
+    if (l && l >= ${largeArraySize}) {`
 
   const concatSnippet = `
     }

--- a/index.js
+++ b/index.js
@@ -16,8 +16,7 @@ let stringSimilarity = null
 let largeArrayMechanism = 'default'
 const validLargeArrayMechanisms = [
   'default',
-  'json-stringify',
-  'array-join'
+  'json-stringify'
 ]
 
 const addComma = `
@@ -1043,9 +1042,12 @@ function buildArray (location, code, name, key = null) {
   }
 
   code += `
-    var l = obj.length`
+    var l = obj.length
+    if (l && l >= 20000) {`
 
   const concatSnippet = `
+    }
+
     var jsonOutput= ''
     for (var i = 0; i < l; i++) {
       var json = ''
@@ -1061,20 +1063,13 @@ function buildArray (location, code, name, key = null) {
 
   switch (largeArrayMechanism) {
     case 'default':
+      code += `
+      return \`[\${obj.map(${result.mapFnName}).join(',')}]\``
       break
 
     case 'json-stringify':
       code += `
-      if (l && l >= 20000) {
-        return JSON.stringify(obj)
-      }`
-      break
-
-    case 'array-join':
-      code += `
-      if (l && l >= 20000) {
-        return \`[\${obj.map(${result.mapFnName}).join(',')}]\`
-      }`
+      return JSON.stringify(obj)`
       break
 
     default:

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -5,12 +5,12 @@ const test = require('tap').test
 const validator = require('is-my-json-valid')
 const build = require('..')
 
-function buildTest (schema, toStringify) {
+function buildTest (schema, toStringify, options) {
   test(`render a ${schema.title} as JSON`, (t) => {
     t.plan(3)
 
     const validate = validator(schema)
-    const stringify = build(schema)
+    const stringify = build(schema, options)
     const output = stringify(toStringify)
 
     t.same(JSON.parse(output), toStringify)
@@ -318,4 +318,47 @@ test('object array with anyOf and symbol', (t) => {
     { name: 'name-1', option: 'Bar' }
   ])
   t.equal(value, '[{"name":"name-0","option":"Foo"},{"name":"name-1","option":"Bar"}]')
+})
+
+const largeArray = new Array(2e4).fill({ a: 'test', b: 1 })
+buildTest({
+  title: 'large array with default mechanism',
+  type: 'object',
+  properties: {
+    ids: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          a: { type: 'string' },
+          b: { type: 'number' }
+        }
+      }
+    }
+  }
+}, {
+  ids: largeArray
+}, {
+  largeArrayMechanism: 'default'
+})
+
+buildTest({
+  title: 'large array with json-stringify mechanism',
+  type: 'object',
+  properties: {
+    ids: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          a: { type: 'string' },
+          b: { type: 'number' }
+        }
+      }
+    }
+  }
+}, {
+  ids: largeArray
+}, {
+  largeArrayMechanism: 'json-stringify'
 })

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -339,6 +339,7 @@ buildTest({
 }, {
   ids: largeArray
 }, {
+  largeArraySize: 2e4,
   largeArrayMechanism: 'default'
 })
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

# Intro

This PR is a tentative approach at improving the behavior described in https://github.com/fastify/fastify/issues/3498. In short, for very large arrays (approx over 20k elements) the overhead introduced by `fast-json-stringify` becomes relevant and makes the stringifying process longer.

Closes https://github.com/fastify/fastify/issues/3498.

# Analysis

Some simple benchmarks were run both in order to better understand the issue and to understand the impact of the various approaches attempted at improving it.

## Methodology

A variable-length array with [similar spec as to the large one available in the linked issue](https://gist.github.com/wilkmaia/85f1e77316a00418abf6703c5ac664aa) was stringified using two approaches:

- `JSON.stringify` as baseline
- `fast-json-stringify`

Data on array length and time taken for the process to complete was collected and plotted over several different graphs, displayed below. `JSON.stringify`'s time to complete is plotted in orange and `fast-json-stringify`'s in blue. Time is displayed in _nanoseconds_. Data for each array length was averaged over 30 different measurements.

The benchmark script used (as well as helpers and dependencies) is available at https://gist.github.com/wilkmaia/c2a43a145fcd0f9dda06710933c26850.

## Results

### Baseline Data

![data1](https://user-images.githubusercontent.com/1902272/162017655-f34d3d9f-487d-476b-9392-bde01bba8473.svg)

Baseline data was initially collected for future comparison. It's shown that the time the two functions take to work over the data starts to get significantly discrepant with arrays of length somewhere between 16k and 32k.

### Closer Look

![data2](https://user-images.githubusercontent.com/1902272/162017783-9ca0384e-b938-427d-b5b9-68a06cec05e5.svg)

Looking at data over a smaller interval (length of `5000` to `32000`) one can see that the discrepancy starts getting more significant for arrays with about 20k items or more. In the following sections we'll consider **large array** an array with `20000` or more elements.

### Approach 1

`Array.join` instead of string concatenation for large arrays.

![data3](https://user-images.githubusercontent.com/1902272/162018429-c594b45f-c7b1-4ce1-9ece-bff20efbd4f5.svg)

This approach compromises performance to maintain high utility. Performance gain for the largest array tested was of about `33%` and there's no loss in the lib's feature set. The performance gain comes from the fact that, for large arrays, currently, `Array.join` performs better than concatenating strings in v8 [1]. Browser performance apparently has been varying over the last years.

### Approach 2 
`Array.join` instead of string concatenation for all arrays.

![data7](https://user-images.githubusercontent.com/1902272/162025802-8709b87a-5b92-45d7-8eee-f6804afc8204.svg)

This was the worst approach of all, performance-wise. With it the worst case scenario ran only about `13%` faster. That was, though, expected, given performance for `Array.join` is significantly worse for smaller arrays. There's no point in following this approach, given it gives no benefit over (Approach 1)[approach-1].

### Approach 3 

`JSON.stringify` all arrays.

![data5](https://user-images.githubusercontent.com/1902272/162024297-59b936cf-3a8f-4aa2-b919-959c2f7e5d0c.svg)

This approach focuses on maximizing performance to the detriment of utility. With that the lib loses spec validation for arrays and its elements but the stringify process completes quickly. Performance gain was about `77%` for the worst case scenario, resulting in overall performance extremely similar to `JSON.stringify` for large arrays and quicker for small ones.

### Approach 4 

`JSON.stringify` for large arrays.

![data6](https://user-images.githubusercontent.com/1902272/162025226-f596ecb9-ce38-4a13-8cae-26a3626a91b2.svg)

This approach compromises a bit of the performance gained from [Approach 3](approach-3) in order to provide more utility to the lib's users. Only large arrays are submitted to `JSON.stringify`. All others would still benefit from spec validation. Performance gain for this approach was of about `76%` for the worst case scenario.

## Conclusion

![data](https://user-images.githubusercontent.com/1902272/162029906-a3bfbc7e-49ba-4271-a77c-e569805d0b22.svg)

In the image above there's a compiled summary of the baselines plus the `fast-json-stringify`'s updated approaches results, disregarding the smallest datasets (less than `2048` elements).

Judging by that I believe the best solution would be to either implement [Approach 1](approach-1) or [Approach 4](approach-4) or, the proposed solution in this PR, to add support for the user to select whether they want the original implementation or one of the two proposed variants.

## References

[1]: [Simple benchmark for string concatenation vs `Array.join`](https://perf.link/#eyJpZCI6Ijl2MHFqcXp0bzFwIiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IFNNQUxMX0FSUkFZX1NJWkUgPSA1MFxuY29uc3QgTEFSR0VfQVJSQVlfU0laRSA9IDIwMDAwXG5cbmNvbnN0IHNtYWxsID0gbmV3IEFycmF5KFNNQUxMX0FSUkFZX1NJWkUpXG5jb25zdCBsYXJnZSA9IG5ldyBBcnJheShMQVJHRV9BUlJBWV9TSVpFKVxuXG5mb3IgKGxldCBpID0gMDsgaSA8IFNNQUxMX0FSUkFZX1NJWkU7ICsraSkge1xuXHRjb25zdCBuID0gTWF0aC5yYW5kb20oKVxuXHRzbWFsbFtpXSA9IG5cblx0bGFyZ2VbaV0gPSBuXG59XG5cbmZvciAobGV0IGkgPSBTTUFMTF9BUlJBWV9TSVpFOyBpIDwgTEFSR0VfQVJSQVlfU0laRTsgKytpKSB7XG5cdGxhcmdlW2ldID0gTWF0aC5yYW5kb20oKVxufSIsInRlc3RzIjpbeyJuYW1lIjoiU21hbGwgYXJyYXkgY29uY2F0IiwiY29kZSI6ImxldCByZXNDID0gJycgKyBzbWFsbFswXTtcbmZvciAobGV0IGkgPSAxOyBpIDwgU01BTExfQVJSQVlfU0laRTsgKytpKSB7XG5cdHJlc0MgKz0gJywnICsgc21hbGxbaV07XG59IiwicnVucyI6Wzc5MTc5Miw4MTcwNTYsNzY1NzM1LDc2OTY3OSw3MzA0NzEsODA2MTUwLDc5MjM5Niw3OTMyMjYsODE4MDAwLDc5MjMwMSw3NzE3MTYsODEyNjYwLDc4MjE1MCw2MDA1ODQsODY0NzU0LDgyOTQ1Miw4MjE2NjAsNTY3NTY2LDgwMTMwMSw4MTg0NTIsODQ3MjY0LDgzNzExMyw4NjcxODgsODY5OTA1LDgyNTcxNiw4MDY4NDksODE3MTg4LDc5MTgzMCw4MTE2OTgsNzgwNzkyLDU5MTAxOCw4NjIzMDEsNzkwNDkwLDc3MDk0Myw3OTk0OTAsODI3MjQ1LDgxNzE4OCw4NDU4MTEsODE5Njc5LDgzMDQzMyw4NTgzMDEsNzc4OTI0LDczNzgxMSw4MTI3OTIsODE0MzU4LDc4Mjk0Myw4MDg0MTUsODAwNzM1LDgxODYwMyw4MzYwNzUsNzYzMDAwLDgwMTgxMSw4NDQzMzksODMzOTA1LDc5ODc1NCw3ODQ3NTQsODA5OTYyLDc2NDMwMSw4NzExODgsNjA1NjAzLDgzNTUyOCw3ODM0OTAsNzQ5OTYyLDgwMjUwOSw3ODEzNzcsNzg1NTA5LDc3ODM3Nyw3OTE4ODYsNzM0ODY3LDgxMDUyOCw3NTYzNzcsNzg0MjA3LDg0NTkwNSw4NDYzNzcsODIwMDAwLDg2NDQ1Miw4MTg0NTIsODA3NTQ3LDc2MDE4OCw4MTg3NzMsODE2ODg2LDU4MTIwNyw4MjE3OTIsODE1NTY2LDc5NTM3Nyw4MTk4MzAsODE0MzU4LDczMjAxOCw4NTU4NDksNTkxMjQ1LDgzODMyMCw4NDc0OTAsODI3Mzk2LDc5OTU0Nyw4MDIyNDUsNzYzNDkwLDgxNDI0NSw3OTM0MTUsODU2NjIyLDc0MTU2Nl0sIm9wcyI6NzkzODg1fSx7Im5hbWUiOiJTbWFsbCBhcnJheSBqb2luIiwiY29kZSI6ImNvbnN0IHJlc0ogPSBzbWFsbC5qb2luKCcsJykiLCJydW5zIjpbNDc1ODY3LDUzNzg0OSw1MTcwNTYsNDc1Njk4LDUyNjU4NCw1MzMzNzcsNTE5NTQ3LDQyNDI4Myw0ODIzMjAsNTA2MTg4LDQ3ODgzMCw0NzQxNTAsNDMwNzU0LDUyNTY0MSw1MjY0OTAsNTQyOTgxLDUyNzUwOSw1MjY4MTEsNTAwMDE4LDUxMDAwMCw1MzIwNzUsNTMwOTYyLDU0MTkyNCw1MTY4MTEsNTA3NDMzLDUyMDczNSw0MTI1ODQsNDg5MDM3LDU0OTE2OSw1MTkyMDcsNTM0ODMwLDUyNDc1NCw1NDAwMDAsNTE1NTY2LDUxMTA3NSw0OTczMDEsNDY2MDE4LDQ3NjM3Nyw1MjE5ODEsNDk1NzczLDUwMTg4Niw1MzA2OTgsNTI2OTYyLDQzNzMyMCw0OTcxNjksNDQwMzc3LDUwNjUyOCw0ODkzMjAsNDcwMjQ1LDUxOTMyMCw0NDMxMzIsNTQwMjY0LDQ4OTIwNyw1MTkyNjQsNTAwNDcxLDU0NDk0Myw1MzAxNjksNTE1NTI4LDQ5NTU0Nyw1MjMxMTMsNTEwMzU4LDQzMDAzNyw1MjA4NjcsNDg1OTI0LDUyMDY5OCw0ODE4ODYsNTA1MTg4LDUzODIyNiw1NDc0MTUsNDI2Njc5LDUzODY2MCw1MDczNTgsNTQzNTQ3LDUwNTIyNiw1MzkyODMsNTEyNDE1LDUxNjkyNCw1MTM5ODEsNTE1OTYyLDUxMjU4NCw1MTk4NjcsNTA5NzM1LDQ3NjMzOSw0NTE2NzksNTE4NDkwLDUwNTQ1Miw1MzYxODgsNDY5NDkwLDQ5MjczNSw1MDc5MjQsNTE4MjgzLDUxNjAxOCw1MjM5ODEsNTE3MDAwLDU1MTAwMCw1Mjg4MzAsNTM4MDc1LDU0OTA3NSw1MDE5MDUsNTEyMDU2XSwib3BzIjo1MDY4NDN9LHsibmFtZSI6IkxhcmdlIGFycmF5IGNvbmNhdCIsImNvZGUiOiJsZXQgcmVzQyA9ICcnICsgbGFyZ2VbMF1cbmZvciAobGV0IGkgPSAxOyBpIDwgTEFSR0VfQVJSQVlfU0laRTsgKytpKSB7XG5cdHJlc0MgKz0gJywnICsgbGFyZ2VbaV1cbn0iLCJydW5zIjpbMTg4LDE4OCwxODgsMTg4LDE2OSwxODgsMTY5LDE2OSwxODgsMTg4LDE2OSwxNjksMTg4LDE4OCwxODgsMTg4LDE4OCwxODgsMTg4LDE4OCwxODgsMTg4LDE4OCwxODgsMTg4LDE2OSwxODgsMTg4LDE4OCwxODgsMTg4LDE4OCwxODgsMTg4LDE2OSwxODgsMTg4LDE4OCwxODgsMjA3LDE4OCwxODgsMTg4LDE2OSwxODgsMTg4LDE2OSwxNjksMTg4LDE4OCwxODgsMTg4LDE2OSwxODgsMTg4LDE2OSwxODgsMTg4LDE4OCwxODgsMTg4LDE2OSwxODgsMTg4LDE2OSwxODgsMTg4LDE4OCwxODgsMTg4LDE2OSwxODgsMTg4LDE2OSwxODgsMTg4LDE4OCwxODgsMTg4LDE4OCwxODgsMTg4LDE4OCwxNjksMTg4LDE2OSwxNjksMTg4LDE4OCwxODgsMTg4LDE4OCwxODgsMTg4LDE2OSwxODgsMTg4LDE4OCwxNjksMTg4XSwib3BzIjoxODR9LHsibmFtZSI6IkxhcmdlIGFycmF5IGpvaW4iLCJjb2RlIjoiY29uc3QgcmVzSiA9IGxhcmdlLmpvaW4oJywnKSIsInJ1bnMiOlsyNDUsMjI2LDIyNiwyNDUsMjI2LDIyNiwyMjYsMjI2LDIyNiwyMjYsMjA3LDIyNiwyMjYsMjQ1LDIyNiwyMDcsMjI2LDIyNiwyMjYsMjQ1LDIyNiwyMDcsMjI2LDIyNiwyNDUsMjI2LDIwNywyNDUsMjI2LDIyNiwyNDUsMjI2LDIyNiwyMjYsMjI2LDIyNiwyNDUsMjI2LDIyNiwyMjYsMjI2LDIyNiwyNDUsMjI2LDI0NSwyMjYsMjQ1LDIwNywyMjYsMjI2LDIwNywyNDUsMjA3LDIyNiwyNDUsMjI2LDIyNiwyNDUsMjQ1LDIyNiwyNDUsMjA3LDIyNiwyNDUsMjQ1LDIyNiwyMDcsMjQ1LDIyNiwyNDUsMjA3LDIyNiwyNDUsMjQ1LDIwNywyMjYsMjI2LDIyNiwyNDUsMjI2LDI0NSwyMjYsMjI2LDIyNiwyNDUsMjI2LDIyNiwyMDcsMjI2LDIyNiwyNDUsMjQ1LDI0NSwyNDUsMjI2LDIyNiwyNDUsMjI2LDIyNiwyNDVdLCJvcHMiOjIyOX1dLCJ1cGRhdGVkIjoiMjAyMi0wNC0wNlQxNjo1Njo1OS42NTRaIn0%3D)

# Project Benchmark

### Previous approach

Output for `npm run benchmark` before changes:

```
> fast-json-stringify@3.0.3 benchmark
> node bench.js

FJS creation x 4,194 ops/sec ±2.72% (88 runs sampled)
CJS creation x 99,109 ops/sec ±1.85% (85 runs sampled)
AJV Serialize creation x 40,912,505 ops/sec ±0.18% (94 runs sampled)
JSON.stringify array x 3,560 ops/sec ±1.97% (94 runs sampled)
fast-json-stringify array x 4,139 ops/sec ±0.63% (94 runs sampled)
compile-json-stringify array x 4,018 ops/sec ±1.91% (89 runs sampled)
AJV Serialize array x 4,067 ops/sec ±0.42% (94 runs sampled)
JSON.stringify long string x 11,016 ops/sec ±1.12% (94 runs sampled)
fast-json-stringify long string x 11,035 ops/sec ±1.10% (93 runs sampled)
compile-json-stringify long string x 11,084 ops/sec ±1.03% (94 runs sampled)
AJV Serialize long string x 10,249 ops/sec ±0.74% (93 runs sampled)
JSON.stringify short string x 7,642,078 ops/sec ±0.32% (95 runs sampled)
fast-json-stringify short string x 19,330,903 ops/sec ±1.35% (93 runs sampled)
compile-json-stringify short string x 19,943,259 ops/sec ±0.35% (94 runs sampled)
AJV Serialize short string x 19,143,538 ops/sec ±2.03% (94 runs sampled)
JSON.stringify obj x 2,007,192 ops/sec ±0.11% (91 runs sampled)
fast-json-stringify obj x 6,912,154 ops/sec ±2.20% (91 runs sampled)
compile-json-stringify obj x 9,561,572 ops/sec ±0.41% (92 runs sampled)
AJV Serialize obj x 5,861,766 ops/sec ±0.99% (94 runs sampled)
JSON stringify date x 525,675 ops/sec ±0.68% (94 runs sampled)
fast-json-stringify date format x 1,309,404 ops/sec ±0.83% (94 runs sampled)
compile-json-stringify date format x 527,306 ops/sec ±0.77% (92 runs sampled)
```

### New approach

Output for `npm run benchmark` after changes:

```
> fast-json-stringify@3.0.3 benchmark
> node bench.js

FJS creation x 4,065 ops/sec ±2.84% (82 runs sampled)
CJS creation x 98,789 ops/sec ±1.34% (88 runs sampled)
AJV Serialize creation x 30,201,125 ops/sec ±1.45% (81 runs sampled)
JSON.stringify array x 3,128 ops/sec ±1.72% (95 runs sampled)
fast-json-stringify array default x 4,567 ops/sec ±0.82% (93 runs sampled)
fast-json-stringify array json-stringify x 4,562 ops/sec ±1.61% (93 runs sampled)
fast-json-stringify array array-join x 4,623 ops/sec ±0.31% (93 runs sampled)
compile-json-stringify array x 4,051 ops/sec ±2.08% (89 runs sampled)
AJV Serialize array x 4,032 ops/sec ±0.20% (96 runs sampled)
JSON.stringify large array x 157 ops/sec ±0.73% (86 runs sampled)
fast-json-stringify large array default x 48.72 ops/sec ±4.92% (48 runs sampled)
fast-json-stringify large array json-stringify x 157 ops/sec ±0.76% (86 runs sampled)
fast-json-stringify large array array-join x 69.04 ops/sec ±4.47% (53 runs sampled)
compile-json-stringify large array x 175 ops/sec ±4.47% (79 runs sampled)
AJV Serialize large array x 58.76 ops/sec ±4.59% (60 runs sampled)
JSON.stringify long string x 11,112 ops/sec ±0.22% (92 runs sampled)
fast-json-stringify long string x 11,053 ops/sec ±1.35% (91 runs sampled)
compile-json-stringify long string x 11,113 ops/sec ±0.22% (92 runs sampled)
AJV Serialize long string x 10,148 ops/sec ±1.59% (91 runs sampled)
JSON.stringify short string x 7,654,762 ops/sec ±0.18% (94 runs sampled)
fast-json-stringify short string x 18,895,714 ops/sec ±2.06% (90 runs sampled)
compile-json-stringify short string x 15,956,471 ops/sec ±1.75% (92 runs sampled)
AJV Serialize short string x 15,845,197 ops/sec ±0.84% (90 runs sampled)
JSON.stringify obj x 1,964,339 ops/sec ±2.23% (93 runs sampled)
fast-json-stringify obj x 6,972,524 ops/sec ±0.40% (94 runs sampled)
compile-json-stringify obj x 9,403,372 ops/sec ±1.99% (92 runs sampled)
AJV Serialize obj x 5,933,215 ops/sec ±0.83% (91 runs sampled)
JSON stringify date x 523,850 ops/sec ±0.53% (93 runs sampled)
fast-json-stringify date format x 1,297,452 ops/sec ±0.89% (94 runs sampled)
compile-json-stringify date format x 548,051 ops/sec ±1.16% (93 runs sampled)
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
