### PR TITLE
Fix stringify for non-standard, non-Date objects like luxon.DateTime

### DIFF
--- a/index.js
+++ b/index.js
@@ -901,7 +901,7 @@ function buildValue (location, input) {
           switch (type) {
             case 'string': {
               code += `
-                ${statement}(${input} === null || typeof ${input} === "${type}" || ${input} instanceof RegExp || (typeof ${input} === "object" && Object.hasOwnProperty.call(${input}, "toString")))
+                ${statement}(${input} === null || typeof ${input} === "${type}" || ${input} instanceof RegExp || (typeof ${input} === "object" && ((!(${input} instanceof Date) && typeof ${input}["toString"] === "function" && ${input}.__proto__.constructor.name !== "Object") || Object.hasOwnProperty.call(${input}, "toString"))))
                   ${nestedResult}
               `
               break

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -525,3 +525,18 @@ test('nullable date', (t) => {
 
   t.same(result, `"${DateTime.fromJSDate(data).toISODate()}"`)
 })
+
+test('Luxon Date stringify', (t) => {
+  t.plan(1)
+
+  const schema = {
+    type: 'string',
+    format: 'date-time'
+  }
+
+  const date = DateTime.now()
+  const stringify = build(schema)
+  const output = stringify(date)
+
+  t.equal(output, `"${date.toISO()}"`)
+})


### PR DESCRIPTION
#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added (no changes required in this case)
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Fixes #492 

The check has become quite ugly, mainly because

- All Objects have a toString and in that case we need to hasOwnProperty check, but only for objects whose constructor is not that of Object
- Logic for Date objects is different so we need to filter these out

Benchmark:

```
$ npm run bench

> fast-json-stringify@5.1.0 bench
> node ./benchmark/bench.js

short string............................................. x 46,201,257 ops/sec ±0.71% (593 runs sampled)
long string.............................................. x 11,675 ops/sec ±0.42% (594 runs sampled)
number................................................... x 988,806,479 ops/sec ±0.52% (594 runs sampled)
integer.................................................. x 149,494,519 ops/sec ±0.66% (593 runs sampled)
formatted date-time...................................... x 4,269,928 ops/sec ±0.43% (594 runs sampled)
formatted date........................................... x 2,846,144 ops/sec ±0.26% (595 runs sampled)
formatted time........................................... x 2,850,038 ops/sec ±0.27% (594 runs sampled)
short array of numbers................................... x 103,756 ops/sec ±0.48% (592 runs sampled)
short array of integers.................................. x 95,856 ops/sec ±0.69% (594 runs sampled)
short array of short strings............................. x 26,121 ops/sec ±0.32% (595 runs sampled)
short array of long strings.............................. x 26,071 ops/sec ±0.42% (594 runs sampled)
short array of objects with properties of different types x 14,203 ops/sec ±0.57% (592 runs sampled)
object with number property.............................. x 995,475,152 ops/sec ±0.28% (596 runs sampled)
object with integer property............................. x 151,170,986 ops/sec ±0.71% (594 runs sampled)
object with short string property........................ x 29,965,328 ops/sec ±0.31% (594 runs sampled)
object with long string property......................... x 11,737 ops/sec ±0.45% (594 runs sampled)
object with properties of different types................ x 3,142,251 ops/sec ±0.54% (594 runs sampled)
```
