### PR TITLE
fix: ref with same id in properties

### DIFF
--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -1317,7 +1317,7 @@ test('ref with same id in properties', (t) => {
 })
 
 test('dedup refs id', (t) => {
-  t.plan(3)
+  t.plan(5)
 
   const externalSchema = {
     ObjectId: {
@@ -1337,6 +1337,7 @@ test('dedup refs id', (t) => {
       const schema = {
         type: 'object',
         properties: {
+          _id: { $ref: 'ObjectId' },
           image: {
             anyOf: [
               { $ref: 'ObjectId' },
@@ -1451,6 +1452,74 @@ test('dedup refs id', (t) => {
     {
       const output = stringify({ _id: 'foo', image: 'hello' })
       t.equal(output, '{"_id":"foo","image":"hello"}')
+    }
+  })
+
+  t.test('same id refs cross multiple anyOf', (t) => {
+    t.plan(1)
+
+    const externalSchema = {
+      ObjectId: {
+        $id: 'ObjectId',
+        type: 'string'
+      }
+    }
+
+    const schema = {
+      type: 'object',
+      properties: {
+        _id: { $ref: 'ObjectId' },
+        image: {
+          anyOf: [
+            { $ref: 'ObjectId' }
+          ]
+        },
+        owner: {
+          anyOf: [
+            { $ref: 'ObjectId' }
+          ]
+        }
+      }
+    }
+
+    const stringify = build(schema, { schema: externalSchema })
+    {
+      const output = stringify({ _id: 'foo', image: 'hello', owner: 'world' })
+      t.equal(output, '{"_id":"foo","image":"hello","owner":"world"}')
+    }
+  })
+
+  t.test('same id refs cross multiple oneOf', (t) => {
+    t.plan(1)
+
+    const externalSchema = {
+      ObjectId: {
+        $id: 'ObjectId',
+        type: 'string'
+      }
+    }
+
+    const schema = {
+      type: 'object',
+      properties: {
+        _id: { $ref: 'ObjectId' },
+        image: {
+          oneOf: [
+            { $ref: 'ObjectId' }
+          ]
+        },
+        owner: {
+          oneOf: [
+            { $ref: 'ObjectId' }
+          ]
+        }
+      }
+    }
+
+    const stringify = build(schema, { schema: externalSchema })
+    {
+      const output = stringify({ _id: 'foo', image: 'hello', owner: 'world' })
+      t.equal(output, '{"_id":"foo","image":"hello","owner":"world"}')
     }
   })
 })


### PR DESCRIPTION
I don't think it is a good fix, but it just works.
Fixes https://github.com/fastify/fastify/issues/4028

This PR is a fix before #462 lands. Since #462 changed a lot in the internal ref resolve and may introduce breaking change.
I see the needs of a temporary fix.

@ivan-tymoshenko do you have better idea on this?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
