### PR TITLE
fix: reference after merge allOf

### DIFF
--- a/index.js
+++ b/index.js
@@ -489,6 +489,10 @@ function mergeAllOfSchema (location, schema, mergedSchema) {
     }
   }
   delete mergedSchema.allOf
+
+  mergedSchema.$id = `merged_${randomUUID()}`
+  ajvInstance.addSchema(mergedSchema)
+  location.schemaId = mergedSchema.$id
 }
 
 function buildInnerObject (location) {

--- a/test/issue-479.test.js
+++ b/test/issue-479.test.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const { test } = require('tap')
+const build = require('..')
+
+test('should validate anyOf after allOf merge', (t) => {
+  t.plan(1)
+
+  const schema = {
+    $id: 'schema',
+    type: 'object',
+    allOf: [
+      {
+        $id: 'base',
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string'
+          }
+        },
+        required: [
+          'name'
+        ]
+      },
+      {
+        $id: 'inner_schema',
+        type: 'object',
+        properties: {
+          union: {
+            $id: '#id',
+            anyOf: [
+              {
+
+                $id: 'guid',
+                type: 'string'
+              },
+              {
+
+                $id: 'email',
+                type: 'string'
+              }
+            ]
+          }
+        },
+        required: [
+          'union'
+        ]
+      }
+    ]
+  }
+
+  const stringify = build(schema)
+
+  t.equal(
+    stringify({ name: 'foo', union: 'a8f1cc50-5530-5c62-9109-5ba9589a6ae1' }),
+    '{"name":"foo","union":"a8f1cc50-5530-5c62-9109-5ba9589a6ae1"}')
+})


### PR DESCRIPTION
fixes https://github.com/fastify/fast-json-stringify/issues/479

The issue:

after the merge of the `allOf` object, we lose the `$id`s of the merged objects, so it is not possible to call `ajv.validate` when one of the `allOf` objects contains an `anyOf` or `allOf` item.

This fix adds a reference to the merged object to use it as a validator.

Any better ideas?