### PR TITLE
fix: throw an error if none of oneOf/anyOf options match

### DIFF
--- a/index.js
+++ b/index.js
@@ -1214,11 +1214,9 @@ function nested (laterCode, locationPath, key, location, subKey, isArray) {
           laterCode = nestedResult.laterCode
         })
 
-        if (!isArray) {
-          code += `
-            else json+= null
-          `
-        }
+        code += `
+          else throw new Error(\`The value $\{JSON.stringify(obj${accessor})} does not match schema definition.\`)
+        `
       } else if (isEmpty(schema)) {
         code += `
           json += JSON.stringify(obj${accessor})

--- a/test/anyof.test.js
+++ b/test/anyof.test.js
@@ -113,11 +113,7 @@ test('object with field of type string and coercion disable ', (t) => {
     }
   }
   const stringify = build(schema)
-
-  const value = stringify({
-    str: 1
-  })
-  t.equal(value, '{"str":null}')
+  t.throws(() => stringify({ str: 1 }))
 })
 
 test('object with field of type string and coercion enable ', (t) => {
@@ -224,7 +220,7 @@ test('symbol value in schema', (t) => {
   t.equal(stringify({ value: 'foo' }), '{"value":"foo"}')
   t.equal(stringify({ value: 'bar' }), '{"value":"bar"}')
   t.equal(stringify({ value: 'baz' }), '{"value":"baz"}')
-  t.equal(stringify({ value: 'qux' }), '{"value":null}')
+  t.throws(() => stringify({ value: 'qux' }))
 })
 
 test('anyOf and $ref together', (t) => {
@@ -513,7 +509,5 @@ test('anyOf object with invalid field date of type string with format or null', 
   }
 
   const withOneOfStringify = build(withOneOfSchema)
-  t.equal(withOneOfStringify({
-    prop: toStringify
-  }), '{"prop":null}')
+  t.throws(() => withOneOfStringify({ prop: toStringify }))
 })

--- a/test/debug-mode.test.js
+++ b/test/debug-mode.test.js
@@ -98,5 +98,5 @@ test('to string auto-consistent with ajv-formats', t => {
   const compiled = fjs.restore(debugMode)
   const tobe = JSON.stringify({ str: 'foo@bar.com' })
   t.same(compiled({ str: 'foo@bar.com' }), tobe)
-  t.same(compiled({ str: 'foo' }), JSON.stringify({ str: null }), 'invalid format is ignored')
+  t.throws(() => compiled({ str: 'foo' }))
 })

--- a/test/oneof.test.js
+++ b/test/oneof.test.js
@@ -104,11 +104,7 @@ test('object with field of type string and coercion disable ', (t) => {
     }
   }
   const stringify = build(schema)
-
-  const value = stringify({
-    str: 1
-  })
-  t.equal(value, '{"str":null}')
+  t.throws(() => stringify({ str: 1 }))
 })
 
 test('object with field of type string and coercion enable ', (t) => {
@@ -403,7 +399,7 @@ test('oneOf object with field of type string with format or null', (t) => {
 })
 
 test('one array item match oneOf types', (t) => {
-  t.plan(1)
+  t.plan(3)
 
   const schema = {
     type: 'object',
@@ -429,15 +425,13 @@ test('one array item match oneOf types', (t) => {
 
   const stringify = build(schema)
 
-  const responseWithMappedType = stringify({
-    data: [false, 'foo']
-  })
-
-  t.equal('{"data":["foo"]}', responseWithMappedType)
+  t.equal(stringify({ data: ['foo'] }), '{"data":["foo"]}')
+  t.equal(stringify({ data: [1] }), '{"data":[1]}')
+  t.throws(() => stringify({ data: [false, 'foo'] }))
 })
 
 test('some array items match oneOf types', (t) => {
-  t.plan(1)
+  t.plan(2)
 
   const schema = {
     type: 'object',
@@ -463,11 +457,8 @@ test('some array items match oneOf types', (t) => {
 
   const stringify = build(schema)
 
-  const responseWithMappedTypes = stringify({
-    data: [false, 'foo', true, 5]
-  })
-
-  t.equal('{"data":["foo",5]}', responseWithMappedTypes)
+  t.equal(stringify({ data: ['foo', 5] }), '{"data":["foo",5]}')
+  t.throws(() => stringify({ data: [false, 'foo', true, 5] }))
 })
 
 test('all array items does not match oneOf types', (t) => {
@@ -497,9 +488,5 @@ test('all array items does not match oneOf types', (t) => {
 
   const stringify = build(schema)
 
-  const emptyResponse = stringify({
-    data: [null, false, true, undefined, [], {}]
-  })
-
-  t.equal('{"data":[]}', emptyResponse)
+  t.throws(() => stringify({ data: [null, false, true, undefined, [], {}] }))
 })


### PR DESCRIPTION
This problem is very similar to https://github.com/fastify/fast-json-stringify/issues/431#issuecomment-1138809786.

What should we do if none of oneOf/anyOf options match? Right now if it's an object it will set the null value, if it's an array it will skip the value.

This can be considered a significant change and can be landed in semver major release.