### PR TITLE
fix: consistently handle string in array

### DIFF
--- a/index.js
+++ b/index.js
@@ -680,7 +680,15 @@ function buildArrayTypeCondition (type, accessor) {
       condition = `obj${accessor} === null`
       break
     case 'string':
-      condition = `typeof obj${accessor} === 'string'`
+      condition = `typeof obj${accessor} === 'string' ||
+      obj${accessor} === null ||
+      obj${accessor} instanceof Date ||
+      obj${accessor} instanceof RegExp ||
+      (
+        typeof obj${accessor} === "object" &&
+        typeof obj${accessor}.toString === "function" &&
+        obj${accessor}.toString !== Object.prototype.toString
+      )`
       break
     case 'integer':
       condition = `Number.isInteger(obj${accessor})`
@@ -740,8 +748,7 @@ function buildMultiTypeSerializer (context, location, input) {
             (
               typeof ${input} === "object" &&
               typeof ${input}.toString === "function" &&
-              ${input}.toString !== Object.prototype.toString &&
-              !(${input} instanceof Date)
+              ${input}.toString !== Object.prototype.toString
             )
           )
             ${nestedResult}

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -23,7 +23,7 @@ test('error on invalid largeArrayMechanism', (t) => {
   }), Error('Unsupported large array mechanism invalid'))
 })
 
-function buildTest (schema, toStringify, options) {
+function buildTest (schema, toStringify, options, isOneWay) {
   test(`render a ${schema.title} as JSON`, (t) => {
     t.plan(3)
 
@@ -31,11 +31,35 @@ function buildTest (schema, toStringify, options) {
     const stringify = build(schema, options)
     const output = stringify(toStringify)
 
-    t.same(JSON.parse(output), toStringify)
+    t.same(JSON.parse(output), JSON.parse(JSON.stringify(toStringify)))
     t.equal(output, JSON.stringify(toStringify))
     t.ok(validate(JSON.parse(output)), 'valid schema')
   })
 }
+
+buildTest({
+  title: 'dates tuple',
+  type: 'object',
+  properties: {
+    dates: {
+      type: 'array',
+      minItems: 2,
+      maxItems: 2,
+      items: [
+        {
+          type: 'string',
+          format: 'date-time'
+        },
+        {
+          type: 'string',
+          format: 'date-time'
+        }
+      ]
+    }
+  }
+}, {
+  dates: [new Date(1), new Date(2)]
+})
 
 buildTest({
   title: 'string array',

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -23,7 +23,7 @@ test('error on invalid largeArrayMechanism', (t) => {
   }), Error('Unsupported large array mechanism invalid'))
 })
 
-function buildTest (schema, toStringify, options, isOneWay) {
+function buildTest (schema, toStringify, options) {
   test(`render a ${schema.title} as JSON`, (t) => {
     t.plan(3)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Closes https://github.com/fastify/fast-json-stringify/issues/662

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Notes
- changed `buildTest` to compare parsed-FJS vs parsed-JSON because some things (like `Date`, and in general anything with `.toJSON`) cannot be parsed back after stringification
- removed `!(${input} instanceof Date` check beacuse earlier we already do `|| instanceof Date`
- `toString` check is giga questionable, real `JSON.stringify` behavior ignores `toString` and instead uses `toJSON`, see:
  - [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description)
  - try in REPL: `JSON.stringify({toString:() => 'json'})` vs `JSON.stringify({toJSON:() => 'json'})`