### PR TITLE
optimize enums with a single value

### DIFF
--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -41,6 +41,30 @@ for (let i = 0; i < SHORT_ARRAY_SIZE; i++) {
 
 const benchmarks = [
   {
+    name: 'single enum string',
+    schema: {
+      type: 'string',
+      enum: ['hello world']
+    },
+    input: 'hello world'
+  },
+  {
+    name: 'const string',
+    schema: {
+      type: 'string',
+      const: 'hello world'
+    },
+    input: 'hello world'
+  },
+  {
+    name: 'const number',
+    schema: {
+      type: 'number',
+      const: 123
+    },
+    input: 123
+  },
+  {
     name: 'short string',
     schema: {
       type: 'string'

--- a/index.js
+++ b/index.js
@@ -847,6 +847,33 @@ function buildConstSerializer (location, input) {
   return code
 }
 
+function buildSingleEnumSerializer (location, input) {
+  const schema = location.schema
+  const type = schema.type
+
+  const hasNullType = Array.isArray(type) && type.includes('null')
+
+  let code = ''
+
+  if (hasNullType) {
+    code += `
+      if (${input} === null) {
+        json += 'null'
+      } else {
+    `
+  }
+
+  code += `json += '${JSON.stringify(schema.enum[0]).replace(SINGLE_TICK, "\\'")}'`
+
+  if (hasNullType) {
+    code += `
+      }
+    `
+  }
+
+  return code
+}
+
 function buildValue (context, location, input) {
   let schema = location.schema
 
@@ -933,6 +960,8 @@ function buildValue (context, location, input) {
 
   if (schema.const !== undefined) {
     code += buildConstSerializer(location, input)
+  } else if (schema.enum && Array.isArray(schema.enum) && schema.enum.length === 1) {
+    code += buildSingleEnumSerializer(location, input)
   } else if (Array.isArray(type)) {
     code += buildMultiTypeSerializer(context, location, input)
   } else {

--- a/test/enum.test.js
+++ b/test/enum.test.js
@@ -3,6 +3,23 @@
 const test = require('tap').test
 const build = require('..')
 
+test('use enum with 1 value', (t) => {
+  t.plan(1)
+  const stringify = build({
+    title: 'Example Schema',
+    type: 'object',
+    properties: {
+      status: {
+        type: 'string',
+        enum: ['ok']
+      }
+    }
+  })
+
+  const obj = { status: 'ok' }
+  t.equal('{"status":"ok"}', stringify(obj))
+})
+
 test('use enum without type', (t) => {
   t.plan(1)
   const stringify = build({


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] <s>documentation is changed or added</s>
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Before and after log:

```console
bmeck@Bradleys-MBP fast-json-stringify % npm run bench # before

> fast-json-stringify@5.9.1 bench
> node ./benchmark/bench.js # before

single enum string....................................... x 33,928,717 ops/sec ±0.32% (196 runs sampled)
const string............................................. x 1,034,264,612 ops/sec ±0.15% (196 runs sampled)
^C
bmeck@Bradleys-MBP fast-json-stringify % npm run bench # after

> fast-json-stringify@5.9.1 bench
> node ./benchmark/bench.js # after

single enum string....................................... x 1,036,391,465 ops/sec ±0.10% (196 runs sampled)
const string............................................. x 1,031,954,256 ops/sec ±0.24% (195 runs sampled)
^C
```