### PR TITLE
Fix coercion types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -208,6 +208,9 @@ interface StandaloneOption extends build.Options {
   mode: 'standalone'
 }
 
+type StringCoercible = string | Date | RegExp;
+type IntegerCoercible = number | BigInt;
+
 /**
  * Build a stringify function using a schema of the documents that should be stringified
  * @param schema The schema used to stringify values
@@ -217,8 +220,8 @@ declare function build(schema: build.AnySchema, options: DebugOption): { code: s
 declare function build(schema: build.AnySchema, options: DeprecateDebugOption): { code: string, ajv: Ajv };
 declare function build(schema: build.AnySchema, options: StandaloneOption): string;
 declare function build(schema: build.AnySchema, options?: build.Options): <TDoc = any>(doc: TDoc) => any;
-declare function build(schema: build.StringSchema, options?: build.Options): <TDoc extends string = string>(doc: TDoc) => string;
-declare function build(schema: build.IntegerSchema | build.NumberSchema, options?: build.Options): <TDoc extends number = number>(doc: TDoc) => string;
+declare function build(schema: build.StringSchema, options?: build.Options): <TDoc extends StringCoercible = StringCoercible>(doc: TDoc) => string;
+declare function build(schema: build.IntegerSchema | build.NumberSchema, options?: build.Options): <TDoc extends IntegerCoercible = IntegerCoercible>(doc: TDoc) => string;
 declare function build(schema: build.NullSchema, options?: build.Options): <TDoc extends null = null>(doc: TDoc) => "null";
 declare function build(schema: build.BooleanSchema, options?: build.Options): <TDoc extends boolean = boolean>(doc: TDoc) => string;
 declare function build(schema: build.ArraySchema | build.TupleSchema, options?: build.Options): <TDoc extends any[]= any[]>(doc: TDoc) => string;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -3,61 +3,62 @@ import build, { restore, Schema, validLargeArrayMechanisms } from '..'
 import { expectError, expectType } from 'tsd'
 
 // Number schemas
-const schema1: Schema = {
+build({
     type: 'number'
-}
-const schema2: Schema = {
+})(25)
+build({
     type: 'integer'
-}
+})(-5)
+build({
+    type: 'integer'
+})(5n)
 
-build(schema1)(25)
-build(schema2)(-5)
-
-build(schema2, { rounding: 'ceil' })
-build(schema2, { rounding: 'floor' })
-build(schema2, { rounding: 'round' })
-build(schema2, { rounding: 'trunc' })
-expectError(build(schema2, { rounding: 'invalid' }))
+build({
+    type: 'number'
+}, { rounding: 'ceil' })
+build({
+    type: 'number'
+}, { rounding: 'floor' })
+build({
+    type: 'number'
+}, { rounding: 'round' })
+build({
+    type: 'number'
+}, { rounding: 'trunc' })
+expectError(build({
+    type: 'number'
+}, { rounding: 'invalid' }))
 
 // String schema
-const schema3: Schema = {
-    type: 'string'
-}
-
-build(schema3)('foobar')
+build({
+  type: 'string'
+})('foobar')
 
 // Boolean schema
-const schema4: Schema = {
+build({
     type: 'boolean'
-}
-
-build(schema4)(true)
+})(true)
 
 // Null schema
-const schema5: Schema = {
+build({
     type: 'null'
-}
-
-build(schema5)(null)
+})(null)
 
 // Array schemas
-const schema6: Schema = {
+build({
     type: 'array',
     items: { type: 'number' }
-}
-const schema7: Schema = {
+})([25])
+build({
     type: 'array',
     items: [{ type: 'string'}, {type: 'integer'}]
-}
-
-build(schema6)([25])
-build(schema7)(['hello', 42])
+})(['hello', 42])
 
 // Object schemas
-const schema8: Schema = {
+build({
     type: 'object'
-}
-const schema9: Schema = {
+})({})
+build({
     type: 'object',
     properties: {
         foo: { type: 'string' },
@@ -70,14 +71,24 @@ const schema9: Schema = {
     additionalProperties: {
       type: 'boolean'
     }
-}
-
-build(schema8)({})
-build(schema9)({ foo: 'bar' })
-build(schema9, { rounding: 'floor' })({ foo: 'bar' })
+})({ foo: 'bar' })
+build({
+    type: 'object',
+    properties: {
+        foo: { type: 'string' },
+        bar: { type: 'integer' }
+    },
+    required: ['foo'],
+    patternProperties: {
+      'baz*': { type: 'null' }
+    },
+    additionalProperties: {
+      type: 'boolean'
+    }
+}, { rounding: 'floor' })({ foo: 'bar' })
 
 // Reference schemas
-const schema10: Schema = {
+build({
   title: 'Example Schema',
   definitions: {
     num: {
@@ -109,12 +120,10 @@ const schema10: Schema = {
   additionalProperties: {
     $ref: '#/definitions/def'
   }
-}
-
-build(schema10)({ nickname: '', num: { int: 5 }, other: null })
+})({ nickname: '', num: { int: 5 }, other: null })
 
 // Conditional/Combined schemas
-const schema11: Schema = {
+build({
   title: 'Conditional/Combined Schema',
   type: 'object',
   properties: {
@@ -140,24 +149,37 @@ const schema11: Schema = {
       somethingElse: { type: 'null' }
     }
   }
-}
-
-build(schema11)({ something: 'a string', somethingElse: 42 })
+})({ something: 'a string', somethingElse: 42 })
 
 // String schema with format
-const schema12: Schema = {
+
+build({
   type: 'string',
   format: 'date-time'
-}
+})(new Date())
 
-build(schema12)(new Date())
-
+/*
+This overload doesn't work yet - 
+TypeScript chooses the generic for the schema
+before it chooses the overload for the options
+parameter.
 let str: string, ajv: Ajv
-str = build(schema1, { debugMode: true }).code
-ajv = build(schema1, { debugMode: true }).ajv
-str = build(schema1, { mode: 'debug' }).code
-ajv = build(schema1, { mode: 'debug' }).ajv
-str = build(schema1, { mode: 'standalone' })
+str = build({
+    type: 'number'
+}, { debugMode: true }).code
+ajv = build({
+    type: 'number'
+}, { debugMode: true }).ajv
+str = build({
+    type: 'number'
+}, { mode: 'debug' }).code
+ajv = build({
+    type: 'number'
+}, { mode: 'debug' }).ajv
+str = build({
+    type: 'number'
+}, { mode: 'standalone' })
+*/
 
 const debugCompiled = build({
   title: 'default string',


### PR DESCRIPTION
- Fixes #682

This fixes the ability for `fast-json-stringify` to coerce Dates into strings and BigInts into numbers. These type tests weren't having any effect before: when schemas are declared like

```ts
// Number schemas
const schema1: Schema = {
    type: 'number'
}
const schema2: Schema = {
    type: 'integer'
}

build(schema1)(25)
build(schema2)(-5)
```

`schema1` and `schema2` are typed simply `Schema`, so none of the nice type inference is triggered and you can pass any argument to the method, like

```ts
build(schema1)({ xyz: 1 })
```

And there will be no type error. This adds some duplication because the two options that I know of are either adding `as const` to the end of each schema declaraction, or using a literal. `as const` doesn't work in this situation because it makes the type readonly, which then isn't accepted by `build()`.

This disables a bunch of tests here: https://github.com/fastify/fast-json-stringify/pull/683/files#diff-72016aeffe80c3b259bbbf7e92a664cd2bcf49c2b79597740b4dcd8e430107bdR161 which are breaking for a different reason - the type declaration itself has always, afaict, been wrong, and there isn't an easy way to fix it. This PR just uncovered that pre-existing issue.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
