### PR TITLE
perf: allow-list only needed files for packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "url": "https://github.com/fastify/fast-json-stringify/issues"
   },
   "homepage": "https://github.com/fastify/fast-json-stringify#readme",
+  "files": ["*.js", "*.d.ts", "build/*.js", "lib/*.js"],
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
     "@sinclair/typebox": "^0.25.2",


### PR DESCRIPTION
In this small patch I add a short allowList to the `package.json` file, to ensure that only essential files are included in the distributed package.

- The package in its compressed form goes down from 56058 bytes to 22579 bytes (around 60% less)
- In its decompressed form, goes down from 379.5kB to 114.7kB (around 70% less)
- Taking into account weekly downloads, this patch saves up to 6.3GB/day in network traffic, and its related energy consumption.

It can be checked by running `npm pack` and inspecting the generated artifacts.

Signed-off-by: Andres Correa Casablanca <castarco@coderspirit.xyz>

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included **(does not apply)**
- [X] documentation is changed or added **(does not apply)**
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
