### PR TITLE
Update for Fastify v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v3
+    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v4.1.0
     with:
       license-check: true
       lint: true

--- a/.taprc
+++ b/.taprc
@@ -1,14 +1,5 @@
-ts: false
-jsx: false
-
-branches: 65
-functions: 100
-lines: 89
-statements: 89
-
-nyc-arg:
-  - "--exclude=.cache/*"
-  - "--exclude=lib/schema-validator.js"
-
+disable-coverage: true
 files:
   - test/**/*.test.js
+plugin:
+  - "!@tapjs/typescript"

--- a/package.json
+++ b/package.json
@@ -37,27 +37,27 @@
   },
   "homepage": "https://github.com/fastify/fast-json-stringify#readme",
   "devDependencies": {
-    "@fastify/pre-commit": "^2.0.2",
-    "@sinclair/typebox": "^0.32.3",
+    "@fastify/pre-commit": "^2.1.0",
+    "@sinclair/typebox": "^0.32.15",
     "benchmark": "^2.1.4",
     "cli-select": "^1.1.2",
     "compile-json-stringify": "^0.1.2",
-    "is-my-json-valid": "^2.20.0",
-    "simple-git": "^3.7.1",
-    "standard": "^17.0.0",
-    "tap": "^16.0.1",
-    "tsd": "^0.30.3",
-    "webpack": "^5.40.0",
+    "is-my-json-valid": "^2.20.6",
+    "simple-git": "^3.23.0",
+    "standard": "^17.1.0",
+    "tap": "^18.7.1",
+    "tsd": "^0.30.7",
+    "webpack": "^5.90.3",
     "fast-json-stringify": "."
   },
   "dependencies": {
-    "ajv": "^8.10.0",
+    "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "fast-deep-equal": "^3.1.3",
-    "fast-uri": "^2.1.0",
-    "rfdc": "^1.2.0",
+    "fast-uri": "^2.3.0",
+    "rfdc": "^1.3.1",
     "json-schema-ref-resolver": "^1.0.1",
-    "@fastify/merge-json-schemas": "^0.1.0"
+    "@fastify/merge-json-schemas": "^0.1.1"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
Ref: https://github.com/fastify/fastify/issues/5116

- Removed the `ts` and `jsx` which are replaced by disabling the `!@tapjs/typescript` plugin. 
-  `branches`, `functions`, `lines` and  `statements` where dropped in v18 -> https://node-tap.org/changelog/
- `nyc` were also dropped in v18
- `coverage` is enabled by default in v18, disabling them via `disable-coverage: true`

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
      
CC: @simoneb 