### PR TITLE
fix: anyOf produces invalid json due to extra comma

### DIFF
--- a/index.js
+++ b/index.js
@@ -900,6 +900,8 @@ function buildValue (context, location, input) {
     `
     if (schema.type === 'object') {
       code += `
+        if (json.endsWith(','))
+          json = json.substr(0, json.length - 1)
         json += '}'
       `
       context.wrapObjects = true

--- a/test/anyof.test.js
+++ b/test/anyof.test.js
@@ -644,3 +644,22 @@ test('object with ref and validated properties', (t) => {
   const stringify = build(schema, { schema: externalSchemas })
   t.equal(stringify({ id: 1, reference: 'hi' }), '{"id":1,"reference":"hi"}')
 })
+
+test('anyOf required props', (t) => {
+  t.plan(3)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      prop1: { type: 'string' },
+      prop2: { type: 'string' },
+      prop3: { type: 'string' }
+    },
+    required: ['prop1'],
+    anyOf: [{ required: ['prop2'] }, { required: ['prop3'] }]
+  }
+  const stringify = build(schema)
+  t.equal(stringify({ prop1: 'test', prop2: 'test2' }), '{"prop1":"test","prop2":"test2"}')
+  t.equal(stringify({ prop1: 'test', prop3: 'test3' }), '{"prop1":"test","prop3":"test3"}')
+  t.equal(stringify({ prop1: 'test', prop2: 'test2', prop3: 'test3' }), '{"prop1":"test","prop2":"test2","prop3":"test3"}')
+})


### PR DESCRIPTION
PR to address https://github.com/fastify/fast-json-stringify/issues/642

It simple removes the extra comma that was introduced since https://github.com/fastify/fast-json-stringify/pull/630 .

I spent around an hour trying a better approach where the comma is not added in the first place.
but the code is hard to follow and I don't have enough time to get to the bottom of it.

added test case from the issue (was red before fix, green after)