### PR TITLE
improve perf of asString

### DIFF
--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -18,6 +18,11 @@ function getRandomInt (max) {
   return Math.floor(Math.random() * max)
 }
 
+let longSimpleString = ''
+for (let i = 0; i < LONG_STRING_LENGTH; i++) {
+  longSimpleString += i
+}
+
 let longString = ''
 for (let i = 0; i < LONG_STRING_LENGTH; i++) {
   longString += i
@@ -41,6 +46,20 @@ const benchmarks = [
       type: 'string'
     },
     input: 'hello world'
+  },
+  {
+    name: 'short string with double quote',
+    schema: {
+      type: 'string'
+    },
+    input: 'hello " world'
+  },
+  {
+    name: 'long string without double quotes',
+    schema: {
+      type: 'string'
+    },
+    input: longSimpleString
   },
   {
     name: 'long string',

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -113,11 +113,10 @@ module.exports = class Serializer {
       }
     }
 
-    // Fast escape chars check
-    if (!STR_ESCAPE.test(str)) {
-      return '"' + str + '"'
-    } else if (str.length < 42) {
+    if (str.length < 42) {
       return this.asStringSmall(str)
+    } else if (STR_ESCAPE.test(str) === false) {
+      return '"' + str + '"'
     } else {
       return JSON.stringify(str)
     }
@@ -130,32 +129,32 @@ module.exports = class Serializer {
   // 34 and 92 happens all the time, so we
   // have a fast case for them
   asStringSmall (str) {
-    const l = str.length
+    const len = str.length
     let result = ''
-    let last = 0
-    let found = false
-    let surrogateFound = false
+    let last = -1
     let point = 255
+
     // eslint-disable-next-line
-    for (var i = 0; i < l && point >= 32; i++) {
+    for (var i = 0; i < len; i++) {
       point = str.charCodeAt(i)
+      if (point < 32) {
+        return JSON.stringify(str)
+      }
       if (point >= 0xD800 && point <= 0xDFFF) {
         // The current character is a surrogate.
-        surrogateFound = true
+        return JSON.stringify(str)
       }
-      if (point === 34 || point === 92) {
+      if (
+        point === 0x22 || // '"'
+        point === 0x5c // '\'
+      ) {
+        last === -1 && (last = 0)
         result += str.slice(last, i) + '\\'
         last = i
-        found = true
       }
     }
 
-    if (!found) {
-      result = str
-    } else {
-      result += str.slice(last)
-    }
-    return ((point < 32) || (surrogateFound === true)) ? JSON.stringify(str) : '"' + result + '"'
+    return (last === -1 && ('"' + str + '"')) || ('"' + result + str.slice(last) + '"')
   }
 
   getState () {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -344,13 +344,45 @@ test('patternProperties - throw on unknown type', (t) => {
   }
 })
 
-test('render a single quote as JSON', (t) => {
+test('render a double quote as JSON /1', (t) => {
   t.plan(2)
 
   const schema = {
     type: 'string'
   }
   const toStringify = '" double quote'
+
+  const validate = validator(schema)
+  const stringify = build(schema)
+  const output = stringify(toStringify)
+
+  t.equal(output, JSON.stringify(toStringify))
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})
+
+test('render a double quote as JSON /2', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'string'
+  }
+  const toStringify = 'double quote " 2'
+
+  const validate = validator(schema)
+  const stringify = build(schema)
+  const output = stringify(toStringify)
+
+  t.equal(output, JSON.stringify(toStringify))
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})
+
+test('render a long string', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'string'
+  }
+  const toStringify = 'the Ultimate Question of Life, the Universe, and Everything.'
 
   const validate = validator(schema)
   const stringify = build(schema)


### PR DESCRIPTION
running only the first 4 benchmarks with maxSamples 100 (or else it takes gazillion years

before:

```sh
short string............................................. x 27,631,407 ops/sec ±0.44% (192 runs sampled)
short string with double quote........................... x 8,093,221 ops/sec ±0.59% (191 runs sampled)
long string without double quotes........................ x 26,659 ops/sec ±0.28% (193 runs sampled)
long string.............................................. x 11,697 ops/sec ±0.19% (192 runs sampled)
```

after:

```sh
short string............................................. x 43,111,798 ops/sec ±0.96% (187 runs sampled)
short string with double quote........................... x 13,393,581 ops/sec ±0.39% (191 runs sampled)
long string without double quotes........................ x 26,907 ops/sec ±0.20% (192 runs sampled)
long string.............................................. x 11,751 ops/sec ±0.23% (191 runs sampled)
```

Actually: Why 42?
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
