### PR TITLE
feat: unsafe string format

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,24 @@ integer-like values, such as:
 - `'2e4'` - _note this will be converted to `2`, not `20000`_
 - `1.5` - _note this will be converted to `1`_
 
+<a name="unsafe"></a>
+#### Unsafe string
+By default, the library escapes all strings. With the 'unsafe' format, the string isn't escaped. This has a potentially dangerous security issue. You can use it only if you are sure that your data doesn't need escaping. The advantage is a significant performance improvement.
+
+Example:
+```javascript
+const stringify = fastJson({
+  title: 'Example Schema',
+  type: 'object',
+  properties: {
+    'code': {
+	    type: 'string',
+	    format 'unsafe'
+    }
+  }
+})
+```
+
 ##### Benchmarks
 
 For reference, here goes some benchmarks for comparison over the three

--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -48,6 +48,14 @@ const benchmarks = [
     input: 'hello world'
   },
   {
+    name: 'unsafe short string',
+    schema: {
+      type: 'string',
+      format: 'unsafe'
+    },
+    input: 'hello world'
+  },
+  {
     name: 'short string with double quote',
     schema: {
       type: 'string'
@@ -62,9 +70,25 @@ const benchmarks = [
     input: longSimpleString
   },
   {
+    name: 'unsafe long string without double quotes',
+    schema: {
+      type: 'string',
+      format: 'unsafe'
+    },
+    input: longSimpleString
+  },
+  {
     name: 'long string',
     schema: {
       type: 'string'
+    },
+    input: longString
+  },
+  {
+    name: 'unsafe long string',
+    schema: {
+      type: 'string',
+      format: 'unsafe'
     },
     input: longString
   },

--- a/index.js
+++ b/index.js
@@ -725,6 +725,8 @@ function buildSingleTypeSerializer (context, location, input) {
         return `json += serializer.asDate(${input})`
       } else if (schema.format === 'time') {
         return `json += serializer.asTime(${input})`
+      } else if (schema.format === 'unsafe') {
+        return `json += serializer.asUnsafeString(${input})`
       } else {
         return `json += serializer.asString(${input})`
       }

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -122,6 +122,10 @@ module.exports = class Serializer {
     }
   }
 
+  asUnsafeString (str) {
+    return '"' + str + '"'
+  }
+
   // magically escape strings for json
   // relying on their charCodeAt
   // everything below 32 needs JSON.stringify()

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -19,6 +19,12 @@ function buildTest (schema, toStringify) {
 }
 
 buildTest({
+  title: 'string',
+  type: 'string',
+  format: 'unsafe'
+}, 'hello world')
+
+buildTest({
   title: 'basic',
   type: 'object',
   properties: {

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -48,3 +48,37 @@ test('serialize long string', (t) => {
   t.equal(output, `"${new Array(2e4).fill('\\u0000').join('')}"`)
   t.equal(JSON.parse(output), input)
 })
+
+test('unsafe string', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'string',
+    format: 'unsafe'
+  }
+
+  const input = 'abcd'
+  const stringify = build(schema)
+  const output = stringify(input)
+
+  t.equal(output, `"${input}"`)
+  t.equal(JSON.parse(output), input)
+})
+
+test('unsafe unescaped string', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'string',
+    format: 'unsafe'
+  }
+
+  const input = 'abcd "abcd"'
+  const stringify = build(schema)
+  const output = stringify(input)
+
+  t.equal(output, `"${input}"`)
+  t.throws(function () {
+    JSON.parse(output)
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This PR add the 'unsafe' string format. By default, `fast-json-stringify` escapes all strings. With the 'unsafe' format, the string isn't escaped. This has a potentially dangerous security issue. You can use it only if you are sure that your data doesn't need escaping. The advantage is a significant performance improvement.

Usage into the JSON schema

```javascript
const stringify = fastJson({
  title: 'Example Schema',
  type: 'object',
  properties: {
    'code': {
      type: 'string',
      format 'unsafe'
    }
  }
})
```

benchmark (safe VS unsafe):

```
short string............................................. x 14,605,189 ops/sec ±3.85% (157 runs sampled)
unsafe short string...................................... x 693,266,405 ops/sec ±3.05% (187 runs sampled)

long string without double quotes........................ x 19,598 ops/sec ±3.48% (165 runs sampled)
unsafe long string without double quotes................. x 378,676,248 ops/sec ±2.95% (157 runs sampled)

long string.............................................. x 6,330 ops/sec ±5.32% (169 runs sampled)
unsafe long string....................................... x 555,420,885 ops/sec ±2.04% (167 runs sampled)
```

side note: this PR is the continuation of the https://github.com/fastify/fast-json-stringify/pull/685 ([cesco69](https://github.com/cesco69) is my other account). https://github.com/fastify/fast-json-stringify/pull/685 will be closed and I'll continue here

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
