### PR TITLE
perf: reduce if statement call on `"` and `\` (micro-optimization)

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -128,10 +128,6 @@ module.exports = class Serializer {
     // eslint-disable-next-line
     for (var i = 0; i < len; i++) {
       point = str.charCodeAt(i)
-      if (point < 32 || (point >= 0xD800 && point <= 0xDFFF)) {
-        // The current character is non-printable characters or a surrogate.
-        return JSON.stringify(str)
-      }
       if (
         point === 0x22 || // '"'
         point === 0x5c // '\'
@@ -139,6 +135,9 @@ module.exports = class Serializer {
         last === -1 && (last = 0)
         result += str.slice(last, i) + '\\'
         last = i
+      } else if (point < 32 || (point >= 0xD800 && point <= 0xDFFF)) {
+        // The current character is non-printable characters or a surrogate.
+        return JSON.stringify(str)
       }
     }
 


### PR DESCRIPTION
With this PR when a  `"` or `\` is into the string, the if statement for surrogate check is not called. This is a little performance improvment

benchmark with focus on small string
master
```
short string............................................. x 23,456,041 ops/sec ±0.52% (190 runs sampled)
short string with double quote........................... x 13,475,336 ops/sec ±0.55% (189 runs sampled)
```
PR
```
short string............................................. x 23,641,068 ops/sec ±0.57% (191 runs sampled)
short string with double quote........................... x 13,703,071 ops/sec ±0.43% (187 runs sampled)
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
