### PR TITLE
fix: set 23 hour cycle

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ class Serializer {
   asTime (date, skipQuotes) {
     const quotes = skipQuotes === true ? '' : '"'
     if (date instanceof Date) {
-      const hour = new Intl.DateTimeFormat('en', { hour: 'numeric', hour12: false }).format(date)
+      const hour = new Intl.DateTimeFormat('en', { hour: 'numeric', hourCycle: 'h23' }).format(date)
       const minute = new Intl.DateTimeFormat('en', { minute: 'numeric' }).format(date)
       const second = new Intl.DateTimeFormat('en', { second: 'numeric' }).format(date)
       return quotes + this.pad2Zeros(hour) + ':' + this.pad2Zeros(minute) + ':' + this.pad2Zeros(second) + quotes

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -97,6 +97,27 @@ test('render a date in a string when format is time as kk:mm:ss', (t) => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
+test('render a midnight time', (t) => {
+  t.plan(3)
+
+  const schema = {
+    title: 'a date in a string',
+    type: 'string',
+    format: 'time'
+  }
+  const midnight = new Date(new Date().setHours(24))
+
+  const validate = validator(schema)
+  const stringify = build(schema)
+  const output = stringify(midnight)
+
+  validate(JSON.parse(output))
+  t.equal(validate.errors, null)
+
+  t.equal(output, `"${moment(midnight).format('HH:mm:ss')}"`)
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})
+
 test('verify padding for rendered date in a string when format is time', (t) => {
   t.plan(3)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Right now date serialization can return 24 hours. "24:12:43". I'm not sure that this is expected.

That is the reason why ci fails sometimes.