### PR TITLE
only pass rounding option to serializer of standalone

### DIFF
--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -25,19 +25,18 @@ function buildStandaloneCode (options, validator, isValidatorUsed, contextFuncti
     buildAjvCode = fs.readFileSync(path.join(__dirname, 'validator.js')).toString()
     buildAjvCode = buildAjvCode.replace("'use strict'", '').replace('module.exports = SchemaValidator', '')
   }
+
+  const serializerOptions = options && options.rounding ? JSON.stringify({ options: options.rounding }) : ''
   return `
   'use strict'
-
   ${serializerCode.replace("'use strict'", '').replace('module.exports = ', '')}
   ${buildAjvCode}
-
-  const serializer = new Serializer(${JSON.stringify(options || {})})
+  const serializer = new Serializer(${serializerOptions})
   ${ajvSchemasCode}
 
   ${contextFunctionCode.replace('return main', '')}
 
-  module.exports = main
-      `
+  module.exports = main`
 }
 
 module.exports = buildStandaloneCode


### PR DESCRIPTION
When we generate a standalone serializer we pass the whole object into the serializer (e.g. `{ mode: 'standalone' }`) which makes no sense. 
This PR basically just passes throuh the rounding option, if set. 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
