### PR TITLE
feat: drop nullable const support

### DIFF
--- a/index.js
+++ b/index.js
@@ -765,12 +765,6 @@ function buildValue (location, input) {
   let funcName
 
   if ('const' in schema) {
-    if (nullable) {
-      code += `
-        json += ${input} === null ? 'null' : '${JSON.stringify(schema.const)}'
-      `
-      return code
-    }
     code += `json += '${JSON.stringify(schema.const)}'`
     return code
   }

--- a/test/const.test.js
+++ b/test/const.test.js
@@ -238,7 +238,7 @@ test('schema with const and null as type', (t) => {
     foo: null
   })
 
-  t.equal(output, '{"foo":null}')
+  t.equal(output, '{"foo":"baz"}')
   t.ok(validate(JSON.parse(output)), 'valid schema')
 
   const output2 = stringify({ foo: 'baz' })
@@ -262,7 +262,7 @@ test('schema with const as nullable', (t) => {
     foo: null
   })
 
-  t.equal(output, '{"foo":null}')
+  t.equal(output, '{"foo":"baz"}')
   t.ok(validate(JSON.parse(output)), 'valid schema')
 
   const output2 = stringify({


### PR DESCRIPTION
❗BREAKING CHANGES

I didn't check it here #511 but turns out if the schema has const property, it can't be nullable.

If I have a schema like that: 
```json
{ "type": ["string", "null"], "const": "abc" }
```
or 
```json
{ "type": "string", "nullable": true, "const": "abc" }
```
it will validate the `null` value as false. That means if we serialize the `null` value as `null`, the serialized object would fail the validation.

P.S. I was confused because I saw the validation check, but it turns out that `is-my-json-valid` doesn't handle `const` check at all.
https://github.com/fastify/fast-json-stringify/blob/ab900c85f1dd047da1a7a94b5b0b69f782434fe1/test/const.test.js#L242




