### PR TITLE
perf: fast regex check on string

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // eslint-disable-next-line
-const STR_ESCAPE = /[\u0000-\u001f\u0022\u005c\ud800-\udfff]|[\ud800-\udbff](?![\udc00-\udfff])|(?:[^\ud800-\udbff]|^)[\udc00-\udfff]/
+const STR_ESCAPE = /[\u0000-\u001f\u0022\u005c\ud800-\udfff]/
 
 module.exports = class Serializer {
   constructor (options) {


### PR DESCRIPTION
The regex 
```
[\u0000-\u001f\u0022\u005c\ud800-\udfff]|[\ud800-\udbff](?![\udc00-\udfff])|(?:[^\ud800-\udbff]|^)[\udc00-\udfff]
```
can be 
```
[\u0000-\u001f\u0022\u005c\ud800-\udfff]
```
The first part of alternation (`[\u0000-\u001f\u0022\u005c\ud800-\udfff]`) will match anything that might have been matched by the second (`[\ud800-\udbff](?![\udc00-\udfff])`) and third part (`(?:[^\ud800-\udbff]|^)[\udc00-\udfff]`).

I have made this simple online test for play with both rule (https://jsfiddle.net/nd84e7fz/):
```js
const NEW = /[\u0000-\u001f\u0022\u005c\ud800-\udfff]/;
const OLD = /[\u0000-\u001f\u0022\u005c\ud800-\udfff]|[\ud800-\udbff](?![\udc00-\udfff])|(?:[^\ud800-\udbff]|^)[\udc00-\udfff]/;

const str1 = '\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000b\f\r' +
              '\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017' +
              '\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f"\\abc012'
console.log(OLD.test(str1) === NEW.test(str1), 'should escape control chars')

const str2 = '\uDF06\uD834'
console.log(OLD.test(str2) === NEW.test(str2), 'should escape surrogate pair')
```
output
```
true, "should escape control chars"
true, "should escape surrogate pair"
```

The two rule works in the same manner!

benchmark only regex execution
```
NEW REGEX 96K ops/s ± 8.44%
OLD REGEX 82K ops/s ± 8.23% (14.57 % slower)
```

benchmark fast-json-stringify (`npm run bench`) with focus on long string
master
```
long string without double quotes........................ x 14,857 ops/sec ±0.33% (187 runs sampled)
long string.............................................. x 15,856 ops/sec ±0.34% (192 runs sampled)
```
PR
```
long string without double quotes........................ x 15,732 ops/sec ±0.47% (191 runs sampled)
long string.............................................. x 16,211 ops/sec ±0.41% (191 runs sampled)
```

DIFF
```
long string without double quotes...... 5.88% (PR faster)
long string.............................2.24% (PR faster)
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
