### PR TITLE
Improve performance for const schemas

### DIFF
--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -255,6 +255,18 @@ const benchmarks = [
     input: {
       foo: { bar: 'baz' }
     }
+  },
+  {
+    name: 'object with const null property',
+    schema: {
+      type: 'object',
+      properties: {
+        foo: { const: null }
+      }
+    },
+    input: {
+      foo: null
+    }
   }
 ]
 
@@ -264,10 +276,10 @@ async function runBenchmark (benchmark) {
   return new Promise((resolve, reject) => {
     let result = null
     worker.on('error', reject)
-    worker.on('message', (benchResult) => {
+    worker.on('message', benchResult => {
       result = benchResult
     })
-    worker.on('exit', (code) => {
+    worker.on('exit', code => {
       if (code === 0) {
         resolve(result)
       } else {

--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -276,10 +276,10 @@ async function runBenchmark (benchmark) {
   return new Promise((resolve, reject) => {
     let result = null
     worker.on('error', reject)
-    worker.on('message', benchResult => {
+    worker.on('message', (benchResult) => {
       result = benchResult
     })
-    worker.on('exit', code => {
+    worker.on('exit', (code) => {
       if (code === 0) {
         resolve(result)
       } else {

--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -213,6 +213,48 @@ const benchmarks = [
       n5: 42,
       b5: true
     }
+  },
+  {
+    name: 'object with const string property',
+    schema: {
+      type: 'object',
+      properties: {
+        a: { const: 'const string' }
+      }
+    },
+    input: { a: 'const string' }
+  },
+  {
+    name: 'object with const number property',
+    schema: {
+      type: 'object',
+      properties: {
+        a: { const: 1 }
+      }
+    },
+    input: { a: 1 }
+  },
+  {
+    name: 'object with const bool property',
+    schema: {
+      type: 'object',
+      properties: {
+        a: { const: true }
+      }
+    },
+    input: { a: true }
+  },
+  {
+    name: 'object with const object property',
+    schema: {
+      type: 'object',
+      properties: {
+        foo: { const: { bar: 'baz' } }
+      }
+    },
+    input: {
+      foo: { bar: 'baz' }
+    }
   }
 ]
 

--- a/example.js
+++ b/example.js
@@ -3,12 +3,79 @@ const stringify = fastJson({
   title: 'Example Schema',
   type: 'object',
   properties: {
-    noRequired: { const: 'hello world' }
+    firstName: {
+      type: 'string'
+    },
+    lastName: {
+      type: 'string'
+    },
+    age: {
+      description: 'Age in years',
+      type: 'integer'
+    },
+    now: {
+      type: 'string'
+    },
+    birthdate: {
+      type: ['string'],
+      format: 'date-time'
+    },
+    reg: {
+      type: 'string'
+    },
+    obj: {
+      type: 'object',
+      properties: {
+        bool: {
+          type: 'boolean'
+        }
+      }
+    },
+    arr: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          str: {
+            type: 'string'
+          }
+        }
+      }
+    }
   },
-  required: ['noRequired']
+  required: ['now'],
+  patternProperties: {
+    '.*foo$': {
+      type: 'string'
+    },
+    test: {
+      type: 'number'
+    },
+    date: {
+      type: 'string',
+      format: 'date-time'
+    }
+  },
+  additionalProperties: {
+    type: 'string'
+  }
 })
 
-const result = stringify({
-})
-
-console.log({ result })
+console.log(
+  stringify({
+    firstName: 'Matteo',
+    lastName: 'Collina',
+    age: 32,
+    now: new Date(),
+    reg: /"([^"]|\\")*"/,
+    foo: 'hello',
+    numfoo: 42,
+    test: 42,
+    strtest: '23',
+    arr: [{ str: 'stark' }, { str: 'lannister' }],
+    obj: { bool: true },
+    notmatch: 'valar morghulis',
+    notmatchobj: { a: true },
+    notmatchnum: 42
+  })
+)

--- a/example.js
+++ b/example.js
@@ -61,21 +61,19 @@ const stringify = fastJson({
   }
 })
 
-console.log(
-  stringify({
-    firstName: 'Matteo',
-    lastName: 'Collina',
-    age: 32,
-    now: new Date(),
-    reg: /"([^"]|\\")*"/,
-    foo: 'hello',
-    numfoo: 42,
-    test: 42,
-    strtest: '23',
-    arr: [{ str: 'stark' }, { str: 'lannister' }],
-    obj: { bool: true },
-    notmatch: 'valar morghulis',
-    notmatchobj: { a: true },
-    notmatchnum: 42
-  })
-)
+console.log(stringify({
+  firstName: 'Matteo',
+  lastName: 'Collina',
+  age: 32,
+  now: new Date(),
+  reg: /"([^"]|\\")*"/,
+  foo: 'hello',
+  numfoo: 42,
+  test: 42,
+  strtest: '23',
+  arr: [{ str: 'stark' }, { str: 'lannister' }],
+  obj: { bool: true },
+  notmatch: 'valar morghulis',
+  notmatchobj: { a: true },
+  notmatchnum: 42
+}))

--- a/index.js
+++ b/index.js
@@ -240,6 +240,11 @@ function inferTypeByKeyword (schema) {
   for (var keyword of numberKeywords) {
     if (keyword in schema) return 'number'
   }
+
+  if (schema.const && typeof schema.const !== 'object') {
+    return typeof schema.const
+  }
+
   return schema.type
 }
 

--- a/index.js
+++ b/index.js
@@ -359,7 +359,7 @@ function buildCode (location) {
 
     const sanitized = JSON.stringify(key)
     const asString = JSON.stringify(sanitized)
-    const isRequired = schema.required !== undefined && schema.required.findIndex(item => item === key) !== -1
+    const isRequired = schema.required !== undefined && schema.required.indexOf(key) !== -1
     const isConst = schema.properties[key].const !== undefined
     // Using obj['key'] !== undefined instead of obj.hasOwnProperty(prop) for perf reasons,
     // see https://github.com/mcollina/fast-json-stringify/pull/3 for discussion.

--- a/index.js
+++ b/index.js
@@ -387,7 +387,7 @@ function buildCode (location) {
         JSON.stringify(constValue)
       )}
       `
-    } else if (required.includes(key)) {
+    } else if (isRequired) {
       code += `
       } else {
         throw new Error('${sanitized} is required!')

--- a/index.js
+++ b/index.js
@@ -932,7 +932,7 @@ function buildValue (location, input) {
           switch (type) {
             case 'string': {
               code += `
-                ${statement}(${input} === null || typeof ${input} === "${type}" || ${input} instanceof RegExp || (typeof ${input} === "object" && Object.hasOwnProperty.call(${input}, "toString")))
+                ${statement}(${input} === null || typeof ${input} === "${type}" || ${input} instanceof RegExp || (typeof ${input} === "object" && Object.prototype.hasOwnProperty.call(${input}, "toString")))
                   ${nestedResult}
               `
               break
@@ -1018,7 +1018,10 @@ function extendDateTimeType (schema) {
 function isEmpty (schema) {
   // eslint-disable-next-line
   for (var key in schema) {
-    if (schema.hasOwnProperty(key) && schema[key] !== undefined) {
+    if (
+      Object.prototype.hasOwnProperty.call(schema, key) &&
+      schema[key] !== undefined
+    ) {
       return false
     }
   }

--- a/index.js
+++ b/index.js
@@ -241,16 +241,6 @@ function inferTypeByKeyword (schema) {
     if (keyword in schema) return 'number'
   }
 
-  if (schema.const) {
-    if (typeof schema.const !== 'object') {
-      return typeof schema.const
-    } else if (schema.const === null) {
-      return 'null'
-    } else if (Array.isArray(schema.const)) {
-      return 'array'
-    }
-  }
-
   return schema.type
 }
 
@@ -827,6 +817,7 @@ function buildValue (location, input) {
     code += `
             json += '${stringifiedSchema}'
         `
+    return code
   } else switchTypeSchema()
 
   return code

--- a/index.js
+++ b/index.js
@@ -1013,6 +1013,6 @@ module.exports.validLargeArrayMechanisms = validLargeArrayMechanisms
 module.exports.restore = function ({ code, ajv }) {
   const serializer = new Serializer()
   // eslint-disable-next-line
-  return Function.apply(null, ["ajv", "serializer", code])
+  return Function.apply(null, ['ajv', 'serializer', code])
     .apply(null, [ajv, serializer])
 }

--- a/test/const.test.js
+++ b/test/const.test.js
@@ -24,6 +24,66 @@ test('schema with const string', (t) => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
+test('schema with const bool', t => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      foo: { const: true }
+    }
+  }
+
+  const validate = validator(schema)
+  const stringify = build(schema)
+  const output = stringify({
+    foo: true
+  })
+
+  t.equal(output, '{"foo":true}')
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})
+
+test('schema with const number', t => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      foo: { const: 1 }
+    }
+  }
+
+  const validate = validator(schema)
+  const stringify = build(schema)
+  const output = stringify({
+    foo: 1
+  })
+
+  t.equal(output, '{"foo":1}')
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})
+
+test('schema with const null', t => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      foo: { const: null }
+    }
+  }
+
+  const validate = validator(schema)
+  const stringify = build(schema)
+  const output = stringify({
+    foo: null
+  })
+
+  t.equal(output, '{"foo":null}')
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})
+
 test('schema with const object', (t) => {
   t.plan(2)
 

--- a/test/const.test.js
+++ b/test/const.test.js
@@ -137,12 +137,61 @@ test('schema with const and invalid object', (t) => {
 
   const stringify = build(schema)
   try {
-    const result = stringify({
+    stringify({
       foo: { foo: 'baz' }
     })
-    console.log({ result })
   } catch (err) {
     t.match(err.message, /^Item .* does not match schema definition/, 'Given object has invalid const value')
+    t.ok(err)
+  }
+})
+
+test('schema with const and invalid number', t => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      foo: { const: 1 }
+    }
+  }
+
+  const stringify = build(schema)
+  try {
+    stringify({
+      foo: 2
+    })
+  } catch (err) {
+    t.match(
+      err.message,
+      /^Item .* does not match schema definition/,
+      'Given object has invalid const value'
+    )
+    t.ok(err)
+  }
+})
+
+test('schema with const and invalid string', t => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      foo: { const: 'hello' }
+    }
+  }
+
+  const stringify = build(schema)
+  try {
+    stringify({
+      foo: 'hell'
+    })
+  } catch (err) {
+    t.match(
+      err.message,
+      /^Item .* does not match schema definition/,
+      'Given object has invalid const value'
+    )
     t.ok(err)
   }
 })

--- a/test/const.test.js
+++ b/test/const.test.js
@@ -84,6 +84,26 @@ test('schema with const null', t => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
+test('schema with const array', t => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      foo: { const: [1, 2, 3] }
+    }
+  }
+
+  const validate = validator(schema)
+  const stringify = build(schema)
+  const output = stringify({
+    foo: [1, 2, 3]
+  })
+
+  t.equal(output, '{"foo":[1,2,3]}')
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})
+
 test('schema with const object', (t) => {
   t.plan(2)
 
@@ -117,9 +137,10 @@ test('schema with const and invalid object', (t) => {
 
   const stringify = build(schema)
   try {
-    stringify({
+    const result = stringify({
       foo: { foo: 'baz' }
     })
+    console.log({ result })
   } catch (err) {
     t.match(err.message, /^Item .* does not match schema definition/, 'Given object has invalid const value')
     t.ok(err)

--- a/test/const.test.js
+++ b/test/const.test.js
@@ -4,7 +4,7 @@ const test = require('tap').test
 const validator = require('is-my-json-valid')
 const build = require('..')
 
-test('schema with const string', t => {
+test('schema with const string', (t) => {
   t.plan(2)
 
   const schema = {
@@ -24,7 +24,7 @@ test('schema with const string', t => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const string and different input', t => {
+test('schema with const string and different input', (t) => {
   t.plan(2)
 
   const schema = {
@@ -44,7 +44,7 @@ test('schema with const string and different input', t => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const string and different type input', t => {
+test('schema with const string and different type input', (t) => {
   t.plan(2)
 
   const schema = {
@@ -64,7 +64,7 @@ test('schema with const string and different type input', t => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const string and no input', t => {
+test('schema with const string and no input', (t) => {
   t.plan(2)
 
   const schema = {
@@ -82,26 +82,7 @@ test('schema with const string and no input', t => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const string and no input but required property', t => {
-  t.plan(2)
-
-  const schema = {
-    type: 'object',
-    properties: {
-      foo: { const: 'bar' }
-    },
-    required: ['foo']
-  }
-
-  const validate = validator(schema)
-  const stringify = build(schema)
-  const output = stringify({})
-
-  t.equal(output, '{"foo":"bar"}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
-})
-
-test('schema with const number', t => {
+test('schema with const number', (t) => {
   t.plan(2)
 
   const schema = {
@@ -121,7 +102,7 @@ test('schema with const number', t => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const number and different input', t => {
+test('schema with const number and different input', (t) => {
   t.plan(2)
 
   const schema = {
@@ -141,7 +122,7 @@ test('schema with const number and different input', t => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const bool', t => {
+test('schema with const bool', (t) => {
   t.plan(2)
 
   const schema = {
@@ -161,7 +142,7 @@ test('schema with const bool', t => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const number', t => {
+test('schema with const number', (t) => {
   t.plan(2)
 
   const schema = {
@@ -181,7 +162,7 @@ test('schema with const number', t => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const null', t => {
+test('schema with const null', (t) => {
   t.plan(2)
 
   const schema = {
@@ -201,7 +182,7 @@ test('schema with const null', t => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const array', t => {
+test('schema with const array', (t) => {
   t.plan(2)
 
   const schema = {
@@ -221,7 +202,7 @@ test('schema with const array', t => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const object', t => {
+test('schema with const object', (t) => {
   t.plan(2)
 
   const schema = {
@@ -241,7 +222,57 @@ test('schema with const object', t => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const and invalid object', t => {
+test('schema with const and null as type', (t) => {
+  t.plan(4)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      foo: { type: ['string', 'null'], const: 'baz' }
+    }
+  }
+
+  const validate = validator(schema)
+  const stringify = build(schema)
+  const output = stringify({
+    foo: null
+  })
+
+  t.equal(output, '{"foo":null}')
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+
+  const output2 = stringify({ foo: 'baz' })
+  t.equal(output2, '{"foo":"baz"}')
+  t.ok(validate(JSON.parse(output2)), 'valid schema')
+})
+
+test('schema with const as nullable', (t) => {
+  t.plan(4)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      foo: { nullable: true, const: 'baz' }
+    }
+  }
+
+  const validate = validator(schema)
+  const stringify = build(schema)
+  const output = stringify({
+    foo: null
+  })
+
+  t.equal(output, '{"foo":null}')
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+
+  const output2 = stringify({
+    foo: 'baz'
+  })
+  t.equal(output2, '{"foo":"baz"}')
+  t.ok(validate(JSON.parse(output2)), 'valid schema')
+})
+
+test('schema with const and invalid object', (t) => {
   t.plan(2)
 
   const schema = {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

As per issue https://github.com/fastify/fast-json-stringify/issues/502, when using a const schema, the performance degrades. This is the continuation of #505.

### Benchmark 
Pre PR
<img width="829" alt="Screenshot 2022-08-16 alle 10 50 37" src="https://user-images.githubusercontent.com/37077048/184842079-5b642410-7897-45e5-936f-e374b75abff6.png">

Post PR
<img width="719" alt="Screenshot 2022-08-25 alle 18 46 08" src="https://user-images.githubusercontent.com/37077048/186725944-119975ce-b2c4-4790-a193-b75f35efd821.png">

This PR supports nullable values:
```javascript
test('schema with const string and no input', t => {
  t.plan(2)

  const schema = {
    type: 'object',
    properties: {
      foo: { const: 'bar' }
    }
  }

  const validate = validator(schema)
  const stringify = build(schema)
  const output = stringify({})

  t.equal(output, '{}')
  t.ok(validate(JSON.parse(output)), 'valid schema')
})
```

Or it coerces the value to the const property if it is required
```javascript

test('schema with const string and no input but required property', t => {
  t.plan(2)

  const schema = {
    type: 'object',
    properties: {
      foo: { const: 'bar' }
    },
    required: ['foo']
  }

  const validate = validator(schema)
  const stringify = build(schema)
  const output = stringify({})

  t.equal(output, '{"foo":"bar"}')
  t.ok(validate(JSON.parse(output)), 'valid schema')
})
```
