### PR TITLE
feat: add validationErrors to schema mismatch errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -866,7 +866,7 @@ function buildValue (context, location, input) {
 
   if ((type === undefined || type === 'object') && (schema.anyOf || schema.oneOf)) {
     context.validatorSchemasIds.add(location.getSchemaId())
-    code = 'const errors = []\n'
+    code += 'const errors = []\n'
 
     if (schema.type === 'object') {
       context.wrapObjects = false

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -47,8 +47,10 @@ class Validator {
     }
   }
 
-  validate (schemaRef, data) {
-    return this.ajv.validate(schemaRef, data)
+  validate (schemaRef, data, errors) {
+    const valid = this.ajv.validate(schemaRef, data)
+    if (this.ajv.errors && Array.isArray(errors)) errors.push(...this.ajv.errors)
+    return valid
   }
 
   // Ajv does not support js date format. In order to properly validate objects containing a date,

--- a/test/any.test.js
+++ b/test/any.test.js
@@ -154,7 +154,7 @@ test('empty schema on anyOf', (t) => {
 })
 
 test('should throw a TypeError with the path to the key of the invalid value /1', (t) => {
-  t.plan(1)
+  t.plan(3)
 
   // any on Foo codepath.
   const schema = {
@@ -186,16 +186,21 @@ test('should throw a TypeError with the path to the key of the invalid value /1'
 
   const stringify = build(schema)
 
-  t.throws(() => stringify({ kind: 'Baz', value: 1 }), Object.assign(new TypeError('The value of \'#\' does not match schema definition.'), {
-    validationErrors: [
-      { message: 'must be equal to one of the allowed values', schemaPath: '#/properties/kind/enum', instancePath: '/kind' },
-      { message: 'must be equal to one of the allowed values', schemaPath: '#/properties/kind/enum', instancePath: '/kind' }
-    ]
-  }))
+  try {
+    stringify({ kind: 'Baz', value: 1 })
+    t.fail('should throw')
+  } catch (err) {
+    t.equal(err.message, 'The value of \'#\' does not match schema definition.')
+    t.same(err.validationErrors, [
+      { message: 'must be equal to one of the allowed values', schemaPath: '#/properties/kind/enum', instancePath: '/kind', keyword: 'enum', params: { allowedValues: ['Foo'] } },
+      { message: 'must be equal to one of the allowed values', schemaPath: '#/properties/kind/enum', instancePath: '/kind', keyword: 'enum', params: { allowedValues: ['Bar'] } }
+    ])
+    t.ok(err instanceof TypeError)
+  }
 })
 
 test('should throw a TypeError with the path to the key of the invalid value /2', (t) => {
-  t.plan(1)
+  t.plan(3)
 
   // any on Foo codepath.
   const schema = {
@@ -232,10 +237,15 @@ test('should throw a TypeError with the path to the key of the invalid value /2'
 
   const stringify = build(schema)
 
-  t.throws(() => stringify({ data: { kind: 'Baz', value: 1 } }), Object.assign(new TypeError('The value of \'#/properties/data\' does not match schema definition.'), {
-    validationErrors: [
-      { message: 'must be equal to one of the allowed values', schemaPath: '#/properties/kind/enum', instancePath: '/kind' },
-      { message: 'must be equal to one of the allowed values', schemaPath: '#/properties/kind/enum', instancePath: '/kind' }
-    ]
-  }))
+  try {
+    stringify({ data: { kind: 'Baz', value: 1 } })
+    t.fail('should throw')
+  } catch (err) {
+    t.equal(err.message, 'The value of \'#/properties/data\' does not match schema definition.')
+    t.same(err.validationErrors, [
+      { message: 'must be equal to one of the allowed values', schemaPath: '#/properties/kind/enum', instancePath: '/kind', keyword: 'enum', params: { allowedValues: ['Foo'] } },
+      { message: 'must be equal to one of the allowed values', schemaPath: '#/properties/kind/enum', instancePath: '/kind', keyword: 'enum', params: { allowedValues: ['Bar'] } }
+    ])
+    t.ok(err instanceof TypeError)
+  }
 })

--- a/test/any.test.js
+++ b/test/any.test.js
@@ -186,7 +186,12 @@ test('should throw a TypeError with the path to the key of the invalid value /1'
 
   const stringify = build(schema)
 
-  t.throws(() => stringify({ kind: 'Baz', value: 1 }), new TypeError('The value of \'#\' does not match schema definition.'))
+  t.throws(() => stringify({ kind: 'Baz', value: 1 }), Object.assign(new TypeError('The value of \'#\' does not match schema definition.'), {
+    validationErrors: [
+      { message: 'must be equal to one of the allowed values', schemaPath: '#/properties/kind/enum', instancePath: '/kind' },
+      { message: 'must be equal to one of the allowed values', schemaPath: '#/properties/kind/enum', instancePath: '/kind' }
+    ]
+  }))
 })
 
 test('should throw a TypeError with the path to the key of the invalid value /2', (t) => {
@@ -227,5 +232,10 @@ test('should throw a TypeError with the path to the key of the invalid value /2'
 
   const stringify = build(schema)
 
-  t.throws(() => stringify({ data: { kind: 'Baz', value: 1 } }), new TypeError('The value of \'#/properties/data\' does not match schema definition.'))
+  t.throws(() => stringify({ data: { kind: 'Baz', value: 1 } }), Object.assign(new TypeError('The value of \'#/properties/data\' does not match schema definition.'), {
+    validationErrors: [
+      { message: 'must be equal to one of the allowed values', schemaPath: '#/properties/kind/enum', instancePath: '/kind' },
+      { message: 'must be equal to one of the allowed values', schemaPath: '#/properties/kind/enum', instancePath: '/kind' }
+    ]
+  }))
 })


### PR DESCRIPTION
when using a schema that includes `anyOf` or `oneOf` and it fails to find a match the error is pretty worthless (in my case it is usually `'The value of \'#\' does not match schema definition.'`)
and it is not trivial to debug since stack trace points to anonymous functions composed at runtime.
this sets the validation errors on the error before throwing it. if the performance penalty is too big I suggest it should be behind a `verbose` option