### PR TITLE
expose only location instead of Object value

### DIFF
--- a/index.js
+++ b/index.js
@@ -734,8 +734,12 @@ function buildMultiTypeSerializer (location, input) {
       }
     }
   })
+  let schemaRef = location.getSchemaRef()
+  if (schemaRef.startsWith(rootSchemaId)) {
+    schemaRef = schemaRef.replace(rootSchemaId, '')
+  }
   code += `
-    else throw new Error(\`The value $\{JSON.stringify(${input})} does not match schema definition.\`)
+    else throw new TypeError(\`The value of '${schemaRef}' does not match schema definition.\`)
   `
 
   return code
@@ -854,8 +858,13 @@ function buildValue (location, input) {
       `
     }
 
+    let schemaRef = location.getSchemaRef()
+    if (schemaRef.startsWith(rootSchemaId)) {
+      schemaRef = schemaRef.replace(rootSchemaId, '')
+    }
+
     code += `
-      else throw new Error(\`The value $\{JSON.stringify(${input})} does not match schema definition.\`)
+      else throw new TypeError(\`The value of '${schemaRef}' does not match schema definition.\`)
     `
     return code
   }

--- a/test/any.test.js
+++ b/test/any.test.js
@@ -152,3 +152,80 @@ test('empty schema on anyOf', (t) => {
   t.equal(stringify({ kind: 'Foo', value: true }), '{"kind":"Foo","value":true}')
   t.equal(stringify({ kind: 'Foo', value: 'hello' }), '{"kind":"Foo","value":"hello"}')
 })
+
+test('should throw a TypeError with the path to the key of the invalid value /1', (t) => {
+  t.plan(1)
+
+  // any on Foo codepath.
+  const schema = {
+    anyOf: [
+      {
+        type: 'object',
+        properties: {
+          kind: {
+            type: 'string',
+            enum: ['Foo']
+          },
+          value: {}
+        }
+      },
+      {
+        type: 'object',
+        properties: {
+          kind: {
+            type: 'string',
+            enum: ['Bar']
+          },
+          value: {
+            type: 'number'
+          }
+        }
+      }
+    ]
+  }
+
+  const stringify = build(schema)
+
+  t.throws(() => stringify({ kind: 'Baz', value: 1 }), new TypeError('The value of \'#\' does not match schema definition.'))
+})
+
+test('should throw a TypeError with the path to the key of the invalid value /2', (t) => {
+  t.plan(1)
+
+  // any on Foo codepath.
+  const schema = {
+    type: 'object',
+    properties: {
+      data: {
+        anyOf: [
+          {
+            type: 'object',
+            properties: {
+              kind: {
+                type: 'string',
+                enum: ['Foo']
+              },
+              value: {}
+            }
+          },
+          {
+            type: 'object',
+            properties: {
+              kind: {
+                type: 'string',
+                enum: ['Bar']
+              },
+              value: {
+                type: 'number'
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+
+  const stringify = build(schema)
+
+  t.throws(() => stringify({ data: { kind: 'Baz', value: 1 } }), new TypeError('The value of \'#/properties/data\' does not match schema definition.'))
+})

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -284,18 +284,7 @@ test('array items is a list of schema and additionalItems is false', (t) => {
   }
 
   const stringify = build(schema)
-
-  try {
-    stringify({
-      foo: [
-        'foo',
-        'bar'
-      ]
-    })
-    t.fail()
-  } catch (error) {
-    t.ok(/does not match schema definition./.test(error.message))
-  }
+  t.throws(() => stringify({ foo: ['foo', 'bar'] }), new Error('Item at 1 does not match schema definition'))
 })
 
 // https://github.com/fastify/fast-json-stringify/issues/279

--- a/test/multi-type-serializer.test.js
+++ b/test/multi-type-serializer.test.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const test = require('tap').test
+const build = require('..')
+
+test('should throw a TypeError with the path to the key of the invalid value', (t) => {
+  t.plan(1)
+  const schema = {
+    type: 'object',
+    properties: {
+      num: {
+        type: ['number']
+      }
+    }
+  }
+
+  const stringify = build(schema)
+  t.throws(() => stringify({ num: { bla: 123 } }), new TypeError('The value of \'#/properties/num\' does not match schema definition.'))
+})


### PR DESCRIPTION
This is a follow up from #569 by @yukha-dw

I previously opened a Report to hackerone, as I feared that the current implementation could be a potential security issue. But as it got closed as not applicable, I guess I can safely propose this PR :).

So instead of calling JSON.stringify to show the value of an Object, we just show the schema location. As such, we avoid, that we have to potentially stringify a JSON, which we didnt want to stringify in the first place. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
