### PR TITLE
fix: reset json pointer in merged allOf schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -493,6 +493,7 @@ function mergeAllOfSchema (location, schema, mergedSchema) {
   mergedSchema.$id = `merged_${randomUUID()}`
   ajvInstance.addSchema(mergedSchema)
   location.schemaId = mergedSchema.$id
+  location.jsonPointer = '#'
 }
 
 function buildInnerObject (location) {

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -1891,3 +1891,38 @@ test('input schema is not mutated', (t) => {
   t.equal(output, '{"obj":"test"}')
   t.same(schema, clonedSchema)
 })
+
+test('anyOf inside allOf', (t) => {
+  t.plan(1)
+
+  const schema = {
+    anyOf: [
+      {
+        type: 'object',
+        allOf: [
+          {
+            properties: {
+              a: {
+                anyOf: [
+                  { const: 'A1' },
+                  { const: 'A2' }
+                ]
+              }
+            }
+          },
+          {
+            properties: {
+              b: { const: 'B' }
+            }
+          }
+        ]
+      }
+    ]
+  }
+
+  const object = { a: 'A1', b: 'B' }
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  t.equal(output, JSON.stringify(object))
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Fix #481
Fix https://github.com/fastify/fastify/issues/4092

#480 sets merged schema as a location, but doesn't set json pointer to the root of this merged schema.