### PR TITLE
Draft: fix(toJSON): support json primitives with toJSON

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -91,6 +91,21 @@ const obj = {
   age: 32
 }
 
+const objToJSON = {
+  props: {
+    firstName: { toJSON () { return 'Matteo' } },
+    lastName: { toJSON () { return 'Collina' } },
+    age: { toJSON () { return 32 } }
+  },
+  toJSON () {
+    return {
+      firstName: this.props.firstName,
+      lastName: this.props.lastName,
+      age: this.props.age
+    }
+  }
+}
+
 const date = new Date()
 
 const multiArray = new Array(MULTI_ARRAY_LENGHT)
@@ -258,6 +273,14 @@ suite.add('compile-json-stringify obj', function () {
 
 suite.add('AJV Serialize obj', function () {
   ajvSerialize(obj)
+})
+
+suite.add('JSON.stringify obj toJSON', function () {
+  JSON.stringify(objToJSON)
+})
+
+suite.add('fast-json-stringify obj toJSON', function () {
+  stringify(objToJSON)
 })
 
 suite.add('JSON stringify date', function () {

--- a/test/toJSON-ref.test.js
+++ b/test/toJSON-ref.test.js
@@ -1,0 +1,320 @@
+'use strict'
+
+const test = require('tap').test
+const build = require('..')
+
+const object = {
+  props: {
+    obj: {
+      toJSON () { return { str: 'test' } }
+    }
+  },
+  toJSON () {
+    return { obj: this.props.obj }
+  }
+}
+
+test('toJSON - ref - properties', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with $ref',
+    definitions: {
+      def: {
+        type: 'object',
+        properties: {
+          str: {
+            type: 'string'
+          }
+        }
+      }
+    },
+    type: 'object',
+    properties: {
+      obj: {
+        $ref: '#/definitions/def'
+      }
+    }
+  }
+
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  JSON.parse(output)
+  t.pass()
+
+  t.equal(output, '{"obj":{"str":"test"}}')
+})
+
+test('toJSON - ref - items', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'array with $ref',
+    definitions: {
+      def: {
+        type: 'object',
+        properties: {
+          str: {
+            type: 'string'
+          }
+        }
+      }
+    },
+    type: 'array',
+    items: { $ref: '#/definitions/def' }
+  }
+
+  const arrayObj = {
+    props: {
+      str: {
+        toJSON () { return { str: 'test' } }
+      }
+    },
+    toJSON () { return [this.props.str] }
+  }
+
+  const stringify = build(schema)
+  const output = stringify(arrayObj)
+
+  JSON.parse(output)
+  t.pass()
+
+  t.equal(output, '[{"str":"test"}]')
+})
+
+test('toJSON - ref - patternProperties', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with $ref',
+    definitions: {
+      def: {
+        type: 'object',
+        properties: {
+          str: {
+            type: 'string'
+          }
+        }
+      }
+    },
+    type: 'object',
+    properties: {},
+    patternProperties: {
+      obj: {
+        $ref: '#/definitions/def'
+      }
+    }
+  }
+
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  JSON.parse(output)
+  t.pass()
+
+  t.equal(output, '{"obj":{"str":"test"}}')
+})
+
+test('toJSON - ref - additionalProperties', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with $ref',
+    definitions: {
+      def: {
+        type: 'object',
+        properties: {
+          str: {
+            type: 'string'
+          }
+        }
+      }
+    },
+    type: 'object',
+    properties: {},
+    additionalProperties: {
+      $ref: '#/definitions/def'
+    }
+  }
+
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  JSON.parse(output)
+  t.pass()
+
+  t.equal(output, '{"obj":{"str":"test"}}')
+})
+
+test('toJSON - ref - pattern-additional Properties', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with $ref',
+    definitions: {
+      def: {
+        type: 'object',
+        properties: {
+          str: {
+            type: 'string'
+          }
+        }
+      }
+    },
+    type: 'object',
+    properties: {},
+    patternProperties: {
+      reg: {
+        $ref: '#/definitions/def'
+      }
+    },
+    additionalProperties: {
+      $ref: '#/definitions/def'
+    }
+  }
+
+  const object = {
+    props: {
+      patternObj: {
+        toJSON () { return { str: 'test' } }
+      }
+    },
+    toJSON () {
+      return {
+        reg: this.props.patternObj,
+        obj: this.props.patternObj
+      }
+    }
+  }
+
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  JSON.parse(output)
+  t.pass()
+
+  t.equal(output, '{"reg":{"str":"test"},"obj":{"str":"test"}}')
+})
+
+test('toJSON - ref - deepObject schema', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with $ref',
+    definitions: {
+      def: {
+        type: 'object',
+        properties: {
+          coming: {
+            type: 'object',
+            properties: {
+              where: {
+                type: 'string'
+              }
+            }
+          }
+        }
+      }
+    },
+    type: 'object',
+    properties: {
+      winter: {
+        type: 'object',
+        properties: {
+          is: {
+            $ref: '#/definitions/def'
+          }
+        }
+      }
+    }
+  }
+
+  const where = {
+    toJSON () { return 'to town' }
+  }
+  const coming = {
+    toJSON () { return { where } }
+  }
+  const is = {
+    toJSON () { return { coming } }
+  }
+  const winter = {
+    toJSON () { return { is } }
+  }
+  const object = {
+    toJSON () { return { winter } }
+  }
+
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  JSON.parse(output)
+  t.pass()
+
+  t.equal(output, '{"winter":{"is":{"coming":{"where":"to town"}}}}')
+})
+
+test('toJSON - ref - Regression 2.5.2', t => {
+  t.plan(1)
+
+  const externalSchema = {
+    '/models/Bar': {
+      $id: '/models/Bar',
+      $schema: 'http://json-schema.org/schema#',
+      definitions: {
+        entity: {
+          type: 'object',
+          properties: { field: { type: 'string' } }
+        }
+      }
+    },
+    '/models/Foo': {
+      $id: '/models/Foo',
+      $schema: 'http://json-schema.org/schema#',
+      definitions: {
+        entity: {
+          type: 'object',
+          properties: {
+            field: { type: 'string' },
+            sub: {
+              oneOf: [
+                { $ref: '/models/Bar#/definitions/entity' },
+                { type: 'null' }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const schema = {
+    type: 'array',
+    items: {
+      $ref: '/models/Foo#/definitions/entity'
+    }
+  }
+
+  const object = {
+    props: {
+      field: {
+        toJSON () { return 'parent' }
+      },
+      sub: {
+        toJSON () { return { field: 'joined' } }
+      }
+    },
+    toJSON () {
+      return [{
+        field: this.props.field,
+        sub: this.props.sub
+      }]
+    }
+  }
+
+  const stringify = build(schema, { schema: externalSchema })
+  const output = stringify(object)
+
+  t.equal(output, '[{"field":"parent","sub":{"field":"joined"}}]')
+})

--- a/test/toJSON-typesArray.test.js
+++ b/test/toJSON-typesArray.test.js
@@ -1,0 +1,408 @@
+'use strict'
+
+const test = require('tap').test
+const build = require('..')
+
+const data4 = {
+  data: { toJSON () { return 4 } }
+}
+const dataNull = {
+  data: { toJSON () { return null } }
+}
+const oNull = { toJSON () { return null } }
+const oTrue = { toJSON () { return true } }
+const oString1 = { toJSON () { return 'string1' } }
+const oString2 = { toJSON () { return 'string2' } }
+const oNumber42 = { toJSON () { return 42 } }
+const oNumber7 = { toJSON () { return 7 } }
+
+test('possibly nullable integer primitive alternative', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'simple object with multi-type nullable primitive',
+    type: 'object',
+    properties: {
+      data: {
+        type: ['integer']
+      }
+    }
+  }
+
+  const stringify = build(schema, { ajv: { allowUnionTypes: true } })
+
+  t.equal(stringify(data4), '{"data":4}')
+})
+
+test('possibly nullable number primitive alternative', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'simple object with multi-type nullable primitive',
+    type: 'object',
+    properties: {
+      data: {
+        type: ['number']
+      }
+    }
+  }
+
+  const stringify = build(schema)
+
+  t.equal(stringify(data4), '{"data":4}')
+})
+
+test('possibly nullable integer primitive alternative with null value', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'simple object with multi-type nullable primitive',
+    type: 'object',
+    properties: {
+      data: {
+        type: ['integer']
+      }
+    }
+  }
+
+  const stringify = build(schema)
+
+  const value = stringify(dataNull)
+  t.equal(value, '{"data":0}')
+})
+
+test('possibly nullable number primitive alternative with null value', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'simple object with multi-type nullable primitive',
+    type: 'object',
+    properties: {
+      data: {
+        type: ['number']
+      }
+    }
+  }
+
+  const stringify = build(schema)
+
+  const value = stringify(dataNull)
+  t.equal(value, '{"data":0}')
+})
+
+test('nullable integer primitive', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'simple object with nullable primitive',
+    type: 'object',
+    properties: {
+      data: {
+        type: ['integer', 'null']
+      }
+    }
+  }
+
+  const stringify = build(schema)
+
+  const value = stringify(data4)
+  t.equal(value, '{"data":4}')
+})
+
+test('nullable number primitive', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'simple object with nullable primitive',
+    type: 'object',
+    properties: {
+      data: {
+        type: ['number', 'null']
+      }
+    }
+  }
+
+  const stringify = build(schema)
+
+  const value = stringify(data4)
+  t.equal(value, '{"data":4}')
+})
+
+test('nullable primitive with null value', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'simple object with nullable primitive',
+    type: 'object',
+    properties: {
+      data: {
+        type: ['integer', 'null']
+      }
+    }
+  }
+
+  const stringify = build(schema)
+
+  const value = stringify(dataNull)
+  t.equal(value, '{"data":null}')
+})
+
+test('nullable number primitive with null value', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'simple object with nullable primitive',
+    type: 'object',
+    properties: {
+      data: {
+        type: ['number', 'null']
+      }
+    }
+  }
+
+  const stringify = build(schema)
+
+  const value = stringify(dataNull)
+  t.equal(value, '{"data":null}')
+})
+
+test('possibly null object with multi-type property', (t) => {
+  t.plan(3)
+
+  const schema = {
+    title: 'simple object with multi-type property',
+    type: 'object',
+    properties: {
+      objectOrNull: {
+        type: ['object', 'null'],
+        properties: {
+          stringOrNumber: {
+            type: ['string', 'number']
+          }
+        }
+      }
+    }
+  }
+  const stringify = build(schema)
+
+  t.equal(stringify({ objectOrNull: { toJSON () { return { stringOrNumber: oString1 } } } }), '{"objectOrNull":{"stringOrNumber":"string1"}}')
+
+  t.equal(stringify({ objectOrNull: { toJSON () { return { stringOrNumber: oNumber42 } } } }), '{"objectOrNull":{"stringOrNumber":42}}')
+
+  t.equal(stringify({ objectOrNull: oNull }), '{"objectOrNull":null}')
+})
+
+test('object with possibly null array of multiple types', (t) => {
+  t.plan(5)
+
+  const schema = {
+    title: 'object with array of multiple types',
+    type: 'object',
+    properties: {
+      arrayOfStringsAndNumbers: {
+        type: ['array', 'null'],
+        items: {
+          type: ['string', 'number', 'null']
+        }
+      }
+    }
+  }
+  const stringify = build(schema)
+
+  const arrayStringsAndNumberString = {
+    arrayOfStringsAndNumbers: { toJSON () { return [oString1, oString2] } }
+  }
+  const arrayStringsAndNumberNumber = {
+    arrayOfStringsAndNumbers: { toJSON () { return [oNumber42, oNumber7] } }
+  }
+  const arrayStringsAndNumberMixed = {
+    arrayOfStringsAndNumbers: { toJSON () { return [oString1, oNumber42, oNumber7, oString2] } }
+  }
+  const arrayStringsAndNumberMixedNull = {
+    arrayOfStringsAndNumbers: { toJSON () { return [oString1, oNull, oNumber42, oNumber7, oString2, oNull] } }
+  }
+
+  try {
+    const value = stringify({ arrayOfStringsAndNumbers: oNull })
+    t.equal(value, '{"arrayOfStringsAndNumbers":null}')
+  } catch (e) {
+    console.log(e)
+    t.fail()
+  }
+
+  try {
+    const value = stringify(arrayStringsAndNumberString)
+    t.equal(value, '{"arrayOfStringsAndNumbers":["string1","string2"]}')
+  } catch (e) {
+    console.log(e)
+    t.fail()
+  }
+
+  t.equal(stringify(arrayStringsAndNumberNumber), '{"arrayOfStringsAndNumbers":[42,7]}')
+
+  t.equal(stringify(arrayStringsAndNumberMixed), '{"arrayOfStringsAndNumbers":["string1",42,7,"string2"]}')
+
+  t.equal(stringify(arrayStringsAndNumberMixedNull), '{"arrayOfStringsAndNumbers":["string1",null,42,7,"string2",null]}')
+})
+
+test('object with tuple of multiple types', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'object with array of multiple types',
+    type: 'object',
+    properties: {
+      fixedTupleOfStringsAndNumbers: {
+        type: 'array',
+        items: [
+          {
+            type: 'string'
+          },
+          {
+            type: 'number'
+          },
+          {
+            type: ['string', 'number']
+          }
+        ]
+      }
+    }
+  }
+  const stringify = build(schema)
+
+  try {
+    const value = stringify({
+      fixedTupleOfStringsAndNumbers: { toJSON () { return [oString1, oNumber42, oNumber7] } }
+    })
+    t.equal(value, '{"fixedTupleOfStringsAndNumbers":["string1",42,7]}')
+  } catch (e) {
+    console.log(e)
+    t.fail()
+  }
+
+  try {
+    // const value = stringify({
+    //   fixedTupleOfStringsAndNumbers: { toJSON () { return [ oString1, oNumber42, oString2 ] } }
+    // })
+    const value = JSON.stringify({
+      fixedTupleOfStringsAndNumbers: { toJSON () { return [oString1, oNumber42, oString2] } }
+    })
+    t.equal(value, '{"fixedTupleOfStringsAndNumbers":["string1",42,"string2"]}')
+  } catch (e) {
+    console.log(e)
+    t.fail()
+  }
+})
+
+test('object with anyOf and multiple types', (t) => {
+  t.plan(3)
+
+  const schema = {
+    title: 'object with anyOf and multiple types',
+    type: 'object',
+    properties: {
+      objectOrBoolean: {
+        anyOf: [
+          {
+            type: 'object',
+            properties: {
+              stringOrNumber: {
+                type: ['string', 'number']
+              }
+            }
+          },
+          {
+            type: 'boolean'
+          }
+        ]
+      }
+    }
+  }
+  const stringify = build(schema, { ajv: { allowUnionTypes: true } })
+
+  try {
+    const value = stringify({
+      objectOrBoolean: { toJSON () { return { stringOrNumber: oString1 } } }
+    })
+    t.equal(value, '{"objectOrBoolean":{"stringOrNumber":"string1"}}')
+  } catch (e) {
+    console.log(e)
+    t.fail()
+  }
+
+  t.equal(stringify({
+    objectOrBoolean: { toJSON () { return { stringOrNumber: oNumber42 } } }
+  }), '{"objectOrBoolean":{"stringOrNumber":42}}')
+
+  t.equal(stringify({ objectOrBoolean: oTrue }), '{"objectOrBoolean":true}')
+})
+
+test('object that is simultaneously a string and a json', (t) => {
+  t.plan(2)
+  const schema = {
+    type: 'object',
+    properties: {
+      simultaneously: {
+        type: ['string', 'object'],
+        properties: {
+          foo: { type: 'string' }
+        }
+      }
+    }
+  }
+
+  const likeObjectId = {
+    toString () { return 'hello' }
+  }
+
+  const stringify = build(schema)
+  const valueStr = stringify({ simultaneously: { toJSON () { return likeObjectId } } })
+  t.equal(valueStr, '{"simultaneously":"hello"}')
+
+  const valueObj = stringify({ simultaneously: { toJSON () { return { foo: likeObjectId } } } })
+  t.equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
+})
+
+test('object that is simultaneously a string and a json switched', (t) => {
+  t.plan(2)
+  const schema = {
+    type: 'object',
+    properties: {
+      simultaneously: {
+        type: ['object', 'string'],
+        properties: {
+          foo: { type: 'string' }
+        }
+      }
+    }
+  }
+
+  const likeObjectId = {
+    toString () { return 'hello' }
+  }
+
+  const stringify = build(schema)
+  const valueStr = stringify({ simultaneously: { toJSON () { return likeObjectId } } })
+  t.equal(valueStr, '{"simultaneously":{}}')
+
+  const valueObj = stringify({ simultaneously: { toJSON () { return { foo: likeObjectId } } } })
+  t.equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
+})
+
+test('should throw an error when type is array and object is null', (t) => {
+  t.plan(1)
+  const schema = {
+    type: 'object',
+    properties: {
+      arr: {
+        type: 'array',
+        items: {
+          type: 'number'
+        }
+      }
+    }
+  }
+
+  const stringify = build(schema)
+  t.throws(() => stringify({ arr: oNull }), new TypeError('Property \'arr\' should be of type array, received \'null\' instead.'))
+})

