### PR TITLE
use Number.isInteger instead of bitwise operation

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -27,7 +27,7 @@ module.exports = class Serializer {
       if (i === Infinity || i === -Infinity) {
         throw new Error(`The value "${i}" cannot be converted to an integer.`)
       }
-      if ((i | 0) === i) {
+      if (Number.isInteger(i)) {
         return '' + i
       }
       if (Number.isNaN(i)) {

--- a/test/integer.test.js
+++ b/test/integer.test.js
@@ -45,6 +45,7 @@ test('render a float as an integer', (t) => {
     { input: 42, output: '42' },
     { input: 1.99999, output: '1' },
     { input: -45.05, output: '-45' },
+    { input: 3333333333333333, output: '3333333333333333' },
     { input: Math.PI, output: '3', rounding: 'trunc' },
     { input: 5.0, output: '5', rounding: 'trunc' },
     { input: null, output: '0', rounding: 'trunc' },


### PR DESCRIPTION
I forgot that the | 0 trick only handles numbers up to 2^32 properly

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
