### PR TITLE
Use uuidv4 instead of randomUUID

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 const merge = require('@fastify/deepmerge')()
 const clone = require('rfdc')({ proto: true })
-const { randomUUID } = require('crypto')
+const { v4: uuidv4 } = require('uuid')
 
 const validate = require('./lib/schema-validator')
 const Serializer = require('./lib/serializer')
@@ -80,7 +80,7 @@ function build (schema, options) {
 
   refResolver = new RefResolver()
 
-  rootSchemaId = schema.$id || randomUUID()
+  rootSchemaId = schema.$id || uuidv4()
 
   isValidSchema(schema)
   refResolver.addSchema(schema, rootSchemaId)
@@ -449,7 +449,7 @@ function mergeAllOfSchema (location, schema, mergedSchema) {
   }
   delete mergedSchema.allOf
 
-  mergedSchema.$id = `merged_${randomUUID()}`
+  mergedSchema.$id = `merged_${uuidv4()}`
   refResolver.addSchema(mergedSchema)
   location.addMergedSchema(mergedSchema, mergedSchema.$id)
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "test:unit": "tap -J test/*.test.js test/**/*.test.js",
     "test": "npm run test:unit && npm run test:typescript"
   },
-  "precommit": ["lint", "test"],
+  "precommit": [
+    "lint",
+    "test"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fastify/fast-json-stringify.git"
@@ -55,7 +58,8 @@
     "ajv-formats": "^2.1.1",
     "fast-deep-equal": "^3.1.3",
     "fast-uri": "^2.1.0",
-    "rfdc": "^1.2.0"
+    "rfdc": "^1.2.0",
+    "uuid": "^9.0.0"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
RandomUUID will not work in node version higher than version 14. To solve this issue real quick, replace randomUUID with uuidv4.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
