### PR TITLE
invalid value for patternproperties are validated by ajv

### DIFF
--- a/index.js
+++ b/index.js
@@ -254,13 +254,6 @@ function buildExtraObjectPropertiesSerializer (location) {
     for (const propertyKey in patternPropertiesSchema) {
       const propertyLocation = patternPropertiesLocation.getPropertyLocation(propertyKey)
 
-      try {
-        RegExp(propertyKey)
-      } catch (err) {
-        const jsonPointer = propertyLocation.getSchemaRef()
-        throw new Error(`${err.message}. Invalid pattern property regexp key ${propertyKey} at ${jsonPointer}`)
-      }
-
       code += `
         if (/${propertyKey.replace(/\\*\//g, '\\/')}/.test(key)) {
           ${addComma}

--- a/test/patternProperties.test.js
+++ b/test/patternProperties.test.js
@@ -148,3 +148,21 @@ test('patternProperties - array coerce', (t) => {
   const incoercibleValues = { foo: 'true', ofoo: 0, objfoo: { tyrion: 'lannister' } }
   t.throws(() => stringify(incoercibleValues))
 })
+
+test('patternProperties - fail on invalid regex, handled by ajv', (t) => {
+  t.plan(1)
+
+  t.throws(() => build({
+    title: 'check array coerce',
+    type: 'object',
+    properties: {},
+    patternProperties: {
+      'foo/\\': {
+        type: 'array',
+        items: {
+          type: 'string'
+        }
+      }
+    }
+  }), new Error('schema is invalid: data/patternProperties must match format "regex"'))
+})


### PR DESCRIPTION
We can never catch that error because ajv is already validating that pattern properties are valid regex values. 

improves code coverage. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