--- a/test/toJSON.test.js
+++ b/test/toJSON.test.js
@@ -305,8 +305,6 @@ test('toJSON supports required types', (t) => {
   t.throws(() => { stringify(invalidInput) })
 })
 
-// TODO add toJSON with $ref
-
 test('use toJSON recursively', (t) => {
   t.plan(2)
   const nullable = true

--- a/test/toJSON.test.js
+++ b/test/toJSON.test.js
@@ -26,7 +26,7 @@ test('use toJSON method on object types', (t) => {
 })
 
 test('use toJSON method on nested object types', (t) => {
-  t.plan(1)
+  t.plan(2)
 
   const stringify = build({
     title: 'simple array',
@@ -56,10 +56,34 @@ test('use toJSON method on nested object types', (t) => {
   ]
 
   t.equal('[{"productName":"cola"},{"productName":"sprite"}]', stringify(array))
+
+  const obj = {
+    props: {
+      array: [
+        {
+          product: { name: 'cola' },
+          toJSON: function () {
+            return { productName: this.product.name }
+          }
+        },
+        {
+          product: { name: 'sprite' },
+          toJSON: function () {
+            return { productName: this.product.name }
+          }
+        }
+      ]
+    },
+    toJSON () {
+      return this.props.array
+    }
+  }
+
+  t.equal(stringify(obj), '[{"productName":"cola"},{"productName":"sprite"}]')
 })
 
-test('use toJSON when it returns a primary type', (t) => {
-  t.plan(3)
+test('use toJSON method on primary json types', (t) => {
+  t.plan(2)
 
   const stringify = build({
     title: 'object of primitive (json) types',
@@ -82,7 +106,7 @@ test('use toJSON when it returns a primary type', (t) => {
       }
     }
   })
-  const input1 = {
+  const input = {
     _bool: {
       toJSON () { return true }
     },
@@ -99,15 +123,29 @@ test('use toJSON when it returns a primary type', (t) => {
       toJSON () { return 'whatever' }
     }
   }
-  const expected1 = '{"_bool":true,"_int":42,"_null":null,"_num":3.14,"_str":"whatever"}'
+  const expected = '{"_bool":true,"_int":42,"_null":null,"_num":3.14,"_str":"whatever"}'
 
-  t.equal(JSON.stringify(input1), expected1)
-  t.equal(stringify(input1), expected1)
+  t.equal(JSON.stringify(input), expected)
+  t.equal(stringify(input), expected)
+})
 
-  const input2 = {
-    _bool: {
-      toJSON () { return undefined }
-    },
+test('toJSON drops props with invalid numbers', (t) => {
+  t.plan(1)
+
+  const stringify = build({
+    title: 'object of primitive (json) types',
+    type: 'object',
+    properties: {
+      _int: {
+        type: 'integer'
+      },
+      _num: {
+        type: 'number'
+      }
+    }
+  })
+
+  const input = {
     _int: {
       toJSON () { return 'not a number' }
     },
@@ -115,15 +153,15 @@ test('use toJSON when it returns a primary type', (t) => {
       toJSON () { return 'not a number' }
     }
   }
-  const expected2 = '{"_bool":false}'
-  t.equal(stringify(input2), expected2)
+  const expected = '{}'
+  t.equal(stringify(input), expected)
 })
 
-test('use toJSON recursively', (t) => {
-  t.plan(2)
+test('toJSON skips missing props when not required', (t) => {
+  t.plan(1)
 
   const stringify = build({
-    title: 'simple object',
+    title: 'object of primitive (json) types',
     type: 'object',
     properties: {
       _bool: {
@@ -142,6 +180,194 @@ test('use toJSON recursively', (t) => {
         type: 'string'
       }
     }
+  })
+
+  const input = {
+    toJSON () { return {} }
+  }
+  const expected = '{}'
+  t.equal(stringify(input), expected)
+})
+
+test('toJSON forwards nullable types', (t) => {
+  t.plan(4)
+
+  const nullable = true
+  const stringify = build({
+    title: 'object of nullable primitive (json) types',
+    type: 'object',
+    properties: {
+      _bool: {
+        type: 'boolean',
+        nullable
+      },
+      _int: {
+        type: 'integer',
+        nullable
+      },
+      _num: {
+        type: 'number',
+        nullable
+      },
+      _str: {
+        type: 'string',
+        nullable
+      }
+    }
+  })
+
+  const inputNull = {
+    _bool: {
+      toJSON () { return null }
+    },
+    _int: {
+      toJSON () { return null }
+    },
+    _num: {
+      toJSON () { return null }
+    },
+    _str: {
+      toJSON () { return null }
+    }
+  }
+  const expectedNull = '{"_bool":null,"_int":null,"_num":null,"_str":null}'
+  t.equal(JSON.stringify(inputNull), expectedNull)
+  t.equal(stringify(inputNull), expectedNull)
+
+  const inputNotNull = {
+    _bool: {
+      toJSON () { return true }
+    },
+    _int: {
+      toJSON () { return 42 }
+    },
+    _num: {
+      toJSON () { return 3.14 }
+    },
+    _str: {
+      toJSON () { return 'whatever' }
+    }
+  }
+  const expectedNotNull = '{"_bool":true,"_int":42,"_num":3.14,"_str":"whatever"}'
+  t.equal(JSON.stringify(inputNotNull), expectedNotNull)
+  t.equal(stringify(inputNotNull), expectedNotNull)
+})
+
+test('toJSON supports required types', (t) => {
+  t.plan(2)
+
+  const stringify = build({
+    title: 'object of required primitive (json) types',
+    type: 'object',
+    properties: {
+      _bool: {
+        type: 'boolean'
+      },
+      _int: {
+        type: 'integer'
+      },
+      _null: {
+        type: 'null'
+      },
+      _num: {
+        type: 'number'
+      },
+      _str: {
+        type: 'string'
+      }
+    },
+    required: ['_bool', '_int', '_null', '_num', '_str']
+  })
+
+  const input = {
+    _bool: {
+      toJSON () { return true }
+    },
+    _int: {
+      toJSON () { return 42 }
+    },
+    _null: {
+      toJSON () { return null }
+    },
+    _num: {
+      toJSON () { return 3.14 }
+    },
+    _str: {
+      toJSON () { return 'whatever' }
+    }
+  }
+  const expected = '{"_bool":true,"_int":42,"_null":null,"_num":3.14,"_str":"whatever"}'
+  t.equal(stringify(input), expected)
+
+  const invalidInput = {
+    toJSON () { return {} }
+  }
+  t.throws(() => { stringify(invalidInput) })
+})
+
+// TODO add toJSON with $ref
+
+test('use toJSON recursively', (t) => {
+  t.plan(2)
+  const nullable = true
+  const stringify = build({
+    title: 'simple object',
+    type: 'object',
+    properties: {
+      _bool: {
+        type: 'boolean'
+      },
+      _bool_nullable: {
+        nullable,
+        type: 'boolean'
+      },
+      _bool_required: {
+        type: 'boolean'
+      },
+      _int: {
+        type: 'integer'
+      },
+      _int_nullable: {
+        nullable,
+        type: 'integer'
+      },
+      _int_required: {
+        type: 'integer'
+      },
+      _null: {
+        type: 'null'
+      },
+      _null_required: {
+        type: 'null'
+      },
+      _num: {
+        type: 'number'
+      },
+      _num_nullable: {
+        nullable,
+        type: 'number'
+      },
+      _num_required: {
+        type: 'number'
+      },
+      _str: {
+        type: 'string'
+      },
+      _str_nullable: {
+        nullable,
+        type: 'string'
+      },
+      _str_required: {
+        type: 'string'
+      }
+    },
+    required: [
+      '_bool_required',
+      '_int_required',
+      '_null_required',
+      '_num_required',
+      '_str_required'
+    ]
   })
   const aggregate = {
     props: {
@@ -164,14 +390,23 @@ test('use toJSON recursively', (t) => {
     toJSON () {
       return {
         _bool: this.props._bool,
+        _bool_nullable: this.props._null,
+        _bool_required: this.props._bool,
         _int: this.props._int,
+        _int_nullable: this.props._null,
+        _int_required: this.props._int,
         _null: this.props._null,
+        _null_required: this.props._null,
         _num: this.props._num,
-        _str: this.props._str
+        _num_nullable: this.props._null,
+        _num_required: this.props._num,
+        _str: this.props._str,
+        _str_nullable: this.props._null,
+        _str_required: this.props._str
       }
     }
   }
-  const expected = '{"_bool":true,"_int":42,"_null":null,"_num":3.14,"_str":"whatever"}'
+  const expected = '{"_bool":true,"_bool_nullable":null,"_bool_required":true,"_int":42,"_int_nullable":null,"_int_required":42,"_null":null,"_null_required":null,"_num":3.14,"_num_nullable":null,"_num_required":3.14,"_str":"whatever","_str_nullable":null,"_str_required":"whatever"}'
 
   t.equal(JSON.stringify(aggregate), expected)
   t.equal(stringify(aggregate), expected)

--- a/test/toJSON.test.js
+++ b/test/toJSON.test.js
@@ -58,6 +58,125 @@ test('use toJSON method on nested object types', (t) => {
   t.equal('[{"productName":"cola"},{"productName":"sprite"}]', stringify(array))
 })
 
+test('use toJSON when it returns a primary type', (t) => {
+  t.plan(3)
+
+  const stringify = build({
+    title: 'object of primitive (json) types',
+    type: 'object',
+    properties: {
+      _bool: {
+        type: 'boolean'
+      },
+      _int: {
+        type: 'integer'
+      },
+      _null: {
+        type: 'null'
+      },
+      _num: {
+        type: 'number'
+      },
+      _str: {
+        type: 'string'
+      }
+    }
+  })
+  const input1 = {
+    _bool: {
+      toJSON () { return true }
+    },
+    _int: {
+      toJSON () { return 42 }
+    },
+    _null: {
+      toJSON () { return null }
+    },
+    _num: {
+      toJSON () { return 3.14 }
+    },
+    _str: {
+      toJSON () { return 'whatever' }
+    }
+  }
+  const expected1 = '{"_bool":true,"_int":42,"_null":null,"_num":3.14,"_str":"whatever"}'
+
+  t.equal(JSON.stringify(input1), expected1)
+  t.equal(stringify(input1), expected1)
+
+  const input2 = {
+    _bool: {
+      toJSON () { return undefined }
+    },
+    _int: {
+      toJSON () { return 'not a number' }
+    },
+    _num: {
+      toJSON () { return 'not a number' }
+    }
+  }
+  const expected2 = '{"_bool":false}'
+  t.equal(stringify(input2), expected2)
+})
+
+test('use toJSON recursively', (t) => {
+  t.plan(2)
+
+  const stringify = build({
+    title: 'simple object',
+    type: 'object',
+    properties: {
+      _bool: {
+        type: 'boolean'
+      },
+      _int: {
+        type: 'integer'
+      },
+      _null: {
+        type: 'null'
+      },
+      _num: {
+        type: 'number'
+      },
+      _str: {
+        type: 'string'
+      }
+    }
+  })
+  const aggregate = {
+    props: {
+      _bool: {
+        toJSON () { return true }
+      },
+      _int: {
+        toJSON () { return 42 }
+      },
+      _null: {
+        toJSON () { return null }
+      },
+      _num: {
+        toJSON () { return 3.14 }
+      },
+      _str: {
+        toJSON () { return 'whatever' }
+      }
+    },
+    toJSON () {
+      return {
+        _bool: this.props._bool,
+        _int: this.props._int,
+        _null: this.props._null,
+        _num: this.props._num,
+        _str: this.props._str
+      }
+    }
+  }
+  const expected = '{"_bool":true,"_int":42,"_null":null,"_num":3.14,"_str":"whatever"}'
+
+  t.equal(JSON.stringify(aggregate), expected)
+  t.equal(stringify(aggregate), expected)
+})
+
 test('not use toJSON if does not exist', (t) => {
   t.plan(1)
 


### PR DESCRIPTION
_This failed to bring extensive support for `toJSON()` method on par with native `JSON.stringify()`._

------

This fixes #412 but I’m not quite sure if it’s the right thing to do. Notably, I have very little clue about performance penalties those changes could have introduced for more common use cases.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [NA] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Benchmarks

Hardware: Intel<sup>®</sup> Core™ i7-8665U @ 1.9GHz × 8T/4C, 16GB, SSD.
Node.js: v16.14.0

##### fast-json-stringify@3.2.0

```
FJS creation x 5,967 ops/sec ±1.48% (88 runs sampled)
CJS creation x 128,198 ops/sec ±0.85% (90 runs sampled)
AJV Serialize creation x 52,421,613 ops/sec ±2.90% (86 runs sampled)
JSON.stringify array x 2,900 ops/sec ±0.42% (93 runs sampled)
fast-json-stringify array default x 5,803 ops/sec ±1.28% (87 runs sampled)
fast-json-stringify array json-stringify x 5,699 ops/sec ±1.47% (88 runs sampled)
compile-json-stringify array x 6,314 ops/sec ±1.63% (90 runs sampled)
AJV Serialize array x 6,796 ops/sec ±0.47% (94 runs sampled)
JSON.stringify large array x 153 ops/sec ±0.44% (85 runs sampled)
fast-json-stringify large array default x 85.13 ops/sec ±2.65% (62 runs sampled)
fast-json-stringify large array json-stringify x 149 ops/sec ±1.27% (83 runs sampled)
compile-json-stringify large array x 283 ops/sec ±2.13% (82 runs sampled)
AJV Serialize large array x 80.90 ops/sec ±0.67% (69 runs sampled)
JSON.stringify long string x 9,499 ops/sec ±0.66% (91 runs sampled)
fast-json-stringify long string x 9,469 ops/sec ±0.79% (91 runs sampled)
compile-json-stringify long string x 9,426 ops/sec ±0.88% (89 runs sampled)
AJV Serialize long string x 16,300 ops/sec ±0.38% (92 runs sampled)
JSON.stringify short string x 7,776,378 ops/sec ±0.49% (89 runs sampled)
fast-json-stringify short string x 37,288,386 ops/sec ±0.39% (91 runs sampled)
compile-json-stringify short string x 31,924,065 ops/sec ±0.26% (92 runs sampled)
AJV Serialize short string x 29,623,818 ops/sec ±0.91% (93 runs sampled)
JSON.stringify obj x 2,003,796 ops/sec ±0.52% (88 runs sampled)
fast-json-stringify obj x 9,710,547 ops/sec ±0.33% (96 runs sampled)
compile-json-stringify obj x 16,001,284 ops/sec ±0.60% (89 runs sampled)
AJV Serialize obj x 8,746,636 ops/sec ±0.32% (95 runs sampled)
JSON stringify date x 651,567 ops/sec ±0.33% (95 runs sampled)
fast-json-stringify date format x 1,413,974 ops/sec ±0.47% (91 runs sampled)
compile-json-stringify date format x 648,176 ops/sec ±0.49% (93 runs sampled)
```

##### This branch ([bmenant:fix/toJSON](https://github.com/bmenant/fast-json-stringify/tree/fix/toJSON))

```
FJS creation x 5,882 ops/sec ±1.56% (88 runs sampled)
CJS creation x 129,776 ops/sec ±0.37% (87 runs sampled)
AJV Serialize creation x 60,253,718 ops/sec ±0.20% (95 runs sampled)
JSON.stringify array x 3,226 ops/sec ±0.39% (94 runs sampled)
fast-json-stringify array default x 6,797 ops/sec ±0.24% (93 runs sampled)
fast-json-stringify array json-stringify x 6,673 ops/sec ±0.16% (96 runs sampled)
compile-json-stringify array x 6,786 ops/sec ±0.42% (91 runs sampled)
AJV Serialize array x 6,880 ops/sec ±0.40% (95 runs sampled)
JSON.stringify large array x 149 ops/sec ±0.25% (83 runs sampled)
fast-json-stringify large array default x 78.14 ops/sec ±2.39% (46 runs sampled)
fast-json-stringify large array json-stringify x 146 ops/sec ±0.52% (82 runs sampled)
compile-json-stringify large array x 300 ops/sec ±0.14% (88 runs sampled)
AJV Serialize large array x 86.68 ops/sec ±0.22% (73 runs sampled)
JSON.stringify long string x 9,742 ops/sec ±0.17% (91 runs sampled)
fast-json-stringify long string x 9,633 ops/sec ±0.37% (93 runs sampled)
compile-json-stringify long string x 9,706 ops/sec ±0.41% (90 runs sampled)
AJV Serialize long string x 16,517 ops/sec ±0.15% (94 runs sampled)
JSON.stringify short string x 7,810,112 ops/sec ±0.49% (92 runs sampled)
fast-json-stringify short string x 37,329,072 ops/sec ±0.20% (94 runs sampled)
compile-json-stringify short string x 31,964,295 ops/sec ±0.33% (94 runs sampled)
AJV Serialize short string x 29,722,570 ops/sec ±0.34% (93 runs sampled)
JSON.stringify obj x 1,957,616 ops/sec ±0.10% (96 runs sampled)
fast-json-stringify obj x 7,125,018 ops/sec ±0.08% (94 runs sampled)
compile-json-stringify obj x 15,947,300 ops/sec ±0.47% (93 runs sampled)
AJV Serialize obj x 8,632,615 ops/sec ±0.18% (92 runs sampled)
JSON.stringify obj toJSON x 969,324 ops/sec ±0.25% (90 runs sampled)
fast-json-stringify obj toJSON x 6,802,310 ops/sec ±0.35% (94 runs sampled)
JSON stringify date x 655,908 ops/sec ±0.11% (94 runs sampled)
fast-json-stringify date format x 1,369,358 ops/sec ±0.12% (92 runs sampled)
compile-json-stringify date format x 651,198 ops/sec ±0.25% (96 runs sampled)
```
