### PR TITLE
perf: cache json strings into const

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,11 +145,13 @@ function build (schema, options) {
     const JSON_STR_END_OBJECT = '}'
     const JSON_STR_BEGIN_ARRAY = '['
     const JSON_STR_END_ARRAY = ']'
-    const JSON_STR_EMPTY_OBJECT = JSON_STR_BEGIN_OBJECT + JSON_STR_END_OBJECT
-    const JSON_STR_EMPTY_ARRAY = JSON_STR_BEGIN_ARRAY + JSON_STR_END_ARRAY
     const JSON_STR_COMMA = ','
     const JSON_STR_COLONS = ':'
     const JSON_STR_QUOTE = '"'
+    const JSON_STR_EMPTY_OBJECT = JSON_STR_BEGIN_OBJECT + JSON_STR_END_OBJECT
+    const JSON_STR_EMPTY_ARRAY = JSON_STR_BEGIN_ARRAY + JSON_STR_END_ARRAY
+    const JSON_STR_EMPTY_STRING = JSON_STR_QUOTE + JSON_STR_QUOTE
+    const JSON_STR_NULL = 'null'
   `
 
   // If we have only the invocation of the 'anonymous0' function, we would
@@ -727,7 +729,7 @@ function buildSingleTypeSerializer (context, location, input) {
 
   switch (schema.type) {
     case 'null':
-      return 'json += \'null\''
+      return 'json += JSON_STR_NULL'
     case 'string': {
       if (schema.format === 'date-time') {
         return `json += serializer.asDateTime(${input})`
@@ -741,7 +743,7 @@ function buildSingleTypeSerializer (context, location, input) {
         return `
         if (typeof ${input} !== 'string') {
           if (${input} === null) {
-            json += JSON_STR_QUOTE + JSON_STR_QUOTE
+            json += JSON_STR_EMPTY_STRING
           } else if (${input} instanceof Date) {
             json += JSON_STR_QUOTE + ${input}.toISOString() + JSON_STR_QUOTE
           } else if (${input} instanceof RegExp) {
@@ -787,7 +789,7 @@ function buildConstSerializer (location, input) {
   if (hasNullType) {
     code += `
       if (${input} === null) {
-        json += 'null'
+        json += JSON_STR_NULL
       } else {
     `
   }
@@ -994,7 +996,7 @@ function buildValue (context, location, input) {
   if (nullable) {
     code += `
       if (${input} === null) {
-        json += 'null'
+        json += JSON_STR_NULL
       } else {
     `
   }

--- a/index.js
+++ b/index.js
@@ -140,7 +140,17 @@ function build (schema, options) {
   const location = new Location(schema, context.rootSchemaId)
   const code = buildValue(context, location, 'input')
 
-  let contextFunctionCode
+  let contextFunctionCode = `
+    const JSON_STR_BEGIN_OBJECT = '{'
+    const JSON_STR_END_OBJECT = '}'
+    const JSON_STR_BEGIN_ARRAY = '['
+    const JSON_STR_END_ARRAY = ']'
+    const JSON_STR_EMPTY_OBJECT = JSON_STR_BEGIN_OBJECT + JSON_STR_END_OBJECT
+    const JSON_STR_EMPTY_ARRAY = JSON_STR_BEGIN_ARRAY + JSON_STR_END_ARRAY
+    const JSON_STR_COMMA = ','
+    const JSON_STR_COLONS = ':'
+    const JSON_STR_QUOTE = '"'
+  `
 
   // If we have only the invocation of the 'anonymous0' function, we would
   // basically just wrap the 'anonymous0' function in the 'main' function and
@@ -148,13 +158,13 @@ function build (schema, options) {
   // wrapping and the unnecessary memory allocation by aliasing 'anonymous0' to
   // 'main'
   if (code === 'json += anonymous0(input)') {
-    contextFunctionCode = `
+    contextFunctionCode += `
     ${context.functions.join('\n')}
     const main = anonymous0
     return main
     `
   } else {
-    contextFunctionCode = `
+    contextFunctionCode += `
     function main (input) {
       let json = ''
       ${code}
@@ -284,7 +294,7 @@ function buildExtraObjectPropertiesSerializer (context, location, addComma) {
       code += `
         if (/${propertyKey.replace(/\\*\//g, '\\/')}/.test(key)) {
           ${addComma}
-          json += serializer.asString(key) + ':'
+          json += serializer.asString(key) + JSON_STR_COLONS
           ${buildValue(context, propertyLocation, 'value')}
           continue
         }
@@ -299,13 +309,13 @@ function buildExtraObjectPropertiesSerializer (context, location, addComma) {
     if (additionalPropertiesSchema === true) {
       code += `
         ${addComma}
-        json += serializer.asString(key) + ':' + JSON.stringify(value)
+        json += serializer.asString(key) + JSON_STR_COLONS + JSON.stringify(value)
       `
     } else {
       const propertyLocation = location.getPropertyLocation('additionalProperties')
       code += `
         ${addComma}
-        json += serializer.asString(key) + ':'
+        json += serializer.asString(key) + JSON_STR_COLONS
         ${buildValue(context, propertyLocation, 'value')}
       `
     }
@@ -341,12 +351,12 @@ function buildInnerObject (context, location) {
     }
   }
 
-  code += 'let json = \'{\'\n'
+  code += 'let json = JSON_STR_BEGIN_OBJECT\n'
 
   let addComma = ''
   if (!hasRequiredProperties) {
     code += 'let addComma = false\n'
-    addComma = '!addComma && (addComma = true) || (json += \',\')'
+    addComma = '!addComma && (addComma = true) || (json += JSON_STR_COMMA)'
   }
 
   for (const key of propertiesKeys) {
@@ -392,7 +402,7 @@ function buildInnerObject (context, location) {
   }
 
   code += `
-    return json + '}'
+    return json + JSON_STR_END_OBJECT
   `
   return code
 }
@@ -483,7 +493,7 @@ function buildObject (context, location) {
     // ${schemaRef}
     function ${functionName} (input) {
       const obj = ${toJSON('input')}
-      ${!nullable ? 'if (obj === null) return \'{}\'' : ''}
+      ${!nullable ? 'if (obj === null) return JSON_STR_EMPTY_OBJECT' : ''}
 
       ${buildInnerObject(context, location)}
     }
@@ -524,7 +534,7 @@ function buildArray (context, location) {
 
   const nullable = schema.nullable === true
   functionCode += `
-    ${!nullable ? 'if (obj === null) return \'[]\'' : ''}
+    ${!nullable ? 'if (obj === null) return JSON_STR_EMPTY_ARRAY' : ''}
     if (!Array.isArray(obj)) {
       throw new TypeError(\`The value of '${schemaRef}' does not match schema definition.\`)
     }
@@ -559,7 +569,7 @@ function buildArray (context, location) {
           if (${buildArrayTypeCondition(item.type, `[${i}]`)}) {
             ${tmpRes}
             if (${i} < arrayEnd) {
-              json += ','
+              json += JSON_STR_COMMA
             }
           } else {
             throw new Error(\`Item at ${i} does not match schema definition.\`)
@@ -573,7 +583,7 @@ function buildArray (context, location) {
         for (let i = ${itemsSchema.length}; i < arrayLength; i++) {
           json += JSON.stringify(obj[i])
           if (i < arrayEnd) {
-            json += ','
+            json += JSON_STR_COMMA
           }
         }`
     }
@@ -583,13 +593,13 @@ function buildArray (context, location) {
       for (let i = 0; i < arrayLength; i++) {
         ${code}
         if (i < arrayEnd) {
-          json += ','
+          json += JSON_STR_COMMA
         }
       }`
   }
 
   functionCode += `
-    return \`[\${json}]\`
+    return JSON_STR_BEGIN_ARRAY + json + JSON_STR_END_ARRAY
   }`
 
   context.functions.push(functionCode)
@@ -731,9 +741,9 @@ function buildSingleTypeSerializer (context, location, input) {
         return `
         if (typeof ${input} !== 'string') {
           if (${input} === null) {
-            json += '""'
+            json += JSON_STR_QUOTE + JSON_STR_QUOTE
           } else if (${input} instanceof Date) {
-            json += '"' + ${input}.toISOString() + '"'
+            json += JSON_STR_QUOTE + ${input}.toISOString() + JSON_STR_QUOTE
           } else if (${input} instanceof RegExp) {
             json += serializer.asString(${input}.source)
           } else {


### PR DESCRIPTION
```
npm run bench:cmp

> fast-json-stringify@5.14.1 bench:cmp
> node ./benchmark/bench-cmp-branch.js

Select the branch you want to compare (feature branch):
cache-str
Select the branch you want to compare with (main branch):
master
Checking out "cache-str"
Execute "npm run bench"

> fast-json-stringify@5.14.1 bench
> node ./benchmark/bench.js

short string............................................. x 16,870,462 ops/sec ±2.49% (173 runs sampled)
unsafe short string...................................... x 724,139,578 ops/sec ±0.41% (186 runs sampled)
short string with double quote........................... x 8,446,363 ops/sec ±0.98% (187 runs sampled)
long string without double quotes........................ x 11,556 ops/sec ±0.44% (191 runs sampled)
unsafe long string without double quotes................. x 813,697,981 ops/sec ±1.28% (191 runs sampled)
long string.............................................. x 13,826 ops/sec ±1.17% (186 runs sampled)
unsafe long string....................................... x 886,199,677 ops/sec ±0.45% (190 runs sampled)
number................................................... x 885,289,169 ops/sec ±0.51% (189 runs sampled)
integer.................................................. x 186,926,499 ops/sec ±0.73% (190 runs sampled)
formatted date-time...................................... x 1,180,142 ops/sec ±1.01% (185 runs sampled)
formatted date........................................... x 770,533 ops/sec ±1.26% (184 runs sampled)
formatted time........................................... x 744,215 ops/sec ±1.54% (181 runs sampled)
short array of numbers................................... x 83,572 ops/sec ±2.01% (179 runs sampled)
short array of integers.................................. x 76,748 ops/sec ±1.77% (179 runs sampled)
short array of short strings............................. x 19,934 ops/sec ±0.44% (189 runs sampled)
short array of long strings.............................. x 18,284 ops/sec ±2.77% (177 runs sampled)
short array of objects with properties of different types x 8,478 ops/sec ±1.37% (176 runs sampled)
object with number property.............................. x 742,860,674 ops/sec ±0.44% (189 runs sampled)
object with integer property............................. x 155,007,833 ops/sec ±0.38% (191 runs sampled)
object with short string property........................ x 16,724,070 ops/sec ±1.23% (179 runs sampled)
object with long string property......................... x 11,640 ops/sec ±1.33% (186 runs sampled)
object with properties of different types................ x 1,683,099 ops/sec ±1.09% (188 runs sampled)
simple object............................................ x 8,467,288 ops/sec ±0.88% (189 runs sampled)
simple object with required fields....................... x 9,377,275 ops/sec ±1.91% (182 runs sampled)
object with const string property........................ x 883,884,078 ops/sec ±0.50% (190 runs sampled)
object with const number property........................ x 885,943,123 ops/sec ±0.45% (191 runs sampled)
object with const bool property.......................... x 887,473,685 ops/sec ±0.51% (191 runs sampled)
object with const object property........................ x 892,204,220 ops/sec ±0.45% (190 runs sampled)
object with const null property.......................... x 881,055,068 ops/sec ±0.65% (190 runs sampled)

Checking out "master"
Execute "npm run bench"

> fast-json-stringify@5.14.1 bench
> node ./benchmark/bench.js

short string............................................. x 16,912,799 ops/sec ±2.45% (174 runs sampled)
unsafe short string...................................... x 734,503,764 ops/sec ±1.31% (185 runs sampled)
short string with double quote........................... x 8,400,416 ops/sec ±1.60% (186 runs sampled)
long string without double quotes........................ x 11,088 ops/sec ±1.01% (179 runs sampled)
unsafe long string without double quotes................. x 738,669,891 ops/sec ±0.48% (189 runs sampled)
long string.............................................. x 11,958 ops/sec ±0.53% (190 runs sampled)
unsafe long string....................................... x 756,187,321 ops/sec ±0.37% (189 runs sampled)
number................................................... x 865,206,823 ops/sec ±1.02% (190 runs sampled)
integer.................................................. x 185,672,593 ops/sec ±0.84% (191 runs sampled)
formatted date-time...................................... x 1,123,406 ops/sec ±1.33% (185 runs sampled)
formatted date........................................... x 750,140 ops/sec ±1.30% (185 runs sampled)
formatted time........................................... x 755,195 ops/sec ±1.16% (184 runs sampled)
short array of numbers................................... x 88,025 ops/sec ±1.69% (179 runs sampled)
short array of integers.................................. x 75,908 ops/sec ±1.83% (181 runs sampled)
short array of short strings............................. x 19,657 ops/sec ±1.18% (189 runs sampled)
short array of long strings.............................. x 18,938 ops/sec ±1.49% (185 runs sampled)
short array of objects with properties of different types x 10,090 ops/sec ±1.62% (181 runs sampled)
object with number property.............................. x 887,652,574 ops/sec ±0.43% (191 runs sampled)
object with integer property............................. x 167,257,031 ops/sec ±2.11% (173 runs sampled)
object with short string property........................ x 16,206,991 ops/sec ±2.19% (177 runs sampled)
object with long string property......................... x 11,758 ops/sec ±1.09% (184 runs sampled)
object with properties of different types................ x 1,665,238 ops/sec ±1.71% (178 runs sampled)
simple object............................................ x 8,314,669 ops/sec ±1.03% (188 runs sampled)
simple object with required fields....................... x 7,716,424 ops/sec ±1.60% (176 runs sampled)
object with const string property........................ x 691,814,706 ops/sec ±0.54% (188 runs sampled)
object with const number property........................ x 688,577,394 ops/sec ±0.79% (186 runs sampled)
object with const bool property.......................... x 721,388,123 ops/sec ±2.22% (181 runs sampled)
object with const object property........................ x 839,403,044 ops/sec ±0.92% (187 runs sampled)
object with const null property.......................... x 881,096,651 ops/sec ±0.77% (191 runs sampled)

short string..............................................-0.25%
unsafe short string.......................................-1.41%
short string with double quote............................+0.55%
long string without double quotes.........................+4.22%
unsafe long string without double quotes.................+10.16%
long string..............................................+15.62%
unsafe long string.......................................+17.19%
number....................................................+2.32%
integer...................................................+0.68%
formatted date-time.......................................+5.05%
formatted date............................................+2.72%
formatted time............................................-1.45%
short array of numbers....................................-5.06%
short array of integers...................................+1.11%
short array of short strings..............................+1.41%
short array of long strings...............................-3.45%
short array of objects with properties of different types-15.98%
object with number property..............................-16.31%
object with integer property..............................-7.32%
object with short string property.........................+3.19%
object with long string property.............................-1%
object with properties of different types.................+1.07%
simple object.............................................+1.84%
simple object with required fields.......................+21.52%
object with const string property........................+27.76%
object with const number property........................+28.66%
object with const bool property..........................+23.02%
object with const object property.........................+6.29%
object with const null property...............................0%
Back to cache-str 651d0e0
```
![image](https://github.com/fastify/fast-json-stringify/assets/310077/58c65b34-0a18-475b-b96b-ade7897f16eb)


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or




* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
