### PR TITLE
improve performance of asInteger serializer

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -23,17 +23,28 @@ module.exports = class Serializer {
   }
 
   asInteger (i) {
-    if (typeof i === 'bigint') {
+    if (typeof i === 'number') {
+      if (i === Infinity || i === -Infinity) {
+        throw new Error(`The value "${i}" cannot be converted to an integer.`)
+      }
+      if ((i | 0) === i) {
+        return '' + i
+      }
+      if (Number.isNaN(i)) {
+        throw new Error(`The value "${i}" cannot be converted to an integer.`)
+      }
+      return this.parseInteger(i)
+    } else if (i === null) {
+      return '0'
+    } else if (typeof i === 'bigint') {
       return i.toString()
-    } else if (Number.isInteger(i)) {
-      return '' + i
     } else {
       /* eslint no-undef: "off" */
       const integer = this.parseInteger(i)
-      if (Number.isNaN(integer) || !Number.isFinite(integer)) {
-        throw new Error(`The value "${i}" cannot be converted to an integer.`)
-      } else {
+      if (Number.isFinite(integer)) {
         return '' + integer
+      } else {
+        throw new Error(`The value "${i}" cannot be converted to an integer.`)
       }
     }
   }


### PR DESCRIPTION
fast path is now the assumption, that it is checking for a number and instead of using Number.isFinite and co. it tries to avoid those function calls.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
