### PR TITLE
perf: replace deepmerge npm-package with @fastify/deepmerge

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 /* eslint no-prototype-builtins: 0 */
 
-const merge = require('deepmerge')
+const merge = require('@fastify/deepmerge')()
 const clone = require('rfdc')({ proto: true })
 const fjsCloned = Symbol('fast-json-stringify.cloned')
 const { randomUUID } = require('crypto')

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "webpack": "^5.40.0"
   },
   "dependencies": {
+    "@fastify/deepmerge": "^1.0.0",
     "ajv": "^8.10.0",
     "ajv-formats": "^2.1.1",
-    "deepmerge": "^4.2.2",
     "fast-uri": "^2.1.0",
     "rfdc": "^1.2.0"
   },


### PR DESCRIPTION
I have just one worry: @fastify/deepmerge has prototype protection handling. What happens if in the json schema an type: object has the key prototype or constructor? It would mean that those keys are not merged/carried over. should we change deepmerge to have an option where we create Objects by using Object.create(null) so that a prototype pollution is not possible?