### PR TITLE
add unit test for allOf, where types, format and nullable missmatch

### DIFF
--- a/test/allof.test.js
+++ b/test/allof.test.js
@@ -506,3 +506,27 @@ test('allOf: throw Error if format mismatch ', (t) => {
   }
   t.throws(() => build(schema), new Error('allOf schemas have different format values'))
 })
+
+test('allOf: throw Error if nullable mismatch /1', (t) => {
+  t.plan(1)
+
+  const schema = {
+    allOf: [
+      { nullable: true },
+      { nullable: false }
+    ]
+  }
+  t.throws(() => build(schema), new Error('allOf schemas have different nullable values'))
+})
+
+test('allOf: throw Error if nullable mismatch /2', (t) => {
+  t.plan(1)
+
+  const schema = {
+    allOf: [
+      { nullable: false },
+      { nullable: true }
+    ]
+  }
+  t.throws(() => build(schema), new Error('allOf schemas have different nullable values'))
+})

--- a/test/allof.test.js
+++ b/test/allof.test.js
@@ -494,3 +494,15 @@ test('allOf: throw Error if types mismatch ', (t) => {
   }
   t.throws(() => build(schema), new Error('allOf schemas have different type values'))
 })
+
+test('allOf: throw Error if format mismatch ', (t) => {
+  t.plan(1)
+
+  const schema = {
+    allOf: [
+      { format: 'date' },
+      { format: 'time' }
+    ]
+  }
+  t.throws(() => build(schema), new Error('allOf schemas have different format values'))
+})

--- a/test/allof.test.js
+++ b/test/allof.test.js
@@ -482,3 +482,15 @@ test('allof with local anchor reference', (t) => {
 
   t.equal(stringify(data), JSON.stringify(data))
 })
+
+test('allOf: throw Error if types mismatch ', (t) => {
+  t.plan(1)
+
+  const schema = {
+    allOf: [
+      { type: 'string' },
+      { type: 'number' }
+    ]
+  }
+  t.throws(() => build(schema), new Error('allOf schemas have different type values'))
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
