### PR TITLE
Support inline $id references

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,10 @@ import { Options as AjvOptions } from "ajv"
 declare namespace build {
   interface BaseSchema {
     /**
+     * Schema id
+     */
+    $id?: string
+    /**
      * Schema title
      */
     title?: string;

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function mergeLocation (source, dest) {
 
 const arrayItemsReferenceSerializersMap = new Map()
 const objectReferenceSerializersMap = new Map()
-const schemaReferenceMap = new Map() 
+const schemaReferenceMap = new Map()
 
 let ajvInstance = null
 

--- a/index.js
+++ b/index.js
@@ -52,11 +52,14 @@ function mergeLocation (source, dest) {
 
 const arrayItemsReferenceSerializersMap = new Map()
 const objectReferenceSerializersMap = new Map()
+const schemaReferenceMap = new Map() 
+
 let ajvInstance = null
 
 function build (schema, options) {
   arrayItemsReferenceSerializersMap.clear()
   objectReferenceSerializersMap.clear()
+  schemaReferenceMap.clear()
 
   options = options || {}
 
@@ -174,6 +177,7 @@ function build (schema, options) {
 
   arrayItemsReferenceSerializersMap.clear()
   objectReferenceSerializersMap.clear()
+  schemaReferenceMap.clear()
 
   return (Function.apply(null, dependenciesName).apply(null, dependencies))
 }
@@ -612,8 +616,18 @@ function refFinder (ref, location) {
   // Split file from walk
   ref = ref.split('#')
 
-  // If external file
-  if (ref[0]) {
+  // Check schemaReferenceMap for $id entry
+  if (ref[0] && schemaReferenceMap.has(ref[0])) {
+    schema = schemaReferenceMap.get(ref[0])
+    root = schemaReferenceMap.get(ref[0])
+    if (schema.$ref) {
+      return refFinder(schema.$ref, {
+        schema: schema,
+        root: root,
+        externalSchema: externalSchema
+      })
+    }
+  } else if (ref[0]) { // If external file
     schema = externalSchema[ref[0]]
     root = externalSchema[ref[0]]
 
@@ -921,7 +935,9 @@ function toJSON (variableName) {
 
 function buildObject (location, code, name) {
   const schema = location.schema
-
+  if (schema.$id !== undefined) {
+    schemaReferenceMap.set(schema.$id, schema)
+  }
   code += `
     function ${name} (input) {
   `
@@ -971,6 +987,9 @@ function buildObject (location, code, name) {
 
 function buildArray (location, code, name, key = null) {
   let schema = location.schema
+  if (schema.$id !== undefined) {
+    schemaReferenceMap.set(schema.$id, schema)
+  }
   code += `
     function ${name} (obj) {
   `

--- a/test/recursion.test.js
+++ b/test/recursion.test.js
@@ -178,3 +178,68 @@ test('can stringify recursive references in object types (issue #365)', t => {
   const value = stringify(data)
   t.equal(value, '{"category":{"parent":{"parent":{"parent":{"parent":{}}}}}}')
 })
+
+test('can stringify recursive inline $id references (issue #410)', t => {
+  t.plan(1)
+  const schema = {
+    $id: 'Node',
+    type: 'object',
+    properties: {
+      id: {
+        type: 'string'
+      },
+      nodes: {
+        type: 'array',
+        items: {
+          $ref: 'Node'
+        }
+      }
+    },
+    required: [
+      'id',
+      'nodes'
+    ]
+  }
+
+  const stringify = build(schema)
+  const data = {
+    id: '0',
+    nodes: [
+      {
+        id: '1',
+        nodes: [{
+          id: '2',
+          nodes: [
+            { id: '3', nodes: [] },
+            { id: '4', nodes: [] },
+            { id: '5', nodes: [] }
+          ]
+        }]
+      },
+      {
+        id: '6',
+        nodes: [{
+          id: '7',
+          nodes: [
+            { id: '8', nodes: [] },
+            { id: '9', nodes: [] },
+            { id: '10', nodes: [] }
+          ]
+        }]
+      },
+      {
+        id: '11',
+        nodes: [{
+          id: '12',
+          nodes: [
+            { id: '13', nodes: [] },
+            { id: '14', nodes: [] },
+            { id: '15', nodes: [] }
+          ]
+        }]
+      }
+    ]
+  }
+  const value = stringify(data)
+  t.equal(value, '{"id":"0","nodes":[{"id":"1","nodes":[{"id":"2","nodes":[{"id":"3","nodes":[]},{"id":"4","nodes":[]},{"id":"5","nodes":[]}]}]},{"id":"6","nodes":[{"id":"7","nodes":[{"id":"8","nodes":[]},{"id":"9","nodes":[]},{"id":"10","nodes":[]}]}]},{"id":"11","nodes":[{"id":"12","nodes":[{"id":"13","nodes":[]},{"id":"14","nodes":[]},{"id":"15","nodes":[]}]}]}]}')
+})


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This PR should resolve inline `$id` references mentioned on issue https://github.com/fastify/fast-json-stringify/issues/410. This implementation adds an additional `schemaReferenceMap` which is used to collect schemas with `$id` observed during the build phase. These references are later resolved in subsequent calls to the `refFinder(...)` function.

Note: There is some overlap here with the existing `externalSchema` variable which I think may be trying to resolve specifically for anchor (or `#`) references (I'm entirely not sure). I have left the `externalSchema` implementation as is as a fall through. It was noted however that the `externalSchema` variable was `undefined` for the inline `$id` / `$ref` code path.

This PR also adds the `$id` property to the TS definition for `BaseSchema`

Submitting for community review

### Benchmark

CPU: AMD Ryzen 7 3700X
RAM: 16GB
OS: Windows 10
```
FJS creation x 7,030 ops/sec ±1.67% (92 runs sampled)
CJS creation x 152,803 ops/sec ±0.20% (94 runs sampled)
AJV Serialize creation x 87,669,032 ops/sec ±0.34% (94 runs sampled)
JSON.stringify array x 3,099 ops/sec ±0.45% (93 runs sampled)
fast-json-stringify array default x 7,551 ops/sec ±0.61% (93 runs sampled)
fast-json-stringify array json-stringify x 7,861 ops/sec ±0.32% (93 runs sampled)
compile-json-stringify array x 7,629 ops/sec ±0.92% (89 runs sampled)
AJV Serialize array x 8,418 ops/sec ±0.64% (95 runs sampled)
JSON.stringify large array x 154 ops/sec ±0.33% (87 runs sampled)
fast-json-stringify large array default x 104 ops/sec ±3.40% (68 runs sampled)
fast-json-stringify large array json-stringify x 153 ops/sec ±0.38% (86 runs sampled)
compile-json-stringify large array x 332 ops/sec ±0.42% (88 runs sampled)
AJV Serialize large array x 96.35 ops/sec ±0.22% (82 runs sampled)
JSON.stringify long string x 9,918 ops/sec ±0.18% (96 runs sampled)
fast-json-stringify long string x 9,991 ops/sec ±0.11% (96 runs sampled)
compile-json-stringify long string x 10,000 ops/sec ±0.09% (97 runs sampled)
AJV Serialize long string x 22,533 ops/sec ±0.72% (97 runs sampled)
JSON.stringify short string x 9,231,883 ops/sec ±0.47% (96 runs sampled)
fast-json-stringify short string x 45,670,735 ops/sec ±0.25% (98 runs sampled)
compile-json-stringify short string x 42,118,334 ops/sec ±0.86% (95 runs sampled)
AJV Serialize short string x 39,980,549 ops/sec ±0.32% (96 runs sampled)
JSON.stringify obj x 1,832,767 ops/sec ±0.74% (93 runs sampled)
fast-json-stringify obj x 11,078,004 ops/sec ±0.45% (97 runs sampled)
compile-json-stringify obj x 21,901,106 ops/sec ±1.34% (95 runs sampled)
AJV Serialize obj x 11,098,735 ops/sec ±1.29% (92 runs sampled)
JSON stringify date x 549,445 ops/sec ±0.23% (91 runs sampled)
fast-json-stringify date format x 898,135 ops/sec ±0.32% (96 runs sampled)
compile-json-stringify date format x 537,925 ops/sec ±0.41% (93 runs sampled)
```