### PR TITLE
fix: toString method validation check

### DIFF
--- a/index.js
+++ b/index.js
@@ -901,7 +901,17 @@ function buildValue (location, input) {
           switch (type) {
             case 'string': {
               code += `
-                ${statement}(${input} === null || typeof ${input} === "${type}" || ${input} instanceof RegExp || (typeof ${input} === "object" && Object.prototype.hasOwnProperty.call(${input}, "toString")))
+                ${statement}(
+                  typeof ${input} === "string" ||
+                  ${input} === null ||
+                  ${input} instanceof RegExp ||
+                  (
+                    typeof ${input} === "object" &&
+                    typeof ${input}.toString === "function" &&
+                    ${input}.toString !== Object.prototype.toString &&
+                    !(${input} instanceof Date)
+                  )
+                )
                   ${nestedResult}
               `
               break

--- a/test/typesArray.test.js
+++ b/test/typesArray.test.js
@@ -438,6 +438,35 @@ test('object that is simultaneously a string and a json switched', (t) => {
   t.equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
 })
 
+test('class instance that is simultaneously a string and a json', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      simultaneously: {
+        type: ['string', 'object'],
+        properties: {
+          foo: { type: 'string' }
+        }
+      }
+    }
+  }
+
+  class Test {
+    toString () { return 'hello' }
+  }
+
+  const likeObjectId = new Test()
+
+  const stringify = build(schema)
+  const valueStr = stringify({ simultaneously: likeObjectId })
+  t.equal(valueStr, '{"simultaneously":"hello"}')
+
+  const valueObj = stringify({ simultaneously: { foo: likeObjectId } })
+  t.equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
+})
+
 test('should throw an error when type is array and object is null', (t) => {
   t.plan(1)
   const schema = {


### PR DESCRIPTION
Fix #492 

I think that this is a good opportunity to discuss this check. It says that if an object has a defined custom `toString` method, we should validate it as a string. There are two points why I think this is a bad check.

1. We don't coerce types during type validation because, otherwise, everything can be coerced to the string. Numbers and booleans also have the toString method, but we don't count them as a string type.

2. Ajv also does not use type coercion during schema validation, so the `toString` method won't be checked if you have anyOf/oneOf instead of a type array.

I want to drop this check in some major release of FJS/Fastify. I would like to heat your thoughts about it.