### PR TITLE
fix: ignore defined type if anyOf and oneOf are defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -835,7 +835,7 @@ function buildValue (context, location, input) {
 
   let code = ''
 
-  if (type === undefined && (schema.anyOf || schema.oneOf)) {
+  if (schema.anyOf || schema.oneOf) {
     context.validatorSchemasIds.add(location.getSchemaId())
 
     const type = schema.anyOf ? 'anyOf' : 'oneOf'

--- a/test/issue-290.test.js
+++ b/test/issue-290.test.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const { test } = require('tap')
+const build = require('..')
+
+test('should work with anyOf', (t) => {
+  t.plan(2)
+
+  const schemaFoo = {
+    properties: {
+      foo: { type: 'string' },
+      baz: { type: 'string' }
+    },
+    required: ['foo', 'baz']
+  }
+
+  const schemaBar = {
+    properties: {
+      bar: { type: 'string' },
+      baz: { type: 'string' }
+    },
+    required: ['bar', 'baz']
+  }
+
+  const stringify = build({
+    type: 'object',
+    anyOf: [schemaFoo, schemaBar]
+  })
+
+  t.equal(stringify({ foo: 'foo', baz: 'baz' }), '{"foo":"foo","baz":"baz"}')
+  t.equal(stringify({ bar: 'bar', baz: 'baz' }), '{"bar":"bar","baz":"baz"}')
+})
+
+test('should work with oneOf', (t) => {
+  t.plan(2)
+
+  const schemaFoo = {
+    properties: {
+      foo: { type: 'string' },
+      baz: { type: 'string' }
+    },
+    required: ['foo', 'baz']
+  }
+
+  const schemaBar = {
+    properties: {
+      bar: { type: 'string' },
+      baz: { type: 'string' }
+    },
+    required: ['bar', 'baz']
+  }
+
+  const stringify = build({
+    type: 'object',
+    oneOf: [schemaFoo, schemaBar]
+  })
+
+  t.equal(stringify({ foo: 'foo', baz: 'baz' }), '{"foo":"foo","baz":"baz"}')
+  t.equal(stringify({ bar: 'bar', baz: 'baz' }), '{"bar":"bar","baz":"baz"}')
+})

--- a/test/issue-290.test.js
+++ b/test/issue-290.test.js
@@ -58,3 +58,18 @@ test('should work with oneOf', (t) => {
   t.equal(stringify({ foo: 'foo', baz: 'baz' }), '{"foo":"foo","baz":"baz"}')
   t.equal(stringify({ bar: 'bar', baz: 'baz' }), '{"bar":"bar","baz":"baz"}')
 })
+
+test('should merge schemas properly', (t) => {
+  t.plan(1)
+
+  const schema = {
+    properties: {
+      foo: { type: 'string' }
+    },
+    oneOf: [{ type: 'object' }]
+  }
+
+  const stringify = build(schema)
+
+  t.equal(stringify({ foo: 'foo' }), '{"foo":"foo"}')
+})


### PR DESCRIPTION
Closes #290 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
