### PR TITLE
benchmark: increase size of testing object

### DIFF
--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -163,12 +163,40 @@ const benchmarks = [
     schema: {
       type: 'object',
       properties: {
-        s: { type: 'string' },
-        n: { type: 'number' },
-        b: { type: 'boolean' }
+        s1: { type: 'string' },
+        n1: { type: 'number' },
+        b1: { type: 'boolean' },
+        s2: { type: 'string' },
+        n2: { type: 'number' },
+        b2: { type: 'boolean' },
+        s3: { type: 'string' },
+        n3: { type: 'number' },
+        b3: { type: 'boolean' },
+        s4: { type: 'string' },
+        n4: { type: 'number' },
+        b4: { type: 'boolean' },
+        s5: { type: 'string' },
+        n5: { type: 'number' },
+        b5: { type: 'boolean' }
       }
     },
-    input: { s: 'hello world', n: 42, b: true }
+    input: {
+      s1: 'hello world',
+      n1: 42,
+      b1: true,
+      s2: 'hello world',
+      n2: 42,
+      b2: true,
+      s3: 'hello world',
+      n3: 42,
+      b3: true,
+      s4: 'hello world',
+      n4: 42,
+      b4: true,
+      s5: 'hello world',
+      n5: 42,
+      b5: true
+    }
   }
 ]
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Small objects with variables of different types is very unstable for benchmarking for some reason. I tried manually remove unused empty if block and it decrease performance. + the problems I described here https://github.com/fastify/fast-json-stringify/pull/416#issuecomment-1133928883. When we increase object size it become more stable.