### PR TITLE
fix: escape single quote when building error message for required property

### DIFF
--- a/index.js
+++ b/index.js
@@ -350,7 +350,6 @@ function buildInnerObject (context, location) {
   for (const key of requiredProperties) {
     if (!propertiesKeys.includes(key)) {
       const sanitizedKey = JSON.stringify(key)
-
       code += `if (obj[${sanitizedKey}] === undefined) throw new Error('${sanitizedKey.replace(/'/g, '\\\'')} is required!')\n`
     }
   }

--- a/index.js
+++ b/index.js
@@ -349,7 +349,9 @@ function buildInnerObject (context, location) {
 
   for (const key of requiredProperties) {
     if (!propertiesKeys.includes(key)) {
-      code += `if (obj['${key}'] === undefined) throw new Error('"${key}" is required!')\n`
+      const sanitizedKey = JSON.stringify(key)
+
+      code += `if (obj[${sanitizedKey}] === undefined) throw new Error('${sanitizedKey.replace(/'/g, '\\\'')} is required!')\n`
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -387,7 +387,7 @@ function buildInnerObject (context, location) {
       `
     } else if (isRequired) {
       code += ` else {
-        throw new Error('${sanitizedKey} is required!')
+        throw new Error('${sanitizedKey.replace(/'/g, '\\\'')} is required!')
       }
       `
     } else {

--- a/test/sanitize7.test.js
+++ b/test/sanitize7.test.js
@@ -19,6 +19,22 @@ test('required property containing single quote, contains property', (t) => {
   t.throws(() => stringify({}), new Error('"\'" is required!'))
 })
 
+test('required property containing double quote, contains property', (t) => {
+  t.plan(1)
+
+  const stringify = build({
+    type: 'object',
+    properties: {
+      '"': { type: 'string' }
+    },
+    required: [
+      '"'
+    ]
+  })
+
+  t.throws(() => stringify({}), new Error('""" is required!'))
+})
+
 test('required property containing single quote, does not contain property', (t) => {
   t.plan(1)
 
@@ -33,4 +49,20 @@ test('required property containing single quote, does not contain property', (t)
   })
 
   t.throws(() => stringify({}), new Error('"\'" is required!'))
+})
+
+test('required property containing double quote, does not contain property', (t) => {
+  t.plan(1)
+
+  const stringify = build({
+    type: 'object',
+    properties: {
+      a: { type: 'string' }
+    },
+    required: [
+      '"'
+    ]
+  })
+
+  t.throws(() => stringify({}), new Error('""" is required!'))
 })

--- a/test/sanitize7.test.js
+++ b/test/sanitize7.test.js
@@ -18,3 +18,19 @@ test('required property containing single quote, contains property', (t) => {
 
   t.throws(() => stringify({}), new Error('"\'" is required!'))
 })
+
+test('required property containing single quote, does not contain property', (t) => {
+  t.plan(1)
+
+  const stringify = build({
+    type: 'object',
+    properties: {
+      a: { type: 'string' }
+    },
+    required: [
+      '\''
+    ]
+  })
+
+  t.throws(() => stringify({}), new Error('"\'" is required!'))
+})

--- a/test/sanitize7.test.js
+++ b/test/sanitize7.test.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const test = require('tap').test
+const build = require('..')
+
+test('required property containing single quote, contains property', (t) => {
+  t.plan(1)
+
+  const stringify = build({
+    type: 'object',
+    properties: {
+      '\'': { type: 'string' }
+    },
+    required: [
+      '\''
+    ]
+  })
+
+  t.throws(() => stringify({}), new Error('"\'" is required!'))
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

closes https://github.com/fastify/fast-json-stringify/issues/715

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
