### PR TITLE
Avoid loading validator un-necessarily

### DIFF
--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -3,6 +3,7 @@
 function buildStandaloneCode (contextFunc, context, serializer, validator) {
   let ajvDependencyCode = ''
   if (context.validatorSchemasIds.size > 0) {
+    ajvDependencyCode += `const Validator = require('fast-json-stringify/lib/validator')\n`
     ajvDependencyCode += `const validatorState = ${JSON.stringify(validator.getState())}\n`
     ajvDependencyCode += 'const validator = Validator.restoreFromState(validatorState)\n'
   } else {
@@ -11,10 +12,8 @@ function buildStandaloneCode (contextFunc, context, serializer, validator) {
 
   return `
   'use strict'
-  const { dependencies } = require('fast-json-stringify/lib/standalone')
 
-  const { Serializer, Validator } = dependencies
-
+  const Serializer = require('fast-json-stringify/lib/serializer')
   const serializerState = ${JSON.stringify(serializer.getState())}
   const serializer = Serializer.restoreFromState(serializerState)
 

--- a/lib/standalone.js
+++ b/lib/standalone.js
@@ -3,7 +3,7 @@
 function buildStandaloneCode (contextFunc, context, serializer, validator) {
   let ajvDependencyCode = ''
   if (context.validatorSchemasIds.size > 0) {
-    ajvDependencyCode += `const Validator = require('fast-json-stringify/lib/validator')\n`
+    ajvDependencyCode += 'const Validator = require(\'fast-json-stringify/lib/validator\')\n'
     ajvDependencyCode += `const validatorState = ${JSON.stringify(validator.getState())}\n`
     ajvDependencyCode += 'const validator = Validator.restoreFromState(validatorState)\n'
   } else {


### PR DESCRIPTION
The validator module pulls in the entire `ajv` dependency and several others and is not always used depending on the condition. Avoid loading this module in generated code when not necessary.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] ~tests and/or benchmarks are included~
- [x] ~documentation is changed or added~
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
