### PR TITLE
Use ajv for schema validation tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -765,12 +765,6 @@ function buildValue (location, input) {
   let funcName
 
   if ('const' in schema) {
-    if (nullable) {
-      code += `
-        json += ${input} === null ? 'null' : '${JSON.stringify(schema.const)}'
-      `
-      return code
-    }
     code += `json += '${JSON.stringify(schema.const)}'`
     return code
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "benchmark": "^2.1.4",
     "cli-select": "^1.1.2",
     "compile-json-stringify": "^0.1.2",
-    "is-my-json-valid": "^2.20.0",
     "luxon": "^3.0.1",
     "proxyquire": "^2.1.3",
     "semver": "^7.1.0",

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -1,20 +1,19 @@
 'use strict'
 
 const test = require('tap').test
-const validator = require('is-my-json-valid')
+const { validate } = require('./util')
 const build = require('..')
 
 function buildTest (schema, toStringify, options) {
   test(`render a ${schema.title} as JSON`, (t) => {
     t.plan(3)
 
-    const validate = validator(schema)
     const stringify = build(schema, options)
     const output = stringify(toStringify)
 
     t.same(JSON.parse(output), toStringify)
     t.equal(output, JSON.stringify(toStringify))
-    t.ok(validate(JSON.parse(output)), 'valid schema')
+    t.ok(validate(JSON.parse(output), schema), 'valid schema')
   })
 }
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,20 +1,19 @@
 'use strict'
 
 const test = require('tap').test
-const validator = require('is-my-json-valid')
+const { validate } = require('./util')
 const build = require('..')
 
 function buildTest (schema, toStringify) {
   test(`render a ${schema.title} as JSON`, (t) => {
     t.plan(3)
 
-    const validate = validator(schema)
     const stringify = build(schema)
     const output = stringify(toStringify)
 
     t.same(JSON.parse(output), toStringify)
     t.equal(output, JSON.stringify(toStringify))
-    t.ok(validate(JSON.parse(output)), 'valid schema')
+    t.ok(validate(JSON.parse(output), schema), 'valid schema')
   })
 }
 
@@ -352,12 +351,11 @@ test('render a single quote as JSON', (t) => {
   }
   const toStringify = '" double quote'
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify(toStringify)
 
   t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('returns JSON.stringify if schema type is boolean', t => {

--- a/test/const.test.js
+++ b/test/const.test.js
@@ -252,7 +252,7 @@ test('schema with const as nullable', (t) => {
   const schema = {
     type: 'object',
     properties: {
-      foo: { nullable: true, const: 'baz' }
+      foo: { type: 'string', nullable: true, const: 'baz' }
     }
   }
 

--- a/test/const.test.js
+++ b/test/const.test.js
@@ -238,7 +238,7 @@ test('schema with const and null as type', (t) => {
     foo: null
   })
 
-  t.equal(output, '{"foo":null}')
+  t.equal(output, '{"foo":"baz"}')
   t.ok(validate(JSON.parse(output)), 'valid schema')
 
   const output2 = stringify({ foo: 'baz' })
@@ -262,7 +262,7 @@ test('schema with const as nullable', (t) => {
     foo: null
   })
 
-  t.equal(output, '{"foo":null}')
+  t.equal(output, '{"foo":"baz"}')
   t.ok(validate(JSON.parse(output)), 'valid schema')
 
   const output2 = stringify({

--- a/test/const.test.js
+++ b/test/const.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('tap').test
-const validator = require('is-my-json-valid')
+const { validate } = require('./util')
 const build = require('..')
 
 test('schema with const string', (t) => {
@@ -14,14 +14,13 @@ test('schema with const string', (t) => {
     }
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({
     foo: 'bar'
   })
 
   t.equal(output, '{"foo":"bar"}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('schema with const string and different input', (t) => {
@@ -34,14 +33,13 @@ test('schema with const string and different input', (t) => {
     }
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({
     foo: 'baz'
   })
 
   t.equal(output, '{"foo":"bar"}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('schema with const string and different type input', (t) => {
@@ -54,14 +52,13 @@ test('schema with const string and different type input', (t) => {
     }
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({
     foo: 1
   })
 
   t.equal(output, '{"foo":"bar"}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('schema with const string and no input', (t) => {
@@ -74,12 +71,11 @@ test('schema with const string and no input', (t) => {
     }
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({})
 
   t.equal(output, '{}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('schema with const number', (t) => {
@@ -92,14 +88,13 @@ test('schema with const number', (t) => {
     }
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({
     foo: 1
   })
 
   t.equal(output, '{"foo":1}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('schema with const number and different input', (t) => {
@@ -112,14 +107,13 @@ test('schema with const number and different input', (t) => {
     }
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({
     foo: 2
   })
 
   t.equal(output, '{"foo":1}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('schema with const bool', (t) => {
@@ -132,14 +126,13 @@ test('schema with const bool', (t) => {
     }
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({
     foo: true
   })
 
   t.equal(output, '{"foo":true}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('schema with const number', (t) => {
@@ -152,14 +145,13 @@ test('schema with const number', (t) => {
     }
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({
     foo: 1
   })
 
   t.equal(output, '{"foo":1}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('schema with const null', (t) => {
@@ -172,14 +164,13 @@ test('schema with const null', (t) => {
     }
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({
     foo: null
   })
 
   t.equal(output, '{"foo":null}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('schema with const array', (t) => {
@@ -192,14 +183,13 @@ test('schema with const array', (t) => {
     }
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({
     foo: [1, 2, 3]
   })
 
   t.equal(output, '{"foo":[1,2,3]}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('schema with const object', (t) => {
@@ -212,14 +202,13 @@ test('schema with const object', (t) => {
     }
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({
     foo: { bar: 'baz' }
   })
 
   t.equal(output, '{"foo":{"bar":"baz"}}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('schema with const and null as type', (t) => {
@@ -232,18 +221,17 @@ test('schema with const and null as type', (t) => {
     }
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({
     foo: null
   })
 
   t.equal(output, '{"foo":"baz"}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 
   const output2 = stringify({ foo: 'baz' })
   t.equal(output2, '{"foo":"baz"}')
-  t.ok(validate(JSON.parse(output2)), 'valid schema')
+  t.ok(validate(JSON.parse(output2), schema), 'valid schema')
 })
 
 test('schema with const as nullable', (t) => {
@@ -256,20 +244,19 @@ test('schema with const as nullable', (t) => {
     }
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({
     foo: null
   })
 
   t.equal(output, '{"foo":"baz"}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 
   const output2 = stringify({
     foo: 'baz'
   })
   t.equal(output2, '{"foo":"baz"}')
-  t.ok(validate(JSON.parse(output2)), 'valid schema')
+  t.ok(validate(JSON.parse(output2), schema), 'valid schema')
 })
 
 test('schema with const and invalid object', (t) => {
@@ -283,12 +270,11 @@ test('schema with const and invalid object', (t) => {
     required: ['foo']
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const result = stringify({
     foo: { foo: 'baz' }
   })
 
   t.equal(result, '{"foo":{"foo":"bar"}}')
-  t.ok(validate(JSON.parse(result)), 'valid schema')
+  t.ok(validate(JSON.parse(result), schema), 'valid schema')
 })

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -2,7 +2,7 @@
 
 const test = require('tap').test
 const { DateTime } = require('luxon')
-const validator = require('is-my-json-valid')
+const { validate } = require('./util')
 const build = require('..')
 
 test('render a date in a string as JSON', (t) => {
@@ -14,12 +14,11 @@ test('render a date in a string as JSON', (t) => {
   }
   const toStringify = new Date()
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify(toStringify)
 
   t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('render a date in a string when format is date-format as ISOString', (t) => {
@@ -32,12 +31,11 @@ test('render a date in a string when format is date-format as ISOString', (t) =>
   }
   const toStringify = new Date()
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify(toStringify)
 
   t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('render a nullable date in a string when format is date-format as ISOString', (t) => {
@@ -51,12 +49,11 @@ test('render a nullable date in a string when format is date-format as ISOString
   }
   const toStringify = new Date()
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify(toStringify)
 
   t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('render a date in a string when format is date as YYYY-MM-DD', (t) => {
@@ -69,12 +66,11 @@ test('render a date in a string when format is date as YYYY-MM-DD', (t) => {
   }
   const toStringify = new Date()
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify(toStringify)
 
   t.equal(output, `"${DateTime.fromJSDate(toStringify).toISODate()}"`)
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('render a nullable date in a string when format is date as YYYY-MM-DD', (t) => {
@@ -88,12 +84,11 @@ test('render a nullable date in a string when format is date as YYYY-MM-DD', (t)
   }
   const toStringify = new Date()
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify(toStringify)
 
   t.equal(output, `"${DateTime.fromJSDate(toStringify).toISODate()}"`)
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('verify padding for rendered date in a string when format is date', (t) => {
@@ -106,16 +101,15 @@ test('verify padding for rendered date in a string when format is date', (t) => 
   }
   const toStringify = new Date(2020, 0, 1, 0, 0, 0, 0)
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify(toStringify)
 
   t.equal(output, `"${DateTime.fromJSDate(toStringify).toISODate()}"`)
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('render a date in a string when format is time as kk:mm:ss', (t) => {
-  t.plan(3)
+  t.plan(2)
 
   const schema = {
     title: 'a date in a string',
@@ -124,19 +118,15 @@ test('render a date in a string when format is time as kk:mm:ss', (t) => {
   }
   const toStringify = new Date()
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  validate(JSON.parse(output))
-  t.equal(validate.errors, null)
-
   t.equal(output, `"${DateTime.fromJSDate(toStringify).toFormat('HH:mm:ss')}"`)
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('render a nullable date in a string when format is time as kk:mm:ss', (t) => {
-  t.plan(3)
+  t.plan(2)
 
   const schema = {
     title: 'a date in a string',
@@ -146,19 +136,15 @@ test('render a nullable date in a string when format is time as kk:mm:ss', (t) =
   }
   const toStringify = new Date()
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  validate(JSON.parse(output))
-  t.equal(validate.errors, null)
-
   t.equal(output, `"${DateTime.fromJSDate(toStringify).toFormat('HH:mm:ss')}"`)
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('render a midnight time', (t) => {
-  t.plan(3)
+  t.plan(2)
 
   const schema = {
     title: 'a date in a string',
@@ -167,19 +153,15 @@ test('render a midnight time', (t) => {
   }
   const midnight = new Date(new Date().setHours(24))
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify(midnight)
 
-  validate(JSON.parse(output))
-  t.equal(validate.errors, null)
-
   t.equal(output, `"${DateTime.fromJSDate(midnight).toFormat('HH:mm:ss')}"`)
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('verify padding for rendered date in a string when format is time', (t) => {
-  t.plan(3)
+  t.plan(2)
 
   const schema = {
     title: 'a date in a string',
@@ -188,15 +170,11 @@ test('verify padding for rendered date in a string when format is time', (t) => 
   }
   const toStringify = new Date(2020, 0, 1, 1, 1, 1, 1)
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  validate(JSON.parse(output))
-  t.equal(validate.errors, null)
-
   t.equal(output, `"${DateTime.fromJSDate(toStringify).toFormat('HH:mm:ss')}"`)
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('render a nested object in a string when type is date-format as ISOString', (t) => {
@@ -214,12 +192,11 @@ test('render a nested object in a string when type is date-format as ISOString',
   }
   const toStringify = { date: new Date() }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify(toStringify)
 
   t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('serializing null value', t => {
@@ -230,17 +207,6 @@ test('serializing null value', t => {
       title: 'an object in a string',
       type: 'object',
       properties
-    }
-  }
-
-  function serialize (schema, input) {
-    const validate = validator(schema)
-    const stringify = build(schema)
-    const output = stringify(input)
-
-    return {
-      validate,
-      output
     }
   }
 
@@ -259,13 +225,12 @@ test('serializing null value', t => {
         }
       }
 
-      const {
-        output,
-        validate
-      } = serialize(createSchema(prop), input)
+      const schema = createSchema(prop)
+      const stringify = build(schema)
+      const output = stringify(input)
 
       t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a date-time format')
+      t.notOk(validate(JSON.parse(output), schema), 'an empty string is not a date-time format')
     })
 
     t.test('format::date', t => {
@@ -278,13 +243,12 @@ test('serializing null value', t => {
         }
       }
 
-      const {
-        output,
-        validate
-      } = serialize(createSchema(prop), input)
+      const schema = createSchema(prop)
+      const stringify = build(schema)
+      const output = stringify(input)
 
       t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a date format')
+      t.notOk(validate(JSON.parse(output), schema), 'an empty string is not a date format')
     })
 
     t.test('format::time', t => {
@@ -297,13 +261,12 @@ test('serializing null value', t => {
         }
       }
 
-      const {
-        output,
-        validate
-      } = serialize(createSchema(prop), input)
+      const schema = createSchema(prop)
+      const stringify = build(schema)
+      const output = stringify(input)
 
       t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a time format')
+      t.notOk(validate(JSON.parse(output), schema), 'an empty string is not a time format')
     })
   })
 
@@ -320,13 +283,12 @@ test('serializing null value', t => {
         }
       }
 
-      const {
-        output,
-        validate
-      } = serialize(createSchema(prop), input)
+      const schema = createSchema(prop)
+      const stringify = build(schema)
+      const output = stringify(input)
 
       t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a date-time format')
+      t.notOk(validate(JSON.parse(output), schema), 'an empty string is not a date-time format')
     })
 
     t.test('format::date', t => {
@@ -339,13 +301,12 @@ test('serializing null value', t => {
         }
       }
 
-      const {
-        output,
-        validate
-      } = serialize(createSchema(prop), input)
+      const schema = createSchema(prop)
+      const stringify = build(schema)
+      const output = stringify(input)
 
       t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a date format')
+      t.notOk(validate(JSON.parse(output), schema), 'an empty string is not a date format')
     })
 
     t.test('format::date', t => {
@@ -358,13 +319,12 @@ test('serializing null value', t => {
         }
       }
 
-      const {
-        output,
-        validate
-      } = serialize(createSchema(prop), input)
+      const schema = createSchema(prop)
+      const stringify = build(schema)
+      const output = stringify(input)
 
       t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a date format')
+      t.notOk(validate(JSON.parse(output), schema), 'an empty string is not a date format')
     })
 
     t.test('format::time, Date object', t => {
@@ -386,7 +346,8 @@ test('serializing null value', t => {
 
       const date = new Date()
       const input = { updatedAt: date }
-      const { output } = serialize(schema, input)
+      const stringify = build(schema)
+      const output = stringify(input)
 
       t.equal(output, JSON.stringify({ updatedAt: DateTime.fromJSDate(date).toFormat('HH:mm:ss') }))
     })
@@ -404,7 +365,8 @@ test('serializing null value', t => {
       }
 
       const date = new Date()
-      const { output } = serialize(schema, date)
+      const stringify = build(schema)
+      const output = stringify(date)
 
       t.equal(output, `"${DateTime.fromJSDate(date).toFormat('HH:mm:ss')}"`)
     })
@@ -421,7 +383,8 @@ test('serializing null value', t => {
         ]
       }
 
-      const { output } = serialize(schema, 42)
+      const stringify = build(schema)
+      const output = stringify(42)
 
       t.equal(output, JSON.stringify(42))
     })
@@ -440,13 +403,12 @@ test('serializing null value', t => {
         }
       }
 
-      const {
-        output,
-        validate
-      } = serialize(createSchema(prop), input)
+      const schema = createSchema(prop)
+      const stringify = build(schema)
+      const output = stringify(input)
 
       t.equal(output, '{"updatedAt":null}')
-      t.ok(validate(JSON.parse(output)), 'valid schema')
+      t.ok(validate(JSON.parse(output), schema), 'valid schema')
     })
 
     t.test('format::date', t => {
@@ -459,13 +421,12 @@ test('serializing null value', t => {
         }
       }
 
-      const {
-        output,
-        validate
-      } = serialize(createSchema(prop), input)
+      const schema = createSchema(prop)
+      const stringify = build(schema)
+      const output = stringify(input)
 
       t.equal(output, '{"updatedAt":null}')
-      t.ok(validate(JSON.parse(output)), 'valid schema')
+      t.ok(validate(JSON.parse(output), schema), 'valid schema')
     })
 
     t.test('format::time', t => {
@@ -478,13 +439,12 @@ test('serializing null value', t => {
         }
       }
 
-      const {
-        output,
-        validate
-      } = serialize(createSchema(prop), input)
+      const schema = createSchema(prop)
+      const stringify = build(schema)
+      const output = stringify(input)
 
       t.equal(output, '{"updatedAt":null}')
-      t.ok(validate(JSON.parse(output)), 'valid schema')
+      t.ok(validate(JSON.parse(output), schema), 'valid schema')
     })
   })
 })

--- a/test/inferType.test.js
+++ b/test/inferType.test.js
@@ -1,20 +1,19 @@
 'use strict'
 
 const test = require('tap').test
-const validator = require('is-my-json-valid')
+const { validate } = require('./util')
 const build = require('..')
 
 function buildTest (schema, toStringify) {
   test(`render a ${schema.title} as JSON`, (t) => {
     t.plan(3)
 
-    const validate = validator(schema)
     const stringify = build(schema)
     const output = stringify(toStringify)
 
     t.same(JSON.parse(output), toStringify)
     t.equal(output, JSON.stringify(toStringify))
-    t.ok(validate(JSON.parse(output)), 'valid schema')
+    t.ok(validate(JSON.parse(output), schema), 'valid schema')
   })
 }
 

--- a/test/integer.test.js
+++ b/test/integer.test.js
@@ -2,7 +2,7 @@
 
 const t = require('tap')
 const test = t.test
-const validator = require('is-my-json-valid')
+const { validate } = require('./util')
 const build = require('..')
 const ROUNDING_TYPES = ['ceil', 'floor', 'round']
 
@@ -14,12 +14,11 @@ test('render an integer as JSON', (t) => {
     type: 'integer'
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify(1615)
 
   t.equal(output, '1615')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('render a float as an integer', (t) => {
@@ -62,12 +61,11 @@ test('render a float as an integer', (t) => {
       type: 'integer'
     }
 
-    const validate = validator(schema)
     const stringify = build(schema, { rounding })
     const str = stringify(input)
 
     t.equal(str, output)
-    t.ok(validate(JSON.parse(str)), 'valid schema')
+    t.ok(validate(JSON.parse(str), schema), 'valid schema')
   }
 })
 
@@ -84,14 +82,13 @@ test('render an object with an integer as JSON', (t) => {
     }
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({
     id: 1615
   })
 
   t.equal(output, '{"id":1615}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('render an array with an integer as JSON', (t) => {
@@ -105,12 +102,11 @@ test('render an array with an integer as JSON', (t) => {
     }
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify([1615])
 
   t.equal(output, '[1615]')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('render an object with an additionalProperty of type integer as JSON', (t) => {
@@ -124,38 +120,35 @@ test('render an object with an additionalProperty of type integer as JSON', (t) 
     }
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({
     num: 1615
   })
 
   t.equal(output, '{"num":1615}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('should round integer object parameter', t => {
   t.plan(2)
 
   const schema = { type: 'object', properties: { magic: { type: 'integer' } } }
-  const validate = validator(schema)
   const stringify = build(schema, { rounding: 'ceil' })
   const output = stringify({ magic: 4.2 })
 
   t.equal(output, '{"magic":5}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('should not stringify a property if it does not exist', t => {
   t.plan(2)
 
   const schema = { title: 'Example Schema', type: 'object', properties: { age: { type: 'integer' } } }
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({})
 
   t.equal(output, '{}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 ROUNDING_TYPES.forEach((rounding) => {
@@ -163,11 +156,10 @@ ROUNDING_TYPES.forEach((rounding) => {
     t.plan(2)
 
     const schema = { type: 'object', properties: { magic: { type: 'integer' } } }
-    const validate = validator(schema)
     const stringify = build(schema, { rounding })
     const output = stringify({})
 
     t.equal(output, '{}')
-    t.ok(validate(JSON.parse(output)), 'valid schema')
+    t.ok(validate(JSON.parse(output), schema), 'valid schema')
   })
 })

--- a/test/regex.test.js
+++ b/test/regex.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('tap').test
-const validator = require('is-my-json-valid')
+const { validate } = require('./util')
 const build = require('..')
 
 test('object with RexExp', (t) => {
@@ -22,12 +22,11 @@ test('object with RexExp', (t) => {
   }
 
   const stringify = build(schema)
-  const validate = validator(schema)
   const output = stringify(obj)
 
   JSON.parse(output)
   t.pass()
 
   t.equal(obj.reg.source, new RegExp(JSON.parse(output).reg).source)
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })

--- a/test/surrogate.test.js
+++ b/test/surrogate.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const test = require('tap').test
-const validator = require('is-my-json-valid')
+const { validate } = require('./util')
 const build = require('..')
 
 test('render a string with surrogate pairs as JSON:test 1', (t) => {
@@ -12,12 +12,11 @@ test('render a string with surrogate pairs as JSON:test 1', (t) => {
     type: 'string'
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify('𝌆')
 
   t.equal(output, '"𝌆"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('render a string with surrogate pairs as JSON: test 2', (t) => {
@@ -28,12 +27,11 @@ test('render a string with surrogate pairs as JSON: test 2', (t) => {
     type: 'string'
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify('\uD834\uDF06')
 
   t.equal(output, '"𝌆"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('render a string with Unpaired surrogate code as JSON', (t) => {
@@ -44,11 +42,10 @@ test('render a string with Unpaired surrogate code as JSON', (t) => {
     type: 'string'
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify('\uDF06\uD834')
   t.equal(output, JSON.stringify('\uDF06\uD834'))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })
 
 test('render a string with lone surrogate code as JSON', (t) => {
@@ -59,9 +56,8 @@ test('render a string with lone surrogate code as JSON', (t) => {
     type: 'string'
   }
 
-  const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify('\uDEAD')
   t.equal(output, JSON.stringify('\uDEAD'))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.ok(validate(JSON.parse(output), schema), 'valid schema')
 })

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const Ajv = require('ajv')
+const ajvFormats = require('ajv-formats')
+
+function validate (data, schema, externalSchemas) {
+  const ajv = new Ajv({
+    strictSchema: false,
+    validateSchema: true,
+    allowUnionTypes: true
+  })
+
+  ajvFormats(ajv)
+
+  if (externalSchemas !== undefined) {
+    for (const externalSchema of externalSchemas) {
+      ajv.addSchema(externalSchema)
+    }
+  }
+
+  return ajv.validate(schema, data)
+}
+
+module.exports = { validate }


### PR DESCRIPTION
It depends on #520

I think it's better to use Ajv to check data serialization results because we use it everywhere in FJS/Fastify and as it turns out, "is my schema valid" sometimes doesn't meet our requirements.