### PR TITLE
Performance improvment: Add format "raw" for "string" type (skip escaping)

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,25 @@ integer-like values, such as:
 - `'2e4'` - _note this will be converted to `2`, not `20000`_
 - `1.5` - _note this will be converted to `1`_
 
+<a name="raw"></a>
+#### Raw string
+By default the library escape all string. With format "raw" the string isn't escaped. This has a very dangerous potential security issue. Raw format would not escape a double quote char which makes it very easy to inject something into the data. You can use it only if you 200% sure in your data. 
+The advantage is a massive performance improvement
+
+Example:
+```javascript
+const stringify = fastJson({
+  title: 'Example Schema',
+  type: 'object',
+  properties: {
+    'code': {
+	type: 'string',
+	format 'raw'
+    }
+  }
+})
+```
+
 ##### Benchmarks
 
 For reference, here goes some benchmarks for comparison over the three

--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -39,7 +39,6 @@ for (let i = 0; i < SHORT_ARRAY_SIZE; i++) {
   shortArrayOfMultiObject[i] = { s: 'hello world', n: 42, b: true }
 }
 
-
 const benchmarks = [
   {
     name: 'short string',

--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -39,6 +39,7 @@ for (let i = 0; i < SHORT_ARRAY_SIZE; i++) {
   shortArrayOfMultiObject[i] = { s: 'hello world', n: 42, b: true }
 }
 
+
 const benchmarks = [
   {
     name: 'short string',

--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -48,6 +48,14 @@ const benchmarks = [
     input: 'hello world'
   },
   {
+    name: 'short string raw',
+    schema: {
+      type: 'string',
+      format: 'raw'
+    },
+    input: 'hello world'
+  },
+  {
     name: 'short string with double quote',
     schema: {
       type: 'string'
@@ -62,9 +70,25 @@ const benchmarks = [
     input: longSimpleString
   },
   {
+    name: 'long string without double quotes raw',
+    schema: {
+      type: 'string',
+      format: 'raw'
+    },
+    input: longSimpleString
+  },
+  {
     name: 'long string',
     schema: {
       type: 'string'
+    },
+    input: longString
+  },
+  {
+    name: 'long string raw',
+    schema: {
+      type: 'string',
+      format: 'raw'
     },
     input: longString
   },

--- a/index.js
+++ b/index.js
@@ -726,7 +726,7 @@ function buildSingleTypeSerializer (context, location, input) {
       } else if (schema.format === 'time') {
         return `json += serializer.asTime(${input})`
       } else {
-        const format = schema?.format ? `${schema.format}` : 'null'
+        const format = schema?.format ? `"${schema.format}"` : 'null'
         return `json += serializer.asString(${input},${format})`
       }
     }

--- a/index.js
+++ b/index.js
@@ -726,7 +726,7 @@ function buildSingleTypeSerializer (context, location, input) {
       } else if (schema.format === 'time') {
         return `json += serializer.asTime(${input})`
       } else {
-        return `json += serializer.asString(${input})`
+        return `json += serializer.asString(${input},"${schema.format}")`
       }
     }
     case 'integer':

--- a/index.js
+++ b/index.js
@@ -284,7 +284,7 @@ function buildExtraObjectPropertiesSerializer (context, location, addComma) {
       code += `
         if (/${propertyKey.replace(/\\*\//g, '\\/')}/.test(key)) {
           ${addComma}
-          json += serializer.asString(key) + ':'
+          json += serializer.asString(key,null) + ':'
           ${buildValue(context, propertyLocation, 'value')}
           continue
         }
@@ -299,13 +299,13 @@ function buildExtraObjectPropertiesSerializer (context, location, addComma) {
     if (additionalPropertiesSchema === true) {
       code += `
         ${addComma}
-        json += serializer.asString(key) + ':' + JSON.stringify(value)
+        json += serializer.asString(key,null) + ':' + JSON.stringify(value)
       `
     } else {
       const propertyLocation = location.getPropertyLocation('additionalProperties')
       code += `
         ${addComma}
-        json += serializer.asString(key) + ':'
+        json += serializer.asString(key,null) + ':'
         ${buildValue(context, propertyLocation, 'value')}
       `
     }
@@ -726,7 +726,7 @@ function buildSingleTypeSerializer (context, location, input) {
       } else if (schema.format === 'time') {
         return `json += serializer.asTime(${input})`
       } else {
-        return `json += serializer.asString(${input},"${schema?.format}")`
+        return `json += serializer.asString(${input},"${schema.format}")`
       }
     }
     case 'integer':

--- a/index.js
+++ b/index.js
@@ -726,7 +726,7 @@ function buildSingleTypeSerializer (context, location, input) {
       } else if (schema.format === 'time') {
         return `json += serializer.asTime(${input})`
       } else {
-        return `json += serializer.asString(${input},"${schema.format}")`
+        return `json += serializer.asString(${input},"${schema?.format}")`
       }
     }
     case 'integer':

--- a/index.js
+++ b/index.js
@@ -726,7 +726,8 @@ function buildSingleTypeSerializer (context, location, input) {
       } else if (schema.format === 'time') {
         return `json += serializer.asTime(${input})`
       } else {
-        return `json += serializer.asString(${input},"${schema.format}")`
+        const format = schema?.format ? `${schema.format}` : 'null'
+        return `json += serializer.asString(${input},${format})`
       }
     }
     case 'integer':

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -114,7 +114,7 @@ module.exports = class Serializer {
     }
 
     if (format === 'raw') {
-      return '"' + str + '"';
+      return '"' + str + '"'
     } else if (str.length < 42) {
       return this.asStringSmall(str)
     } else if (STR_ESCAPE.test(str) === false) {

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -98,7 +98,7 @@ module.exports = class Serializer {
     throw new Error(`The value "${date}" cannot be converted to a time.`)
   }
 
-  asString (str) {
+  asString (str, format) {
     if (typeof str !== 'string') {
       if (str === null) {
         return '""'

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -113,7 +113,9 @@ module.exports = class Serializer {
       }
     }
 
-    if (str.length < 42) {
+    if (format === 'raw') {
+      return '"' + str + '"';
+    } else if (str.length < 42) {
       return this.asStringSmall(str)
     } else if (STR_ESCAPE.test(str) === false) {
       return '"' + str + '"'

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -19,6 +19,12 @@ function buildTest (schema, toStringify) {
 }
 
 buildTest({
+  title: 'string',
+  type: 'string',
+  format: 'raw'
+}, 'hello world')
+
+buildTest({
   title: 'basic',
   type: 'object',
   properties: {

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -4,6 +4,22 @@ const t = require('tap')
 const test = t.test
 const build = require('..')
 
+test('serialize short string raw', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'string',
+    format: 'raw'
+  }
+
+  const input = 'abcd'
+  const stringify = build(schema)
+  const output = stringify(input)
+
+  t.equal(output, '"abcd"')
+  t.equal(JSON.parse(output), input)
+})
+
 test('serialize short string', (t) => {
   t.plan(2)
 


### PR DESCRIPTION
JSON with a lot of strings take time during escaping. 

This PR introduce "raw" string format (no need to escape).

```json
"schema": {
  "type": "string",
  "format": "raw"
}
```
benchmark (compare classic bench VS same bench with format raw)
```
short string............................................. x 22,581,464 ops/sec ±0.79% (186 runs sampled)
short string and raw..................................... x 1,038,659,823 ops/sec ±0.40% (189 runs sampled)

long string without double quotes........................ x 22,477 ops/sec ±0.46% (192 runs sampled)
long string without double quotes raw.................... x 1,035,763,724 ops/sec ±0.39% (189 runs sampled)

long string.............................................. x 15,865 ops/sec ±0.42% (190 runs sampled)
long string raw.......................................... x 1,060,214,143 ops/sec ±0.49% (190 runs sampled)
```

raw string seem x45 faster