### PR TITLE
fix: non-nullable schema receiving null input does not coerce for default types on object and arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,8 @@ Otherwise, instead of raising an error, null values will be coerced as follows:
 - `number` -> `0`
 - `string` -> `""`
 - `boolean` -> `false`
+- `object` -> `{}`
+- `array` -> `[]`
 
 <a name="largearrays"></a>
 #### Large Arrays

--- a/index.js
+++ b/index.js
@@ -559,11 +559,23 @@ function buildObject (context, location) {
 
   let functionCode = `
   `
+  let checkNullableCode = `
+  `
+
+  const nullable = schema.nullable === true
+  if (!nullable) {
+    checkNullableCode = `
+      if (obj === null) {
+        obj = {}
+      }
+    `
+  }
 
   functionCode += `
     // ${schemaRef}
     function ${functionName} (input) {
-      const obj = ${toJSON('input')} || {}
+      let obj = ${toJSON('input')}
+      ${checkNullableCode}
 
       ${buildInnerObject(context, location)}
     }
@@ -597,12 +609,25 @@ function buildArray (context, location) {
     schemaRef = schemaRef.replace(context.rootSchemaId, '')
   }
 
+  let checkNullableCode = `
+  `
+
   let functionCode = `
     function ${functionName} (obj) {
       // ${schemaRef}
   `
 
+  const nullable = schema.nullable === true
+  if (!nullable) {
+    checkNullableCode = `
+      if (obj === null) {
+        obj = []
+      }
+    `
+  }
+
   functionCode += `
+    ${checkNullableCode}
     if (!Array.isArray(obj)) {
       throw new TypeError(\`The value of '${schemaRef}' does not match schema definition.\`)
     }

--- a/index.js
+++ b/index.js
@@ -559,23 +559,13 @@ function buildObject (context, location) {
 
   let functionCode = `
   `
-  let checkNullableCode = `
-  `
 
   const nullable = schema.nullable === true
-  if (!nullable) {
-    checkNullableCode = `
-      if (obj === null) {
-        obj = {}
-      }
-    `
-  }
-
   functionCode += `
     // ${schemaRef}
     function ${functionName} (input) {
-      let obj = ${toJSON('input')}
-      ${checkNullableCode}
+      const obj = ${toJSON('input')}
+      ${!nullable ? 'if (obj === null) return \'{}\'' : ''}
 
       ${buildInnerObject(context, location)}
     }
@@ -609,25 +599,14 @@ function buildArray (context, location) {
     schemaRef = schemaRef.replace(context.rootSchemaId, '')
   }
 
-  let checkNullableCode = `
-  `
-
   let functionCode = `
     function ${functionName} (obj) {
       // ${schemaRef}
   `
 
   const nullable = schema.nullable === true
-  if (!nullable) {
-    checkNullableCode = `
-      if (obj === null) {
-        obj = []
-      }
-    `
-  }
-
   functionCode += `
-    ${checkNullableCode}
+    ${!nullable ? 'if (obj === null) return \'[]\'' : ''}
     if (!Array.isArray(obj)) {
       throw new TypeError(\`The value of '${schemaRef}' does not match schema definition.\`)
     }

--- a/index.js
+++ b/index.js
@@ -560,10 +560,24 @@ function buildObject (context, location) {
   let functionCode = `
   `
 
+  let checkNullableCode = `
+  `
+  const nullable = schema.nullable === true
+  if (!nullable) {
+    // use schemaRef in the hope there's anything useful for which schema is detecting the issue
+    checkNullableCode += `
+    if (obj === null) {
+      throw new Error('schema: ${schemaRef} is not nullable, received null input!')
+    }
+    `
+  }
+
   functionCode += `
     // ${schemaRef}
     function ${functionName} (input) {
       const obj = ${toJSON('input')}
+      ${checkNullableCode}
+
       ${buildInnerObject(context, location)}
     }
   `

--- a/index.js
+++ b/index.js
@@ -560,23 +560,10 @@ function buildObject (context, location) {
   let functionCode = `
   `
 
-  let checkNullableCode = `
-  `
-  const nullable = schema.nullable === true
-  if (!nullable) {
-    // use schemaRef in the hope there's anything useful for which schema is detecting the issue
-    checkNullableCode += `
-    if (obj === null) {
-      throw new Error('schema: ${schemaRef} is not nullable, received null input!')
-    }
-    `
-  }
-
   functionCode += `
     // ${schemaRef}
     function ${functionName} (input) {
-      const obj = ${toJSON('input')}
-      ${checkNullableCode}
+      const obj = ${toJSON('input')} || {}
 
       ${buildInnerObject(context, location)}
     }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -376,32 +376,6 @@ test('render a double quote as JSON /2', (t) => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('should error on non-nullable', t => {
-  t.plan(1)
-  const schema = {
-    title: 'non-nullable schema error',
-    type: 'object',
-    properties: {
-      firstName: {
-        type: 'string'
-      },
-      lastName: {
-        type: 'string'
-      }
-    },
-    required: ['firstName', 'lastName']
-  }
-
-  try {
-    const stringify = build(schema)
-    stringify(null)
-    t.fail('stringify should throw for null doc validated on non-nullable schema')
-  } catch (err) {
-    const message = err.message
-    t.equal(message, 'schema: # is not nullable, received null input!')
-  }
-})
-
 test('render a long string', (t) => {
   t.plan(2)
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -376,6 +376,32 @@ test('render a double quote as JSON /2', (t) => {
   t.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
+test('should error on non-nullable', t => {
+  t.plan(1)
+  const schema = {
+    title: 'non-nullable schema error',
+    type: 'object',
+    properties: {
+      firstName: {
+        type: 'string'
+      },
+      lastName: {
+        type: 'string'
+      }
+    },
+    required: ['firstName', 'lastName']
+  }
+
+  try {
+    const stringify = build(schema)
+    stringify(null)
+    t.fail('stringify should throw for null doc validated on non-nullable schema')
+  } catch (err) {
+    const message = err.message
+    t.equal(message, 'schema: # is not nullable, received null input!')
+  }
+})
+
 test('render a long string', (t) => {
   t.plan(2)
 

--- a/test/toJSON.test.js
+++ b/test/toJSON.test.js
@@ -127,7 +127,7 @@ test('not fail on null sub-object declared nullable', (t) => {
   t.equal('{"product":null}', stringify(object))
 })
 
-test('throw an error on non nullable null sub-object', (t) => {
+test('on non nullable null sub-object it should coerce to {}', (t) => {
   t.plan(1)
 
   const stringify = build({
@@ -148,10 +148,12 @@ test('throw an error on non nullable null sub-object', (t) => {
   const object = {
     product: null
   }
-  t.throws(() => { stringify(object) })
+
+  const result = stringify(object)
+  t.equal(result, JSON.stringify({ product: {} }))
 })
 
-test('throw an error on non nullable null object', (t) => {
+test('on non nullable null object it should coerce to {}', (t) => {
   t.plan(1)
 
   const stringify = build({
@@ -170,5 +172,37 @@ test('throw an error on non nullable null object', (t) => {
       }
     }
   })
-  t.throws(() => { stringify(null) })
+
+  const result = stringify(null)
+  t.equal(result, '{}')
+})
+
+test('on non-nullable null object with required fields it should throw complaining missing required fields', (t) => {
+  t.plan(1)
+
+  const stringify = build({
+    title: 'simple object',
+    nullable: false,
+    type: 'object',
+    properties: {
+      product: {
+        nullable: false,
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string'
+          }
+        }
+      }
+    },
+    required: ['product']
+  })
+
+  try {
+    stringify(null)
+    t.fail('stringify should throw for missing required fields')
+  } catch (err) {
+    const message = err.message
+    t.equal(message, '"product" is required!')
+  }
 })

--- a/test/toJSON.test.js
+++ b/test/toJSON.test.js
@@ -177,7 +177,7 @@ test('on non nullable null object it should coerce to {}', (t) => {
   t.equal(result, '{}')
 })
 
-test('on non-nullable null object with required fields it should throw complaining missing required fields', (t) => {
+test('on non-nullable null object it should skip rendering, skipping required fields checks', (t) => {
   t.plan(1)
 
   const stringify = build({
@@ -198,11 +198,6 @@ test('on non-nullable null object with required fields it should throw complaini
     required: ['product']
   })
 
-  try {
-    stringify(null)
-    t.fail('stringify should throw for missing required fields')
-  } catch (err) {
-    const message = err.message
-    t.equal(message, '"product" is required!')
-  }
+  const result = stringify(null)
+  t.equal(result, '{}')
 })

--- a/test/typesArray.test.js
+++ b/test/typesArray.test.js
@@ -467,7 +467,7 @@ test('class instance that is simultaneously a string and a json', (t) => {
   t.equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
 })
 
-test('should throw an error when type is array and object is null', (t) => {
+test('should not throw an error when type is array and object is null, it should instead coerce to []', (t) => {
   t.plan(1)
   const schema = {
     type: 'object',
@@ -482,7 +482,8 @@ test('should throw an error when type is array and object is null', (t) => {
   }
 
   const stringify = build(schema)
-  t.throws(() => stringify({ arr: null }), new TypeError('The value of \'#/properties/arr\' does not match schema definition.'))
+  const result = stringify({ arr: null })
+  t.equal(result, JSON.stringify({ arr: [] }))
 })
 
 test('should throw an error when type is array and object is not an array', (t) => {


### PR DESCRIPTION
This PR is related to issue #669. The changes applied bring an error being thrown with a somewhat descriptive message whenever a non-nullable schema of type 'object' validates against a null value.

Before this change, the generated code would ignore checks on the input value, trying to access properties on a null value which of course results in the application throwing `cannot read <prop> of undefined`. To address this we simply add a check on the function head and throw a meaningful error if needed.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
