### PR TITLE
fixed cast of number causing Cannot convert a BigInt value to a number

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -41,7 +41,7 @@ module.exports = class Serializer {
 
   asNumber (i) {
     // fast cast to number
-    const num = +i
+    const num = Number(i);
     // check if number is NaN
     // eslint-disable-next-line no-self-compare
     if (num !== num) {


### PR DESCRIPTION
Hello 
i was working on a project for a client and was using Prisma as an ORM. In my schema i was using BigInt as a value and everything was working fine until i upgraded to 5.15 of fast-json-stringify.

I then went and digged into your commits and found that you changed from `Number(i)` to `+i`.

This change broke my project causing 'Cannot convert a BigInt value to a number' when returing a big int from the database, and now i have to stay on version prior to 5.15.

Therefore i created this pr to revert that line of code back to Number(i) and everything works fine.

Hope this helps. 
Let me know if you need more details! 