### PR TITLE
fix: merged schemas cache key

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ajv-formats": "^3.0.1",
     "fast-uri": "^3.0.0",
     "json-schema-ref-resolver": "^1.0.1",
+    "object-hash": "^3.0.0",
     "rfdc": "^1.2.0"
   },
   "standard": {

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -2128,3 +2128,40 @@ test('ref internal - throw if schema has definition twice with different shape',
     t.equal(err.message, 'There is already another anchor "#uri" in a schema "test".')
   }
 })
+
+test('2 anyOf self ref', (t) => {
+  t.plan(1)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      field: { type: 'string' },
+      field1: {
+        anyOf: [
+          { $ref: '#' },
+          { type: 'null' }
+        ]
+      },
+      field2: {
+        anyOf: [
+          { $ref: '#' },
+          { type: 'null' }
+        ]
+      }
+    }
+  }
+
+  const object = {
+    field: 'a',
+    field1: {
+      field: 'b',
+      field1: null,
+      field2: null
+    },
+    field2: null
+  }
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  t.equal(output, JSON.stringify(object))
+})


### PR DESCRIPTION
- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] ~~documentation is changed or added~~
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Hello, this PR fixes #724.

When diving in the bug, I found that the `context.mergedSchemasIds` Map, added by @ivan-tymoshenko, is using objects as keys. This caused the schema to infinitely try to build and results into `Maximum call stack size exceeded` error.
So I replaced the key by a hash of the object, then I got another problem : `anyOf inside allOf` test failed because, to my understanding, we try to cache different merged schemas using the same key in `context.mergedSchemasIds` (like merged schemas from `buildOneOf` and from `buildAllOf` functions).

I am not sure of the solution. Thank you for your review !