### PR TITLE
Serializing const type with `'` character

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ const Serializer = require('./lib/serializer')
 const Validator = require('./lib/validator')
 const Location = require('./lib/location')
 
+const SINGLE_TICK = /'/g
+
 let largeArraySize = 2e4
 let largeArrayMechanism = 'default'
 
@@ -834,7 +836,7 @@ function buildConstSerializer (location, input) {
     `
   }
 
-  code += `json += '${JSON.stringify(schema.const).replaceAll("'", "\\'")}'`
+  code += `json += '${JSON.stringify(schema.const).replace(SINGLE_TICK, "\\'")}'`
 
   if (hasNullType) {
     code += `

--- a/index.js
+++ b/index.js
@@ -834,7 +834,7 @@ function buildConstSerializer (location, input) {
     `
   }
 
-  code += `json += '${JSON.stringify(schema.const)}'`
+  code += `json += '${JSON.stringify(schema.const).replaceAll("'", "\\'")}'`
 
   if (hasNullType) {
     code += `

--- a/test/const.test.js
+++ b/test/const.test.js
@@ -82,6 +82,26 @@ test('schema with const string and no input', (t) => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
+test('schema with const string that contains \'', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      foo: { const: "'bar'" }
+    }
+  }
+
+  const validate = validator(schema)
+  const stringify = build(schema)
+  const output = stringify({
+    foo: "'bar'"
+  })
+
+  t.equal(output, '{"foo":"\'bar\'"}')
+  t.ok(validate(JSON.parse(output)), 'valid schema')
+})
+
 test('schema with const number', (t) => {
   t.plan(2)
 


### PR DESCRIPTION
I found a bug in serialization function composition logic where if I have const schema that contains `'` character it doesn't escape that character properly. I fixed this case by escaping all `'` characters in used produced JSON.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
