### PR TITLE
chore(perf): asStringSmall slower than JSON.stringify

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -100,7 +100,7 @@ module.exports = class Serializer {
 
   asString (str) {
     if (str.length < 42) {
-      return this.asStringSmall(str)
+      return JSON.stringify(str)
     } else if (str.length < 5000 && STR_ESCAPE.test(str) === false) {
       // Only use the regular expression for shorter input. The overhead is otherwise too much.
       return '"' + str + '"'
@@ -111,38 +111,6 @@ module.exports = class Serializer {
 
   asUnsafeString (str) {
     return '"' + str + '"'
-  }
-
-  // magically escape strings for json
-  // relying on their charCodeAt
-  // everything below 32 needs JSON.stringify()
-  // every string that contain surrogate needs JSON.stringify()
-  // 34 and 92 happens all the time, so we
-  // have a fast case for them
-  asStringSmall (str) {
-    const len = str.length
-    let result = ''
-    let last = -1
-    let point = 255
-
-    // eslint-disable-next-line
-    for (var i = 0; i < len; i++) {
-      point = str.charCodeAt(i)
-      if (point < 32 || (point >= 0xD800 && point <= 0xDFFF)) {
-        // The current character is non-printable characters or a surrogate.
-        return JSON.stringify(str)
-      }
-      if (
-        point === 0x22 || // '"'
-        point === 0x5c // '\'
-      ) {
-        last === -1 && (last = 0)
-        result += str.slice(last, i) + '\\'
-        last = i
-      }
-    }
-
-    return (last === -1 && ('"' + str + '"')) || ('"' + result + str.slice(last) + '"')
   }
 
   getState () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

`asStringSmall`  seem slower than `JSON.stringify`

[online benchmark](https://perf.link/#eyJpZCI6ImVueW1ieXRpdnY2IiwidGl0bGUiOiJhc1N0cmluZ1NtYWxsIHZzIEpTT04uc3RyaW5naWZ5IiwiYmVmb3JlIjoiZnVuY3Rpb24gYXNTdHJpbmdTbWFsbChzdHIpIHtcbiAgICBjb25zdCBsZW4gPSBzdHIubGVuZ3RoXG4gICAgbGV0IHJlc3VsdCA9ICcnXG4gICAgbGV0IGxhc3QgPSAtMVxuICAgIGxldCBwb2ludCA9IDI1NVxuXG4gICAgLy8gZXNsaW50LWRpc2FibGUtbmV4dC1saW5lXG4gICAgZm9yICh2YXIgaSA9IDA7IGkgPCBsZW47IGkrKykge1xuICAgICAgcG9pbnQgPSBzdHIuY2hhckNvZGVBdChpKVxuICAgICAgaWYgKHBvaW50IDwgMzIgfHwgKHBvaW50ID49IDB4RDgwMCAmJiBwb2ludCA8PSAweERGRkYpKSB7XG4gICAgICAgIC8vIFRoZSBjdXJyZW50IGNoYXJhY3RlciBpcyBub24tcHJpbnRhYmxlIGNoYXJhY3RlcnMgb3IgYSBzdXJyb2dhdGUuXG4gICAgICAgIHJldHVybiBKU09OLnN0cmluZ2lmeShzdHIpXG4gICAgICB9XG4gICAgICBpZiAoXG4gICAgICAgIHBvaW50ID09PSAweDIyIHx8IC8vICdcIidcbiAgICAgICAgcG9pbnQgPT09IDB4NWMgLy8gJ1xcJ1xuICAgICAgKSB7XG4gICAgICAgIGxhc3QgPT09IC0xICYmIChsYXN0ID0gMClcbiAgICAgICAgcmVzdWx0ICs9IHN0ci5zbGljZShsYXN0LCBpKSArICdcXFxcJ1xuICAgICAgICBsYXN0ID0gaVxuICAgICAgfVxuICAgIH1cblxuICAgIHJldHVybiAobGFzdCA9PT0gLTEgJiYgKCdcIicgKyBzdHIgKyAnXCInKSkgfHwgKCdcIicgKyByZXN1bHQgKyBzdHIuc2xpY2UobGFzdCkgKyAnXCInKVxuICB9XG5jb25zdCBTVFJfMSAgPSAnQSdcbmNvbnN0IFNUUl8xMCA9IFNUUl8xIC5yZXBlYXQoMTApXG5jb25zdCBTVFJfMjAgPSBTVFJfMSAucmVwZWF0KDIwKVxuY29uc3QgU1RSXzMwID0gU1RSXzEgLnJlcGVhdCgzMClcbmNvbnN0IFNUUl80MCA9IFNUUl8xIC5yZXBlYXQoNDApIiwidGVzdHMiOlt7Im5hbWUiOiJhc1N0cmluZ1NtYWxsKFNUUl8xKSIsImNvZGUiOiJhc1N0cmluZ1NtYWxsKFNUUl8xKSIsInJ1bnMiOlsxMDAwLDMxMjAwMCw0ODAwMCwyMTUwMDAsMzEyMDAwLDEwMDAsMzEyMDAwLDY3MzAwMCwxNzEwMDAsMzEyMDAwLDEwMDAsNTIwMDAsMjQwMDAwLDE2ODAwMCwxMDAwLDUyODAwMCw2MDAwLDI4MzAwMCw0NzUwMDAsMzYxMDAwLDIwMDAwMCw5MDYwMDAsMTUzMDAwLDEwMDAsMTAwMCw1NjAwMCw3MjQwMDAsNzg2MDAwLDIzNjAwMCwxMDAwLDMxMjAwMCwzMTIwMDAsMTAwMCwzMTIwMDAsMTE4MDAwLDMxMjAwMCw3MDIwMDAsMjIwMDAwLDY1MDAwLDI3MTAwMCwzODQwMDAsMzE1MDAwLDE3MjAwMCwxMDAwLDMxMzAwMCwzNjYwMDAsNjg2MDAwLDkxMDAwLDMxMjAwMCwxMDUwMDAsMTcwMDAsMTQ0MDAwLDMxMjAwMCwxMDAwLDE3MDAwLDU2MjAwMCwxMDAwLDEwMDAsMzEyMDAwLDEyNTAwMCwzNTAwMCwzMTIwMDAsMzg3MDAwLDQ4MzAwMCwxMDAwLDE1OTAwMCwyMTAwMCwxMDAwLDYwMDAsMzEyMDAwLDE3NDAwMCwxMDAwLDMxMjAwMCwxMDAwLDk2MDAwLDI3MDAwLDIwOTAwMCwyNTcwMDAsMzEyMDAwLDE3MDAwMCwxMDAwLDUwMDAsMTUzMDAwLDMxMTAwMCwxNTkwMDAsMzEyMDAwLDMxMjAwMCwzMTIwMDAsMjI3MDAwLDQ4NjAwMCwzMTIwMDAsMzEyMDAwLDEwMDAsMzEyMDAwLDc1MDAwLDEwMDAsMjI0MDAwLDUyOTAwMCwxNDAwMDAsMjY1MDAwXSwib3BzIjoyMjEyMzB9LHsibmFtZSI6IkpTT04uc3RyaW5naWZ5KFNUUl8xKSIsImNvZGUiOiJKU09OLnN0cmluZ2lmeShTVFJfMSkiLCJydW5zIjpbNTk3MDAwLDY2MjAwMCw5NDAwMDAsMzY1MDAwLDE0NDAwMCw4NTkwMDAsMzMzMDAwLDc3MDAwMCw0MDcwMDAsNjkyMDAwLDQ4MjAwMCw1ODYwMDAsNjU1MDAwLDEzOTkwMDAsNDk2MDAwLDEzOTkwMDAsNTQ3MDAwLDg1NjAwMCwyMDY4MDAwLDUzMjAwMCw2NzMwMDAsMTM5OTAwMCwyNTAwMDAsNTQzMDAwLDMxNTAwMCwyMTMwMDAsOTUyMDAwLDU4MzAwMCw5OTEwMDAsMTg1MDAwLDYxMDAwMCw4MDkwMDAsNTE2MDAwLDUwMDAwLDQ1NTAwMCwzMDAwLDMyNTAwMCw3ODkwMDAsMTQ4MDAwLDU2NzAwMCwzOTcwMDAsNjIzMDAwLDE0ODAwMCwyNzQwMDAsNTk2MDAwLDc1NDAwMCwxOTgwMDAwLDEzOTcwMDAsMTEyODAwMCw2MDEwMDAsNTQ1MDAwLDQzOTAwMCwzMTcwMDAsMTkyMDAwLDc0NjAwMCwxMTQyMDAwLDMyMTAwMCwxNjUwMDAsMzAxMDAwLDM5NzAwMCwyNTAwMDAsNjE5MDAwLDI5NzAwMCw1NTAwMCwyNjUwMDAsMzIwMDAwLDEwNjYwMDAsMzUxMDAwLDE3MzAwMCwxMzk5MDAwLDExNjgwMDAsNDM4MDAwLDQ3MTAwMCwxOTAwMCw5MjEwMDAsMTgwMDAsNDI1MDAwLDY2MjAwMCw1MDYwMDAsODMwMDAsNDg4MDAwLDg3NTAwMCw1MDYwMDAsMTc3NjAwMCw1NTAwMCwxMTU3MDAwLDI1NzAwMCw4MDUwMDAsNTgwMDAwLDI4MzAwMCwxMzk5MDAwLDczODAwMCw4MjAwMDAsMTM5OTAwMCwxMDczMDAwLDEyMTUwMDAsMTU0NDAwMCw5NTIwMDAsMTQ1MDAwLDcxMDAwMF0sIm9wcyI6NjM5MTEwfSx7Im5hbWUiOiJhc1N0cmluZ1NtYWxsKFNUUl8xMCkiLCJjb2RlIjoiYXNTdHJpbmdTbWFsbChTVFJfMTApIiwicnVucyI6WzEwMDAsMTAwMCwxNjAwMCw3MTAwMCwyMjAwMCw1MDAwLDIwMDAsNzgwMDAsNjgwMDAsNTMwMDAsMTAwMCw1MzAwMCwxMDAwLDk5MDAwLDI0NDAwMCw3MTAwMCwyNTUwMDAsMTAwMCwxMDAwLDIwMDAsNzEwMDAsNDMwMDAsMTAwMCwyMzEwMDAsOTkwMDAsNDc3MDAwLDUyNzAwMCw0ODAwMCwyMDAwLDEwNTAwMCwzOTAwMCw3MTAwMCwxMDAwLDExMjAwMCw3MTAwMCw5MTAwMCw3MTAwMCw1MzAwMCw3MTAwMCwxMTAwMCwxMDAwLDcxMDAwLDcxMDAwLDE2MDAwLDcxMDAwLDcxMDAwLDcxMDAwLDcxMDAwLDEwMDAsMjAyMDAwLDEwMDAsMTQwMDAsMTAwMCw1MDAwMCwxMDAwLDcxMDAwLDcxMDAwLDIwMDAsNzEwMDAsMTQwMDAwLDEzMDAwLDcxMDAwLDQwMDAwLDEwMDAsNzEwMDAsMTAwMCwyNjAwMCwxMDAwLDMxNTAwMCw4ODAwMCwyMDUwMDAsNzEwMDAsNDkwMDAsMjE2MDAwLDMyMTAwMCw3MDAwMCw0MDAwLDY4MDAwLDcxMDAwLDIyODAwMCwxMDAwLDEwMDAsNzEwMDAsMTMwMDAsNzAwMDAsMTQyMDAwLDEwMDAsMTAwMCw0MDAwMCwxMzcwMDAsODQwMDAsNzEwMDAsNzEwMDAsMTE1MDAwLDcxMDAwLDIxMDAwLDEwMDAsNzEwMDAsMTEwMDAsODIwMDBdLCJvcHMiOjczMTMwfSx7Im5hbWUiOiJKU09OLnN0cmluZ2lmeShTVFJfMTApIiwiY29kZSI6IkpTT04uc3RyaW5naWZ5KFNUUl8xMCkiLCJydW5zIjpbMzYwMDAwLDUyNjAwMCwyMzgwMDAsNzI0MDAwLDM1NTAwMCw0MjAwMDAsNzg4MDAwLDEwMDkwMDAsNDUyMDAwLDQyMjAwMCwyNTQwMDAsOTYwMDAsNzAwMDAsMTAxMzAwMCwzOTYwMDAsMzczMDAwLDEzOTkwMDAsMTMxMDAwLDExODcwMDAsNjI3MDAwLDg1OTAwMCwzMDAwMCw5MTAwMDAsMTAzMDAwLDMzOTAwMCwxMjE5MDAwLDMyOTAwMCw4NzIwMDAsNTMwMDAwLDg2OTAwMCwxNzkwMDAsMTM5OTAwMCw1MjAwMCwzOTQwMDAsODgwMDAwLDQ3NTAwMCw1NTkwMDAsNjQ1MDAwLDIwODAwMCw0MjIwMDAsOTg3MDAwLDg4OTAwMCwyNDYwMDAsOTc3MDAwLDE0NzQwMDAsNzc3MDAwLDkxNDAwMCwxMTc1MDAwLDgzNjAwMCw1MDEwMDAsMTM5OTAwMCwyNTkwMDAsNjY4MDAwLDU0MDAwMCwyMDAwLDQ5NzAwMCwxNDkwMDAsMjQ1MDAwLDkzOTAwMCwxMzQwMDAsMzE0MDAwLDk5NjAwMCw4NTQwMDAsODEwMDAsNzY5MDAwLDM5MjAwMCw0NzYwMDAsMTM5OTAwMCwxMjQ3MDAwLDEzMDAwMDAsMTM5OTAwMCw5NDEwMDAsNDkyMDAwLDI5MDAwLDUzNzAwMCw3NjQwMDAsNjg4MDAwLDEzMzYwMDAsMzIzMDAwLDk0MDAwMCw1MzQwMDAsMzU3MDAwLDE3MDAwLDU1ODAwMCwyMjAwMCwzNDMwMDAsNzYwMDAwLDI0MjAwMCwzODAwMDAsMTI0MDAwLDQ2MjAwMCw4MDIwMDAsMTk1MDAwLDEwMDAwLDI0NjIwMDAsNjgxMDAwLDEwOTAwMCw1MzMwMDAsMTcwMDAsMTk2MDAwXSwib3BzIjo1OTgwMjB9LHsibmFtZSI6ImFzU3RyaW5nU21hbGwoU1RSXzIwKSIsImNvZGUiOiJhc1N0cmluZ1NtYWxsKFNUUl8yMCkiLCJydW5zIjpbMTEwMDAsMzkwMDAsMzkwMDAsMzkwMDAsMTc3MDAwLDIyMDAwLDEyMzAwMCwyNjAwMCw2MDAwLDMzMDAwLDEwMDAsMTkwMDAsMTAwMCwxMDAwLDEwMDAsMTAwMCwzOTAwMCwxMDAwLDE4MzAwMCwxMDAwLDM5MDAwLDEwMDAsMTAwMCwzOTAwMCwzOTAwMCwxOTQwMDAsMzcwMDAsMjExMDAwLDEwMDAsMTMwMDAsMzkwMDAsMzkwMDAsMTAwMCwyMTAwMCwzOTAwMCwxMDAwLDE2MzAwMCwyMzAwMCwzOTAwMCw1MzAwMCwzOTAwMCw3OTAwMCw1MTAwMCwyMzAwMCwxMDAwMDAsMTAwMCw1NjAwMCwzOTAwMCwyMDAwLDIxMDAwLDM5MDAwLDgwMDAsMTA5MDAwLDEwMDAsMTAwMCwyODAwMCwxMDAwLDEwMDAsMCwzOTAwMCwzOTAwMCwzOTAwMCwxMzAwMCwxODAwMCwzOTAwMCwxMDAwLDM5MDAwLDIxNzAwMCwxNjcwMDAsMjEwMDAsMzkwMDAsNDAwMCwzOTAwMCwzOTAwMCwxMDAwLDQwMDAsMzIwMDAsMzgwMDAsNDEwMDAsMzkwMDAsNTMwMDAsMTAwMCw2MDAwLDEwMDAsMzkwMDAsMzUwMDAsMjkwMDAsNDIwMDAsMjcwMDAsMTAwMCwzNTAwMCw1NTAwMCwxNTQwMDAsMzkwMDAsMzkwMDAsMjkwMDAsMTAwMCwxMDAwLDM5MDAwLDEwMDBdLCJvcHMiOjM4OTAwfSx7Im5hbWUiOiJKU09OLnN0cmluZ2lmeShTVFJfMjApIiwiY29kZSI6IkpTT04uc3RyaW5naWZ5KFNUUl8yMCkiLCJydW5zIjpbMzc0MDAwLDQ4NTAwMCwzNDcwMDAsMjM5MDAwLDQxMzAwMCwyNDIwMDAsOTk5MDAwLDYyMzAwMCw1MzIwMDAsNDUyMDAwLDEwNDUwMDAsMTc4MDAwLDEzOTkwMDAsMTY0MjAwMCw4MDYwMDAsNTMwMDAsNjcyMDAwLDU3MjAwMCwzMzEwMDAsNzcxMDAwLDU3MDAwLDI5NTAwMCwzMTAwMCwxMzUwMDAwLDM3MzAwMCw5MDAwMCwxOTAwMCwzMDEwMDAsMTQ2MDAwLDc4MzAwMCwyMTEwMDAsMTY1MDAwLDc0MDAwLDQ4NzAwMCwwLDI2ODAwMCw0NzIwMDAsMTA2MTAwMCwxMDEyMDAwLDM2MDAwMCwyMDMwMDAsNDUxMDAwLDM4MzAwMCw0NzgwMDAsNjgyMDAwLDQ4NzAwMCwzMzgwMDAsMTM5OTAwMCwzMTcwMDAsMTM5OTAwMCw4NjQwMDAsNzA2MDAwLDEzOTkwMDAsOTAyMDAwLDEwNzYwMDAsMzk2MDAwLDk4ODAwMCwxMDc2MDAwLDUyNTAwMCw3ODUwMDAsMTQ3MDAwLDg5MDAwLDEzOTAwMCwyMjUwMDAsMTM5OTAwMCwzMjgwMDAsNzkwMDAsMTI2MzAwMCwxMzk5MDAwLDE0MTMwMDAsODYwMDAwLDY1MjAwMCwzMTIwMDAsOTU1MDAwLDQ3OTAwMCwxNzIwMDAsNDcyMDAwLDY5NDAwMCw1ODMwMDAsMTM5OTAwMCwxMTgwMDAsOTczMDAwLDIzNTAwMCw4MzAwMDAsMTk2MDAwLDk5OTAwMCwzNjEwMDAsNDE0MDAwLDExNTEwMDAsOTEwMDAsODQ4MDAwLDExMTQwMDAsMjM5MDAwLDQzMDAwMCwyNzkwMDAsMTA3MDAwMCw0MDgwMDAsOTE0MDAwLDcxNTAwMCw2MjAwMDBdLCJvcHMiOjU5NjQ4MH0seyJuYW1lIjoiYXNTdHJpbmdTbWFsbChTVFJfMzApIiwiY29kZSI6ImFzU3RyaW5nU21hbGwoU1RSXzMwKSIsInJ1bnMiOlsxMDAwLDEwMDAsMTAwMDAsNzEwMDAsMjcwMDAsMTAwMCwxMDAwLDkxMDAwLDI3MDAwLDI3MDAwLDEwMDAsMjAwMDAsMjcwMDAsMjcwMDAsMTAwMCwyNzAwMCw1OTAwMCwyNzAwMCwyNzAwMCwyNzAwMCwyNzAwMCw5MDAwLDEwMDAsMjcwMDAsMTAwMCwzMTAwMCw3MDAwLDE4MDAwLDI3MDAwLDIwMDAsMjcwMDAsNTUwMDAsODcwMDAsMjcwMDAsMjcwMDAsMzcwMDAsNTAwMDAsMTcwMDAsMjcwMDAsMTAwMCwyNzAwMCwxMDAwLDI3MDAwLDQxMDAwLDI3MDAwLDE1MDAwLDExMjAwMCwxMDAwLDEzOTAwMCwyNzAwMCwyNzAwMCwyNzAwMCwxMjEwMDAsODQwMDAsMTAwMCwyNDAwMCwyNzAwMCwyNTAwMCwyMTAwMCwyNzAwMCwyMDAwMCwyNzAwMCwxMTIwMDAsMjcwMDAsMTcwMDAsMjAwMCwzMjAwMCwxMDAwLDIwODAwMCwyNzAwMCwyMDAwLDI3MDAwLDEwMDAsMTAwMCwyNzAwMCwxMDAwLDIwMDAwLDEwMDAsNTAwMCwyMzAwMCwyNzAwMCwyNzAwMCwyNzAwMCw4OTAwMCwyNzAwMCwyNzAwMCwzNzAwMCwyNzAwMCw0MDAwLDEwMDAsMTAwMCwxMDAwLDI3MDAwLDcwMDAsMTY0MDAwLDI3MDAwLDY0MDAwLDEwMDAsMjMwMDAsMTAwMF0sIm9wcyI6Mjk5NjB9LHsibmFtZSI6IkpTT04uc3RyaW5naWZ5KFNUUl8zMCkiLCJjb2RlIjoiSlNPTi5zdHJpbmdpZnkoU1RSXzMwKSIsInJ1bnMiOls0ODAwMCw1MjAwMCw0NTUwMDAsMTQwMDAsMTAwMCwzMDAwLDE1NjAwMCwyMzUwMDAsNjc0MDAwLDQ1MDAwLDYzNzAwMCwxMTMwMDAsMTMxMDAwLDg1NjAwMCw3MDAwLDQ0MDAwMCwxMjE0MDAwLDIwODAwMCw1NzAwMCwxMTUwMDAsNjcwMDAsODAwMCw4OTYwMDAsNDAwMCw4NDAwMCw0NDAwMDAsNDQ5MDAwLDY1MjAwMCw4NTYwMDAsMjk5MDAwLDE0OTAwMCw3MTQwMDAsOTYwMDAsMzg1MDAwLDYyNTAwMCw2MjcwMDAsMjA0MDAwLDI0MDAwLDEwMzAwMCw2MTQwMDAsMjQwMDAwLDEwOTAwMCw1NjAwMCw4MDUwMDAsMTYzMDAwLDYyNTAwMCwxMjk3MDAwLDk3ODAwMCw1MTkwMDAsMTAwMCwyODkwMDAsMzU2MDAwLDEwMDcwMDAsMjI5MDAwLDEwNjAwMDAsNTkzMDAwLDEwNzYwMDAsNDYwMDAsNzMxMDAwLDUzNzAwMCw1NDgwMDAsMTg4MDAwLDM5MTAwMCw1NDUwMDAsMTI1MDAwLDkyMDAwLDUyMDAwLDEyODQwMDAsMTgwMDAwLDcxMDAwMCwxMDk2MDAwLDEwNTUwMDAsNTk5MDAwLDU4MDAwLDE5ODAwMCw0ODcwMDAsNTI5MDAwLDM0MjAwMCw4MTgwMDAsMjI0MDAwLDI2NjAwMCwxMDMwMDAsNDcwMDAwLDE0NzAwMCwzNjkwMDAsMjk5MDAwLDQ0NTAwMCw4NzQwMDAsNTE4MDAwLDE5ODAwMCwxODEwMDAsMjUwMDAwLDc1NDAwMCw5OTgwMDAsOTMxMDAwLDI1MDAwLDU2MTAwMCwzNzUwMDAsMjAwMDAsNTY0MDAwXSwib3BzIjo0MTM0MzB9LHsibmFtZSI6ImFzU3RyaW5nU21hbGwoU1RSXzQwKSIsImNvZGUiOiJhc1N0cmluZ1NtYWxsKFNUUl80MCkiLCJydW5zIjpbMTYwMDAsMTAwMCwyMTAwMCwyMDAwLDIxMDAwLDYwMDAsMTAwMCwxMDAwLDEwMDAsNjAwMCwzMjAwMCwyMTAwMCw2NDAwMCw3MTAwMCw0NDAwMCwxMTAwMCwyMTAwMCwyMTAwMCwyMTAwMCwyNDAwMCwxNjQwMDAsMjEwMDAsMTAwMCwxNjAwMCwyMTAwMCwxMDAwLDcwMDAsMTAwMCw0MTAwMCwyMTAwMCwyNDAwMCwyMTAwMCwyOTAwMCwxMDAwLDE2MDAwLDIxMDAwLDIwMDAsMjYwMDAsNDkwMDAsNDUwMDAsMjcwMDAsMjEwMDAsMTAwMCwyOTAwMCwxMDAwLDE4MDAwLDIxMDAwLDIxMDAwLDIxMDAwLDIyMDAwLDEwMDAsMjAwMDAsNTIwMDAsMjEwMDAsMTAwMCwxMDAwLDIxMDAwLDIxMDAwLDIxMDAwLDEzMDAwLDEwMDAsMjkwMDAsMjEwMDAsNDEwMDAsOTIwMDAsOTAwMCw1MDAwLDM1MDAwLDQwMDAsMzMwMDAsMTMwMDAwLDc1MDAwLDEwMDAsMTAwMCwxMDAwLDIxMDAwLDEwMDAsMjEwMDAsMzgwMDAsMjEwMDAsMTAwMCwxMDAwLDE0MDAwLDIwMDAsMTAwMCwxMDAwLDU4MDAwLDgwMDAsMTAwMCwyMTAwMCwxMDAwLDI4MDAwLDEwMDAsNjAwMCwxMjAwMCwyMTAwMCwyMTAwMCwxOTAwMCwyMTAwMCw3ODAwMF0sIm9wcyI6MjE4NDB9LHsibmFtZSI6IkpTT04uc3RyaW5naWZ5KFNUUl80MCkiLCJjb2RlIjoiSlNPTi5zdHJpbmdpZnkoU1RSXzQwKSIsInJ1bnMiOls4NDAwMCw3NjAwMCw1MjQwMDAsNTI0MDAwLDM5MDAwLDQzNzAwMCwzOTYwMDAsNDEyMDAwLDYzMTAwMCwxMDgwMDAwLDI0NzAwMCwxMzQwMDAsNDQ2MDAwLDExNDAwMCwxMzk5MDAwLDE1NzAwMCw5NzYwMDAsNDIwMDAsMjU4MDAwLDQyMDAwLDE3MDAwLDY3MDAwLDQ2NjAwMCwyODIwMDAsNzgzMDAwLDExMjcwMDAsMTMyMDAwMCwzOTcwMDAsMjcwMDAwLDQyODAwMCwyMjcwMDAsMTAzMDAwLDIxNjAwMCw4MzAwMCw3ODUwMDAsMjI0MDAwLDE5MDAwLDM4MDAwLDg2MDAwLDUyOTAwMCw1MDUwMDAsNTAwMDAwLDEwMDAsMjAwMDAsMTMwMDAwLDEzODAwMDAsODI4MDAwLDEzMDAwMDAsODI1MDAwLDI4NzAwMCw0OTMwMDAsNDg3MDAwLDI3MzAwMCwyMjIwMDAsMzQ0MDAwLDY4NDAwMCwxMzUwMDAsMTcxMDAwLDQ2NDAwMCw0MTQwMDAsNTAwMCw0MjYwMDAsMjEwMDAsMTA3MDAwLDQ5MzAwMCw1MTMwMDAsNDMyMDAwLDU1MzAwMCw4MDIwMDAsNTYwMDAwLDIxNDAwMCw3NTEwMDAsODg0MDAwLDEyNTEwMDAsMTM5OTAwMCw3NzUwMDAsODI2MDAwLDEwNDgwMDAsMTYzMDAwLDE2MzAwMCwyNDEwMDAsMjM3MDAwLDEzOTkwMDAsNDIyMDAwLDcyOTAwMCw1NDAwMDAsMzk1MDAwLDY5NzAwMCw0MTcwMDAsMzE2MDAwLDc4MjAwMCwyOTgwMDAsNDQ1MDAwLDExMzAwMCw0NjQwMDAsMTAwMDAsMTM5OTAwMCwyMjkwMDAsMTMwMDAsNjE3MDAwXSwib3BzIjo0NjA5NzB9XSwidXBkYXRlZCI6IjIwMjQtMDMtMTJUMTQ6MzE6MzAuNjAyWiJ9)

it seems better to use `JSON.stringify` instead of `asStringSmall`

In detail:

```js
// Test cases ...
const STR_1  = 'A'
const STR_10 = STR_1.repeat(10) // 10 chars
const STR_20 = STR_1.repeat(20) // 20 chars
const STR_30 = STR_1.repeat(30) // 30 chars
const STR_40 = STR_1.repeat(40) // 40 chars
```

```
asStringSmall(STR_1)   221,230 ops/s
JSON.stringify(STR_1)  639,110 ops/s

asStringSmall(STR_10)   73,130 ops/s
JSON.stringify(STR_10) 598,020 ops/s

asStringSmall(STR_20)   38,900 ops/s
JSON.stringify(STR_20) 596,480 ops/s

asStringSmall(STR_30)   29,960 ops/s
JSON.stringify(STR_30) 413,430 ops/s

asStringSmall(STR_40)   21,840 ops/s
JSON.stringify(STR_40) 460,970 ops/s
```

JSON.stringify win in all cases.

V8 has optimized version of string escaping [EscapeJSONStringImpl](https://chromium.googlesource.com/chromium/src/base/+/master/json/string_escape.cc#83) and [EscapeSpecialCodePoint](https://chromium.googlesource.com/chromium/src/base/+/master/json/string_escape.cc#37).
A javascript implementation will never beat these in C++

This make `JSON.stringify` always faster on small string. The idea is just skip `JSON.stringify` on medium string without char to escape:

```js
asString (str) {
    // SMALL STRING: JSON.stringify is always faster
    if (str.length < 42) {
      return JSON.stringify(str)
    // MEDIUM STRING: the check of, if string has char to escape, is fast on not big string
    } else if (str.length < 5000 && STR_ESCAPE.test(str) === false) {
      // Only use the regular expression for shorter input. The overhead is otherwise too much.
      return '"' + str + '"'
    // BIG STRING
    } else {
      return JSON.stringify(str)
    }
}
```


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
