### PR TITLE
chore(perf): only use the regular expression for shorter input

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -101,7 +101,8 @@ module.exports = class Serializer {
   asString (str) {
     if (str.length < 42) {
       return this.asStringSmall(str)
-    } else if (STR_ESCAPE.test(str) === false) {
+    } else if (str.length < 5000 && STR_ESCAPE.test(str) === false) {
+      // Only use the regular expression for shorter input. The overhead is otherwise too much.
       return '"' + str + '"'
     } else {
       return JSON.stringify(str)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Only use the regular expression `STR_ESCAPE` for shorter input. The overhead is otherwise too much.

Before
```
long string without double quotes........................ x 9,395 ops/sec ±6.66% (136 runs sampled)
long string.............................................. x 7,237 ops/sec ±2.61% (175 runs sampled)
```
After
```
long string without double quotes........................ x 13,095 ops/sec ±1.26% (184 runs sampled)
long string.............................................. x 13,734 ops/sec ±1.65% (179 runs sampled)
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
