### PR TITLE
fix: make asString monomorphic  and trigger V8 optimization

### DIFF
--- a/index.js
+++ b/index.js
@@ -728,7 +728,21 @@ function buildSingleTypeSerializer (context, location, input) {
       } else if (schema.format === 'unsafe') {
         return `json += serializer.asUnsafeString(${input})`
       } else {
-        return `json += serializer.asString(${input})`
+        return `
+        if (typeof ${input} !== 'string') {
+          if (${input} === null) {
+            json += '""'
+          } else if (${input} instanceof Date) {
+            json += '"' + ${input}.toISOString() + '"'
+          } else if (${input} instanceof RegExp) {
+            json += serializer.asString(${input}.source)
+          } else {
+            json += serializer.asString(${input}.toString())
+          }
+        } else {
+          json += serializer.asString(${input})
+        }
+        `
       }
     }
     case 'integer':

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -99,20 +99,6 @@ module.exports = class Serializer {
   }
 
   asString (str) {
-    if (typeof str !== 'string') {
-      if (str === null) {
-        return '""'
-      }
-      if (str instanceof Date) {
-        return '"' + str.toISOString() + '"'
-      }
-      if (str instanceof RegExp) {
-        str = str.source
-      } else {
-        str = str.toString()
-      }
-    }
-
     if (str.length < 42) {
       return this.asStringSmall(str)
     } else if (STR_ESCAPE.test(str) === false) {


### PR DESCRIPTION
asString is Polymorphic/Megamorphic because accept more type (string, date, regex, null)

So let’s spend some more time defining this.

- Monomorphic: If function arguments are always the same type.
- Polymorphic: If function arguments are few (four or fewer) different type.
- Megamorphic: If function arguments are more than four type.

In short: functions that are invoked with the same types over and over again are optimized in the JIT compiler, hence faster.

**Megamorphism asString (actual code)**
```
short string............................................. x 14,825,973 ops/sec ±4.07% (156 runs sampled)
short string with double quote........................... x 6,743,956 ops/sec ±4.15% (156 runs sampled)
long string without double quotes........................ x 3,662 ops/sec ±5.18% (161 runs sampled)
long string.............................................. x 5,154 ops/sec ±3.17% (183 runs sampled)
```

**Monomorphic asString (my PR)**
```
short string............................................. x 15,750,724 ops/sec ±2.55% (172 runs sampled)
short string with double quote........................... x 6,067,413 ops/sec ±3.97% (158 runs sampled)
long string without double quotes........................ x 19,700 ops/sec ±3.74% (169 runs sampled)
long string.............................................. x 13,170 ops/sec ±1.65% (180 runs sampled)
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
