### PR TITLE
fix: set array function name by array schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,8 +70,7 @@ function resolveRef (location, ref) {
   return { schema, schemaId, jsonPointer }
 }
 
-const arrayItemsReferenceSerializersMap = new Map()
-const objectReferenceSerializersMap = new Map()
+const contextFunctionsNamesBySchema = new Map()
 
 let rootSchemaId = null
 let refResolver = null
@@ -79,8 +78,7 @@ let validator = null
 let contextFunctions = null
 
 function build (schema, options) {
-  arrayItemsReferenceSerializersMap.clear()
-  objectReferenceSerializersMap.clear()
+  contextFunctionsNamesBySchema.clear()
 
   contextFunctions = []
   options = options || {}
@@ -163,8 +161,7 @@ function build (schema, options) {
   validator = null
   rootSchemaId = null
   contextFunctions = null
-  arrayItemsReferenceSerializersMap.clear()
-  objectReferenceSerializersMap.clear()
+  contextFunctionsNamesBySchema.clear()
 
   return stringifyFunc
 }
@@ -537,12 +534,12 @@ function toJSON (variableName) {
 function buildObject (location) {
   const schema = location.schema
 
-  if (objectReferenceSerializersMap.has(schema)) {
-    return objectReferenceSerializersMap.get(schema)
+  if (contextFunctionsNamesBySchema.has(schema)) {
+    return contextFunctionsNamesBySchema.get(schema)
   }
 
   const functionName = generateFuncName()
-  objectReferenceSerializersMap.set(schema, functionName)
+  contextFunctionsNamesBySchema.set(schema, functionName)
 
   const schemaId = location.schemaId === rootSchemaId ? '' : location.schemaId
   let functionCode = `
@@ -584,12 +581,12 @@ function buildArray (location) {
 
   const itemsSchema = itemsLocation.schema
 
-  if (arrayItemsReferenceSerializersMap.has(itemsSchema)) {
-    return arrayItemsReferenceSerializersMap.get(itemsSchema)
+  if (contextFunctionsNamesBySchema.has(schema)) {
+    return contextFunctionsNamesBySchema.get(schema)
   }
 
   const functionName = generateFuncName()
-  arrayItemsReferenceSerializersMap.set(itemsSchema, functionName)
+  contextFunctionsNamesBySchema.set(schema, functionName)
 
   const schemaId = location.schemaId === rootSchemaId ? '' : location.schemaId
   let functionCode = `

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -327,6 +327,31 @@ test('object array with anyOf and symbol', (t) => {
   t.equal(value, '[{"name":"name-0","option":"Foo"},{"name":"name-1","option":"Bar"}]')
 })
 
+test('different arrays with same item schemas', (t) => {
+  t.plan(1)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      array1: {
+        type: 'array',
+        items: [{ type: 'string' }],
+        additionalItems: false
+      },
+      array2: {
+        type: 'array',
+        items: { $ref: '#/properties/array1/items' },
+        additionalItems: true
+      }
+    }
+  }
+
+  const stringify = build(schema)
+  const data = { array1: ['bar'], array2: ['foo', 'bar'] }
+
+  t.equal(stringify(data), '{"array1":["bar"],"array2":["foo","bar"]}')
+})
+
 const largeArray = new Array(2e4).fill({ a: 'test', b: 1 })
 buildTest({
   title: 'large array with default mechanism',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


1. Set array context function by array schema instead of array's items schema. 
2. There is no need to have two different Maps for storing context functions names.