### PR TITLE
chore: performance improvement on asStringSmall

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -141,11 +141,8 @@ module.exports = class Serializer {
     // eslint-disable-next-line
     for (var i = 0; i < len; i++) {
       point = str.charCodeAt(i)
-      if (point < 32) {
-        return JSON.stringify(str)
-      }
-      if (point >= 0xD800 && point <= 0xDFFF) {
-        // The current character is a surrogate.
+      if (point < 32 || (point >= 0xD800 && point <= 0xDFFF)) {
+        // The current character is non-printable characters or a surrogate.
         return JSON.stringify(str)
       }
       if (


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Comparing more values in a single if statement has a little performance hit instead of make multiple if statement. In general, combining multiple comparisons into one if statement might result in slightly better performance due to reduced overhead from evaluating conditions and executing multiple control flow structures. This is because combining conditions can reduce the number of times the JavaScript engine has to evaluate expressions and jump between different parts of the code.

benchmark (master VS PR)
```
short string............................................. x 16,634,103 ops/sec ±2.06% (182 runs sampled)

short string............................................. x 18,920,179 ops/sec ±1.07% (184 runs sampled)
```

PR seems better!

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
