### PR TITLE
fast-json-stringify is not a validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,9 @@ While the `schema` is currently validated for any developer errors,
 there is no guarantee that supplying user-generated schema could not
 expose your application to remote attacks.
 
+The _data_ that `fast-json-stringify` serializes is trusted too. In other terms,
+fast-json-stringify makes no claim to validate the incoming data against the schema. 
+
 <a name="debug"></a>
 ### Debug Mode
 

--- a/README.md
+++ b/README.md
@@ -650,8 +650,9 @@ While the `schema` is currently validated for any developer errors,
 there is no guarantee that supplying user-generated schema could not
 expose your application to remote attacks.
 
-The _data_ that `fast-json-stringify` serializes is trusted too. In other terms,
-fast-json-stringify makes no claim to validate the incoming data against the schema. 
+Users are responsibile for sending trusted data. `fast-json-stringify` guarantees that you will get
+a valid output only if your input matches the schema or can be coerced to the schema. If your input
+doesn't match the schema, you will get undefined behavior. 
 
 <a name="debug"></a>
 ### Debug Mode


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Let's make it clear that fast-json-stringify is not a validator and the caller takes all the responsibilities on the safety of the data being rendered.

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
