### PR TITLE
fix: fix error message when type is array and object is object

### DIFF
--- a/index.js
+++ b/index.js
@@ -558,7 +558,7 @@ function buildArray (location) {
 
   functionCode += `
     if (!Array.isArray(obj)) {
-      throw new TypeError(\`The value of '${location.jsonPointer}' does not match schema definition.\`)
+      throw new TypeError(\`The value of '${schemaRef}' does not match schema definition.\`)
     }
     const arrayLength = obj.length
   `

--- a/index.js
+++ b/index.js
@@ -558,7 +558,7 @@ function buildArray (location) {
 
   functionCode += `
     if (!Array.isArray(obj)) {
-      throw new TypeError(\`The value '$\{obj}' does not match schema definition.\`)
+      throw new TypeError(\`The value '$\{JSON.stringify(obj)}' does not match schema definition.\`)
     }
     const arrayLength = obj.length
   `

--- a/index.js
+++ b/index.js
@@ -558,7 +558,7 @@ function buildArray (location) {
 
   functionCode += `
     if (!Array.isArray(obj)) {
-      throw new TypeError(\`The value '$\{JSON.stringify(obj)}' does not match schema definition.\`)
+      throw new TypeError(\`The value of '${location.jsonPointer}' does not match schema definition.\`)
     }
     const arrayLength = obj.length
   `

--- a/test/typesArray.test.js
+++ b/test/typesArray.test.js
@@ -482,10 +482,10 @@ test('should throw an error when type is array and object is null', (t) => {
   }
 
   const stringify = build(schema)
-  t.throws(() => stringify({ arr: null }), new TypeError('The value \'null\' does not match schema definition.'))
+  t.throws(() => stringify({ arr: null }), new TypeError('The value of \'#/properties/arr\' does not match schema definition.'))
 })
 
-test('should throw an error when type is array and object is object', (t) => {
+test('should throw an error when type is array and object is not at an array', (t) => {
   t.plan(1)
   const schema = {
     type: 'object',
@@ -500,7 +500,7 @@ test('should throw an error when type is array and object is object', (t) => {
   }
 
   const stringify = build(schema)
-  t.throws(() => stringify({ arr: { foo: 'hello' } }), new TypeError('The value \'{"foo":"hello"}\' does not match schema definition.'))
+  t.throws(() => stringify({ arr: { foo: 'hello' } }), new TypeError('The value of \'#/properties/arr\' does not match schema definition.'))
 })
 
 test('throw an error if none of types matches', (t) => {

--- a/test/typesArray.test.js
+++ b/test/typesArray.test.js
@@ -485,7 +485,7 @@ test('should throw an error when type is array and object is null', (t) => {
   t.throws(() => stringify({ arr: null }), new TypeError('The value of \'#/properties/arr\' does not match schema definition.'))
 })
 
-test('should throw an error when type is array and object is not at an array', (t) => {
+test('should throw an error when type is array and object is not an array', (t) => {
   t.plan(1)
   const schema = {
     type: 'object',
@@ -501,6 +501,34 @@ test('should throw an error when type is array and object is not at an array', (
 
   const stringify = build(schema)
   t.throws(() => stringify({ arr: { foo: 'hello' } }), new TypeError('The value of \'#/properties/arr\' does not match schema definition.'))
+})
+
+test('should throw an error when type is array and object is not an array with external schema', (t) => {
+  t.plan(1)
+  const schema = {
+    type: 'object',
+    properties: {
+      arr: {
+        $ref: 'arrayOfNumbers#/definitions/arr'
+      }
+    }
+  }
+
+  const externalSchema = {
+    arrayOfNumbers: {
+      definitions: {
+        arr: {
+          type: 'array',
+          items: {
+            type: 'number'
+          }
+        }
+      }
+    }
+  }
+
+  const stringify = build(schema, { schema: externalSchema })
+  t.throws(() => stringify({ arr: { foo: 'hello' } }), new TypeError('The value of \'arrayOfNumbers#/definitions/arr\' does not match schema definition.'))
 })
 
 test('throw an error if none of types matches', (t) => {

--- a/test/typesArray.test.js
+++ b/test/typesArray.test.js
@@ -485,6 +485,24 @@ test('should throw an error when type is array and object is null', (t) => {
   t.throws(() => stringify({ arr: null }), new TypeError('The value \'null\' does not match schema definition.'))
 })
 
+test('should throw an error when type is array and object is object', (t) => {
+  t.plan(1)
+  const schema = {
+    type: 'object',
+    properties: {
+      arr: {
+        type: 'array',
+        items: {
+          type: 'number'
+        }
+      }
+    }
+  }
+
+  const stringify = build(schema)
+  t.throws(() => stringify({ arr: { foo: 'hello' } }), new TypeError('The value \'{"foo":"hello"}\' does not match schema definition.'))
+})
+
 test('throw an error if none of types matches', (t) => {
   t.plan(1)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

When we attempt to stringify Object as an Array, the Object does not displayed properly (`'[object Object]'`). To simplify debugging process, we should display better error message to pinpoint where the problem using `schemaRef` property of `location` object.

Example:
```
// Schema
const schema = {
    type: 'object',
    properties: {
      arr: {
        type: 'array',
        items: {
          type: 'number'
        }
      }
    }
  };
const stringify = build(schema);
stringify({ arr: { foo: 'hello' } });
```

Original:
```
{
 "type": "TypeError",
 "message": "The value '[object Object]' does not match schema definition."
}
```
Proposed:
```
{
 "type": "TypeError",
 "message": "The value of '#/properties/arr' does not match schema definition."
}
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
