### PR TITLE
fix: large array serialization

### DIFF
--- a/test/array.test.js
+++ b/test/array.test.js
@@ -344,7 +344,7 @@ buildTest({
 })
 
 buildTest({
-  title: 'large array with json-stringify mechanism',
+  title: 'large array of objects with json-stringify mechanism',
   type: 'object',
   properties: {
     ids: {
@@ -362,4 +362,84 @@ buildTest({
   ids: largeArray
 }, {
   largeArrayMechanism: 'json-stringify'
+})
+
+buildTest({
+  title: 'large array of strings with default mechanism',
+  type: 'object',
+  properties: {
+    ids: {
+      type: 'array',
+      items: { type: 'string' }
+    }
+  }
+}, {
+  ids: new Array(2e4).fill('string')
+}, {
+  largeArraySize: 2e4,
+  largeArrayMechanism: 'default'
+})
+
+buildTest({
+  title: 'large array of numbers with default mechanism',
+  type: 'object',
+  properties: {
+    ids: {
+      type: 'array',
+      items: { type: 'number' }
+    }
+  }
+}, {
+  ids: new Array(2e4).fill(42)
+}, {
+  largeArraySize: 2e4,
+  largeArrayMechanism: 'default'
+})
+
+buildTest({
+  title: 'large array of integers with default mechanism',
+  type: 'object',
+  properties: {
+    ids: {
+      type: 'array',
+      items: { type: 'integer' }
+    }
+  }
+}, {
+  ids: new Array(2e4).fill(42)
+}, {
+  largeArraySize: 2e4,
+  largeArrayMechanism: 'default'
+})
+
+buildTest({
+  title: 'large array of booleans with default mechanism',
+  type: 'object',
+  properties: {
+    ids: {
+      type: 'array',
+      items: { type: 'boolean' }
+    }
+  }
+}, {
+  ids: new Array(2e4).fill(true)
+}, {
+  largeArraySize: 2e4,
+  largeArrayMechanism: 'default'
+})
+
+buildTest({
+  title: 'large array of null values with default mechanism',
+  type: 'object',
+  properties: {
+    ids: {
+      type: 'array',
+      items: { type: 'null' }
+    }
+  }
+}, {
+  ids: new Array(2e4).fill(null)
+}, {
+  largeArraySize: 2e4,
+  largeArrayMechanism: 'default'
 })

--- a/test/nullable.test.js
+++ b/test/nullable.test.js
@@ -231,3 +231,216 @@ test('handle nullable time correctly', (t) => {
   t.same(result, JSON.stringify(data))
   t.same(JSON.parse(result), data)
 })
+
+test('large array of nullable strings with default mechanism', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      ids: {
+        type: 'array',
+        items: {
+          type: 'string',
+          nullable: true
+        }
+      }
+    }
+  }
+
+  const options = {
+    largeArraySize: 2e4,
+    largeArrayMechanism: 'default'
+  }
+
+  const stringify = build(schema, options)
+
+  const data = { ids: new Array(2e4).fill(null) }
+  const result = stringify(data)
+
+  t.same(result, JSON.stringify(data))
+  t.same(JSON.parse(result), data)
+})
+
+test('large array of nullable date-time strings with default mechanism', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      ids: {
+        type: 'array',
+        items: {
+          type: 'string',
+          format: 'date-time',
+          nullable: true
+        }
+      }
+    }
+  }
+
+  const options = {
+    largeArraySize: 2e4,
+    largeArrayMechanism: 'default'
+  }
+
+  const stringify = build(schema, options)
+
+  const data = { ids: new Array(2e4).fill(null) }
+  const result = stringify(data)
+
+  t.same(result, JSON.stringify(data))
+  t.same(JSON.parse(result), data)
+})
+
+test('large array of nullable date-time strings with default mechanism', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      ids: {
+        type: 'array',
+        items: {
+          type: 'string',
+          format: 'date',
+          nullable: true
+        }
+      }
+    }
+  }
+
+  const options = {
+    largeArraySize: 2e4,
+    largeArrayMechanism: 'default'
+  }
+
+  const stringify = build(schema, options)
+
+  const data = { ids: new Array(2e4).fill(null) }
+  const result = stringify(data)
+
+  t.same(result, JSON.stringify(data))
+  t.same(JSON.parse(result), data)
+})
+
+test('large array of nullable date-time strings with default mechanism', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      ids: {
+        type: 'array',
+        items: {
+          type: 'string',
+          format: 'time',
+          nullable: true
+        }
+      }
+    }
+  }
+
+  const options = {
+    largeArraySize: 2e4,
+    largeArrayMechanism: 'default'
+  }
+
+  const stringify = build(schema, options)
+
+  const data = { ids: new Array(2e4).fill(null) }
+  const result = stringify(data)
+
+  t.same(result, JSON.stringify(data))
+  t.same(JSON.parse(result), data)
+})
+
+test('large array of nullable numbers with default mechanism', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      ids: {
+        type: 'array',
+        items: {
+          type: 'number',
+          nullable: true
+        }
+      }
+    }
+  }
+
+  const options = {
+    largeArraySize: 2e4,
+    largeArrayMechanism: 'default'
+  }
+
+  const stringify = build(schema, options)
+
+  const data = { ids: new Array(2e4).fill(null) }
+  const result = stringify(data)
+
+  t.same(result, JSON.stringify(data))
+  t.same(JSON.parse(result), data)
+})
+
+test('large array of nullable integers with default mechanism', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      ids: {
+        type: 'array',
+        items: {
+          type: 'integer',
+          nullable: true
+        }
+      }
+    }
+  }
+
+  const options = {
+    largeArraySize: 2e4,
+    largeArrayMechanism: 'default'
+  }
+
+  const stringify = build(schema, options)
+
+  const data = { ids: new Array(2e4).fill(null) }
+  const result = stringify(data)
+
+  t.same(result, JSON.stringify(data))
+  t.same(JSON.parse(result), data)
+})
+
+test('large array of nullable booleans with default mechanism', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      ids: {
+        type: 'array',
+        items: {
+          type: 'boolean',
+          nullable: true
+        }
+      }
+    }
+  }
+
+  const options = {
+    largeArraySize: 2e4,
+    largeArrayMechanism: 'default'
+  }
+
+  const stringify = build(schema, options)
+
+  const data = { ids: new Array(2e4).fill(null) }
+  const result = stringify(data)
+
+  t.same(result, JSON.stringify(data))
+  t.same(JSON.parse(result), data)
+})


### PR DESCRIPTION
Depends on #437 

This PR fixed two bugs:
1. Add support for nullable large arrays.
2. Fix large array string serialization.
If we pass the `asString` function
https://github.com/fastify/fast-json-stringify/blob/4bec21e6ee6951879958247f0299b11a25490d19/index.js#L159
to this map as `mapFnName `
https://github.com/fastify/fast-json-stringify/blob/4bec21e6ee6951879958247f0299b11a25490d19/index.js#L1043
it will receive the array index as the second argument and will skip quotes