### PR TITLE
perf: add only required schemas to the validator

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ function mergeLocation (location, key) {
   return {
     schema: location.schema[key],
     schemaId: location.schemaId,
-    jsonPointer: location.jsonPointer + '/' + key
+    jsonPointer: location.jsonPointer + '/' + key,
+    isValidated: location.isValidated
   }
 }
 
@@ -63,27 +64,29 @@ function resolveRef (location, ref) {
     throw new Error(`Cannot find reference "${ref}"`)
   }
 
+  if (location.isValidated) {
+    validatorSchemasIds.add(schemaId)
+  }
+
   if (schema.$ref !== undefined) {
     return resolveRef({ schema, schemaId, jsonPointer }, schema.$ref)
   }
 
-  return { schema, schemaId, jsonPointer }
+  return { schema, schemaId, jsonPointer, isValidated: location.isValidated }
 }
 
 const contextFunctionsNamesBySchema = new Map()
 
-let isValidatorUsed = null
 let rootSchemaId = null
 let refResolver = null
 let contextFunctions = null
-let mergeAllOfSchemas = null
+let validatorSchemasIds = null
 
 function build (schema, options) {
   contextFunctionsNamesBySchema.clear()
 
-  isValidatorUsed = false
   contextFunctions = []
-  mergeAllOfSchemas = {}
+  validatorSchemasIds = new Set()
   options = options || {}
 
   refResolver = new RefResolver()
@@ -122,7 +125,7 @@ function build (schema, options) {
     }
   }
 
-  const location = { schema, schemaId: rootSchemaId, jsonPointer: '#' }
+  const location = { schema, schemaId: rootSchemaId, jsonPointer: '#', isValidated: false }
   const code = buildValue(location, 'input')
 
   const contextFunctionCode = `
@@ -138,12 +141,12 @@ function build (schema, options) {
   const serializer = new Serializer(options)
   const validator = new Validator(options.ajv)
 
-  if (isValidatorUsed) {
-    validator.addSchema(schema, rootSchemaId)
-    const externalSchemas = options.schema || {}
-    const validatorSchemas = { ...externalSchemas, ...mergeAllOfSchemas }
-    for (const [schemaKey, schema] of Object.entries(validatorSchemas)) {
-      validator.addSchema(schema, schemaKey)
+  for (const schemaId of validatorSchemasIds) {
+    const schema = refResolver.getSchema(schemaId)
+    if (schema) {
+      validator.addSchema(schema, schemaId)
+    } else {
+      throw new Error(`Cannot find schema "${schemaId}"`)
     }
   }
 
@@ -164,6 +167,7 @@ function build (schema, options) {
 
   if (options.mode === 'standalone') {
     // lazy load
+    const isValidatorUsed = validatorSchemasIds.size > 0
     const buildStandaloneCode = require('./lib/standalone')
     return buildStandaloneCode(options, validator, isValidatorUsed, contextFunctionCode)
   }
@@ -172,11 +176,10 @@ function build (schema, options) {
   const contextFunc = new Function('validator', 'serializer', contextFunctionCode)
   const stringifyFunc = contextFunc(validator, serializer)
 
-  isValidatorUsed = false
   refResolver = null
   rootSchemaId = null
   contextFunctions = null
-  mergeAllOfSchemas = null
+  validatorSchemasIds = null
   contextFunctionsNamesBySchema.clear()
 
   return stringifyFunc
@@ -477,7 +480,6 @@ function mergeAllOfSchema (location, schema, mergedSchema) {
   delete mergedSchema.allOf
 
   mergedSchema.$id = `merged_${randomUUID()}`
-  mergeAllOfSchemas[mergedSchema.$id] = mergedSchema
   refResolver.addSchema(mergedSchema)
   location.schemaId = mergedSchema.$id
   location.jsonPointer = '#'
@@ -495,7 +497,8 @@ function buildInnerObject (location) {
 }
 
 function addIfThenElse (location, input) {
-  isValidatorUsed = true
+  location.isValidated = true
+  validatorSchemasIds.add(location.schemaId)
 
   const schema = merge({}, location.schema)
   const thenSchema = schema.then
@@ -874,7 +877,8 @@ function buildValue (location, input) {
   let code = ''
 
   if (type === undefined && (schema.anyOf || schema.oneOf)) {
-    isValidatorUsed = true
+    location.isValidated = true
+    validatorSchemasIds.add(location.schemaId)
 
     const type = schema.anyOf ? 'anyOf' : 'oneOf'
     const anyOfLocation = mergeLocation(location, type)

--- a/index.js
+++ b/index.js
@@ -143,11 +143,7 @@ function build (schema, options) {
 
   for (const schemaId of validatorSchemasIds) {
     const schema = refResolver.getSchema(schemaId)
-    if (schema) {
-      validator.addSchema(schema, schemaId)
-    } else {
-      throw new Error(`Cannot find schema "${schemaId}"`)
-    }
+    validator.addSchema(schema, schemaId)
   }
 
   const dependenciesName = ['validator', 'serializer', contextFunctionCode]

--- a/test/anyof.test.js
+++ b/test/anyof.test.js
@@ -596,3 +596,23 @@ test('anyOf object with invalid field date of type string with format or null', 
   const withOneOfStringify = build(withOneOfSchema)
   t.throws(() => withOneOfStringify({ prop: toStringify }))
 })
+
+test('anyOf with a nested external schema', (t) => {
+  t.plan(1)
+
+  const externalSchemas = {
+    schema1: {
+      definitions: {
+        def1: {
+          $id: 'external',
+          type: 'string'
+        }
+      },
+      type: 'number'
+    }
+  }
+  const schema = { anyOf: [{ $ref: 'external' }] }
+
+  const stringify = build(schema, { schema: externalSchemas })
+  t.equal(stringify('foo'), '"foo"')
+})


### PR DESCRIPTION
This will optimize a cold start for those schemas that have validation parts (anyOf, oneOf, if/then) and others external schemas in the context. 
\+ It might help with resolving schema conflicts in the future for #508.