### PR TITLE
Adding support for TypedArrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,10 +27,6 @@ const validLargeArrayMechanisms = [
   'json-stringify'
 ]
 
-const supportedTypedArrays = [
-  'Uint8Array'
-]
-
 const addComma = '!addComma && (addComma = true) || (json += \',\')'
 
 function isValidSchema (schema, name) {
@@ -590,7 +586,8 @@ function buildArray (context, location) {
   `
 
   functionCode += `
-    if (!Array.isArray(obj) && !(obj != null && (${supportedTypedArrays.map(type => ' obj.constructor.name === \'' + type + '\' ').join('||')}) )) {
+    const supportedTypedArrays = ['Uint8Array'];
+    if (!Array.isArray(obj) && !(obj != null && supportedTypedArrays.indexOf(obj.constructor.name) != -1)) {
       throw new TypeError(\`The value of '${schemaRef}' does not match schema definition.\`)
     }
     const arrayLength = obj.length

--- a/index.js
+++ b/index.js
@@ -27,6 +27,10 @@ const validLargeArrayMechanisms = [
   'json-stringify'
 ]
 
+const supportedTypedArrays = [
+  'Uint8Array'
+]
+
 const addComma = '!addComma && (addComma = true) || (json += \',\')'
 
 function isValidSchema (schema, name) {
@@ -586,7 +590,7 @@ function buildArray (context, location) {
   `
 
   functionCode += `
-    if (!Array.isArray(obj)) {
+    if (!Array.isArray(obj) && !(obj != null && (${supportedTypedArrays.map(type => ' obj.constructor.name === \'' + type + '\' ').join('||')}) )) {
       throw new TypeError(\`The value of '${schemaRef}' does not match schema definition.\`)
     }
     const arrayLength = obj.length

--- a/test/anyof.test.js
+++ b/test/anyof.test.js
@@ -644,3 +644,31 @@ test('object with ref and validated properties', (t) => {
   const stringify = build(schema, { schema: externalSchemas })
   t.equal(stringify({ id: 1, reference: 'hi' }), '{"id":1,"reference":"hi"}')
 })
+
+test('anyOf with a TypedArray', (t) => {
+  t.plan(1)
+
+  const anyOfSchema = {
+    type: 'object',
+    properties: {
+      maybeArray: {
+        anyOf: [{
+          type: 'array',
+          items: {
+            type: 'number'
+          }
+        },
+        {
+          type: 'string'
+        }]
+      }
+    }
+  }
+  const stringify = build(anyOfSchema)
+
+  const typed = new Uint8Array(5)
+  typed.fill(10)
+
+  const value = stringify({ maybeArray: typed })
+  t.equal(value, '{maybeArray: [10,10,10,10,10]}')
+})

--- a/test/oneof.test.js
+++ b/test/oneof.test.js
@@ -490,3 +490,31 @@ test('all array items does not match oneOf types', (t) => {
 
   t.throws(() => stringify({ data: [null, false, true, undefined, [], {}] }))
 })
+
+test('oneOf with a TypedArray', (t) => {
+  t.plan(1)
+
+  const oneOfSchema = {
+    type: 'object',
+    properties: {
+      maybeArray: {
+        oneOf: [{
+          type: 'array',
+          items: {
+            type: 'number'
+          }
+        },
+        {
+          type: 'string'
+        }]
+      }
+    }
+  }
+  const stringify = build(oneOfSchema)
+
+  const typed = new Uint8Array(5)
+  typed.fill(10)
+
+  const value = stringify({ maybeArray: typed })
+  t.equal(value, '{maybeArray: [10,10,10,10,10]}')
+})

--- a/test/typesArray.test.js
+++ b/test/typesArray.test.js
@@ -547,3 +547,24 @@ test('throw an error if none of types matches', (t) => {
   const stringify = build(schema)
   t.throws(() => stringify({ data: 'string' }), 'The value "string" does not match schema definition.')
 })
+
+test('typedArray Uint8Array', (t) => {
+  t.plan(1)
+  const schema = {
+    type: 'object',
+    properties: {
+      arr: {
+        type: 'array',
+        items: {
+          type: 'number'
+        }
+      }
+    }
+  }
+
+  const stringify = build(schema)
+  const arr = new Uint8Array(5)
+  arr.fill(5)
+
+  t.equal(stringify({ arr }), '{"arr":[5,5,5,5,5]}')
+})


### PR DESCRIPTION
I have added support for `Uint8Array` with a test showing that it works as expected. No additional types have been created, this works by simply treating a `Uint8Array` like a normal `array`. Afaik, you cannot create a nested array this way so the changes are quite limited.

Support for more types of `TypedArray` is easy to add but as I worked on this issue further I realised that there may be wider implications for this:
- Does this conflict with JSONSchema?
- TypedArrays appear to be strongly typed (for example, creating a Uint8Array with values longer than 8 bits will always be cast down to 8 bit values) so would it be possible to improve perf by removing type checks (I looked at this briefly but I didn't see how it could be done without broader changes).
- Which `TypedArray` should be supported?

Related to - https://github.com/fastify/fast-json-stringify/issues/626 - I haven't verified the performance difference either, I am assuming this can only come from removing type checks?

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
