### PR TITLE
Revert "perf: use `node:` prefix to bypass require.cache call for builtins (#644)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ The standalone mode is used to compile the code that can be directly run by `nod
 itself. You need to have `fast-json-stringify` installed for the standalone code to work.
 
 ```js
-const fs = require('node:fs')
+const fs = require('fs')
 const code = fastJson({
   title: 'default string',
   type: 'object',

--- a/benchmark/bench-cmp-branch.js
+++ b/benchmark/bench-cmp-branch.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { spawn } = require('node:child_process')
+const { spawn } = require('child_process')
 
 const cliSelect = require('cli-select')
 const simpleGit = require('simple-git')

--- a/benchmark/bench-thread.js
+++ b/benchmark/bench-thread.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { workerData: benchmark, parentPort } = require('node:worker_threads')
+const { workerData: benchmark, parentPort } = require('worker_threads')
 
 const Benchmark = require('benchmark')
 Benchmark.options.minSamples = 100

--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const path = require('node:path')
-const { Worker } = require('node:worker_threads')
+const path = require('path')
+const { Worker } = require('worker_threads')
 
 const BENCH_THREAD_PATH = path.join(__dirname, 'bench-thread.js')
 

--- a/build/build-schema-validator.js
+++ b/build/build-schema-validator.js
@@ -3,8 +3,8 @@
 const Ajv = require('ajv')
 const standaloneCode = require('ajv/dist/standalone').default
 const ajvFormats = require('ajv-formats')
-const fs = require('node:fs')
-const path = require('node:path')
+const fs = require('fs')
+const path = require('path')
 
 const ajv = new Ajv({
   addUsedSchema: false,

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('node:http')
+const http = require('http')
 
 const stringify = require('fast-json-stringify')({
   type: 'object',

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 const merge = require('@fastify/deepmerge')()
 const clone = require('rfdc')({ proto: true })
-const { randomUUID } = require('node:crypto')
+const { randomUUID } = require('crypto')
 const { RefResolver } = require('json-schema-ref-resolver')
 
 const validate = require('./lib/schema-validator')

--- a/test/standalone-mode.test.js
+++ b/test/standalone-mode.test.js
@@ -2,8 +2,8 @@
 
 const test = require('tap').test
 const fjs = require('..')
-const fs = require('node:fs')
-const path = require('node:path')
+const fs = require('fs')
+const path = require('path')
 
 function build (opts, schema) {
   return fjs(schema || {

--- a/test/webpack.test.js
+++ b/test/webpack.test.js
@@ -2,7 +2,7 @@
 
 const test = require('tap').test
 const webpack = require('webpack')
-const path = require('node:path')
+const path = require('path')
 
 test('the library should work with webpack', async (t) => {
   t.plan(1)


### PR DESCRIPTION
This reverts commit 4073e5b6c9b2f4c6b4a3cea1f0f1d6f0ba89e769.

Signed-off-by: Matteo Collina <hello@matteocollina.com>

Fixes https://github.com/fastify/fast-json-stringify/issues/659

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
