### PR TITLE
chore: benchmark fast-json-stringify vs JSON.stringify

### DIFF
--- a/benchmark/bench-thread.js
+++ b/benchmark/bench-thread.js
@@ -12,7 +12,11 @@ const stringify = FJS(benchmark.schema)
 
 suite
   .add(benchmark.name, () => {
-    stringify(benchmark.input)
+    if (benchmark.native) {
+      JSON.stringify(benchmark.input)
+    } else {
+      stringify(benchmark.input)
+    }
   })
   .on('cycle', (event) => {
     parentPort.postMessage(String(event.target))

--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -383,8 +383,14 @@ async function runBenchmarks () {
 
   for (const benchmark of benchmarks) {
     benchmark.name = benchmark.name.padEnd(maxNameLength, '.')
-    const resultMessage = await runBenchmark(benchmark)
-    console.log(resultMessage)
+
+    const resultLibMessage = await runBenchmark({ ...benchmark, native: false })
+    console.log(resultLibMessage + ' (fast-json-stringify)')
+
+    const resultNativeMessage = await runBenchmark({ ...benchmark, native: true })
+    console.log(resultNativeMessage + ' (JSON.stringify)')
+
+    console.log('\n')
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

With this PR each benchmark is executed both with fast-json-stringify and JSON.stringify for help developer to compare the result

```
short string............................................. x 17,031,936 ops/sec ±1.16% (186 runs sampled) (fast-json-stringify)
short string............................................. x 9,878,418 ops/sec ±0.92% (189 runs sampled) (JSON.stringify)

unsafe short string...................................... x 754,072,385 ops/sec ±0.69% (188 runs sampled) (fast-json-stringify)
unsafe short string...................................... x 9,676,614 ops/sec ±1.53% (188 runs sampled) (JSON.stringify)

short string with double quote........................... x 9,396,306 ops/sec ±0.93% (187 runs sampled) (fast-json-stringify)
short string with double quote........................... x 9,309,407 ops/sec ±1.19% (187 runs sampled) (JSON.stringify)

long string without double quotes........................ x 28,134 ops/sec ±1.44% (184 runs sampled) (fast-json-stringify)
long string without double quotes........................ x 13,123 ops/sec ±1.27% (183 runs sampled) (JSON.stringify)

unsafe long string without double quotes................. x 707,753,414 ops/sec ±2.58% (186 runs sampled) (fast-json-stringify)
unsafe long string without double quotes................. x 11,775 ops/sec ±0.54% (186 runs sampled) (JSON.stringify)

long string.............................................. x 12,037 ops/sec ±0.48% (190 runs sampled) (fast-json-stringify)
long string.............................................. x 11,718 ops/sec ±0.98% (186 runs sampled) (JSON.stringify)

unsafe long string....................................... x 727,363,512 ops/sec ±0.84% (189 runs sampled) (fast-json-stringify)
unsafe long string....................................... x 12,137 ops/sec ±0.44% (190 runs sampled) (JSON.stringify)

number................................................... x 761,039,377 ops/sec ±0.32% (192 runs sampled) (fast-json-stringify)
number................................................... x 16,054,549 ops/sec ±1.14% (183 runs sampled) (JSON.stringify)

integer.................................................. x 186,907,293 ops/sec ±0.74% (191 runs sampled) (fast-json-stringify)
integer.................................................. x 16,886,344 ops/sec ±1.86% (182 runs sampled) (JSON.stringify)

formatted date-time...................................... x 1,167,297 ops/sec ±1.03% (187 runs sampled) (fast-json-stringify)
formatted date-time...................................... x 550,689 ops/sec ±1.16% (185 runs sampled) (JSON.stringify)

formatted date........................................... x 782,367 ops/sec ±1.14% (185 runs sampled) (fast-json-stringify)
formatted date........................................... x 491,574 ops/sec ±5.02% (182 runs sampled) (JSON.stringify)

formatted time........................................... x 790,945 ops/sec ±0.96% (184 runs sampled) (fast-json-stringify)
formatted time........................................... x 533,953 ops/sec ±1.15% (185 runs sampled) (JSON.stringify)

short array of numbers................................... x 56,663 ops/sec ±4.98% (156 runs sampled) (fast-json-stringify)
short array of numbers................................... x 14,718 ops/sec ±3.91% (153 runs sampled) (JSON.stringify)

short array of integers.................................. x 42,258 ops/sec ±4.17% (153 runs sampled) (fast-json-stringify)
short array of integers.................................. x 12,509 ops/sec ±4.34% (148 runs sampled) (JSON.stringify)
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
