### PR TITLE
New option added: `stripNull`, which removes nulls in serialized output

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ const stringify = fastJson(mySchema, {
 - `rounding`: setup how the `integer` types will be rounded when not integers. [More details](#integer)
 - `largeArrayMechanism`: set the mechanism that should be used to handle large
 (by default `20000` or more items) arrays. [More details](#largearrays)
+- `stripNull`: removes keys with null values from serialised output. If you have lots of null values, using this will result in smallerpayload and improved performance.
 
 
 <a name="api"></a>

--- a/index.js
+++ b/index.js
@@ -374,7 +374,7 @@ function buildInnerObject (context, location) {
 
     code += `
       value = obj[${sanitizedKey}]
-      if (value !== undefined) {
+      if ${context.options.stripNull ? '(value != null)' : '(value !== undefined)'} {
         ${addComma}
         json += ${JSON.stringify(sanitizedKey + ':')}
         ${buildValue(context, propertyLocation, 'value')}

--- a/test/stripNull.test.js
+++ b/test/stripNull.test.js
@@ -1,0 +1,110 @@
+const test = require('tap').test
+const build = require('..')
+
+test('should handle null string values properly', (t) => {
+  t.plan(3)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      firstName: { type: 'string' },
+      lastName: { type: 'string' }
+    },
+    required: ['firstName']
+  }
+  const stringify = build(schema, { stripNull: true })
+
+  const json1 = { firstName: 'Matteo', lastName: 'Collina' }
+  t.equal(stringify(json1), '{"firstName":"Matteo","lastName":"Collina"}')
+
+  const json2 = { firstName: 'Matteo', lastName: null }
+  t.equal(stringify(json2), '{"firstName":"Matteo"}')
+
+  const json3 = { firstName: null, lastName: 'Collina' }
+  t.throws(() => stringify(json3)) // throw error when required property is missing
+})
+
+test('should handle null int values properly', (t) => {
+  t.plan(3)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      age: { type: 'integer' },
+      experience: { type: 'integer' }
+    }
+  }
+  const stringify = build(schema, { stripNull: true })
+
+  const json1 = { name: 'Matteo', age: 32, experience: 12 }
+  t.equal(stringify(json1), '{"name":"Matteo","age":32,"experience":12}')
+
+  const json2 = { name: 'Matteo', age: null, experience: null }
+  t.equal(stringify(json2), '{"name":"Matteo"}')
+
+  const json3 = { name: 'Matteo', age: 3, experience: null }
+  t.equal(stringify(json3), '{"name":"Matteo","age":3}')
+})
+
+test('should handle arrays properly', (t) => {
+  t.plan(1)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      experience: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            company: { type: 'string' },
+            years: { type: 'integer' }
+          }
+        }
+      }
+    }
+  }
+  const stringify = build(schema, { stripNull: true })
+
+  const json1 = {
+    name: 'Matteo',
+    experience: [
+      { company: 'C1', years: 12 },
+      { company: 'C2', years: null },
+      { company: null, years: 6 },
+      { company: null, years: null }
+    ]
+  }
+
+  t.equal(
+    stringify(json1),
+    '{"name":"Matteo","experience":[{"company":"C1","years":12},{"company":"C2"},{"years":6},{}]}'
+  )
+})
+
+test('should handle objects and nested objects properly', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      address: {
+        type: 'object',
+        properties: {
+          city: { type: 'string' },
+          country: { type: 'string' }
+        }
+      }
+    }
+  }
+  const stringify = build(schema, { stripNull: true })
+
+  const json1 = { name: 'Matteo', address: { city: 'Mumbai', country: null } }
+  t.equal(stringify(json1), '{"name":"Matteo","address":{"city":"Mumbai"}}')
+
+  const json2 = { name: null, address: { city: null, country: 'India' } }
+  t.equal(stringify(json2), '{"address":{"country":"India"}}')
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -187,6 +187,13 @@ declare namespace build {
      * @default 'default'
      */
     largeArrayMechanism?: 'default' | 'json-stringify'
+
+    /**
+     * Specify if null key-value are removed from serialised JSON output, for a smaller payload
+     *
+     * @default 'false'
+     */
+    stripNull?: boolean
   }
 
   export const validLargeArrayMechanisms: string[]


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
      
 
Added the option to remove keys with null value, this makes serialized output significantly small, if you have lots of null in the schema. By default, it will work as expected, as it is working now. This behavior to remove unnecessary null keys from serialized output can be configured via options, if someone needs it.

Example to configure for removing unnecessary nulls: 
```js
const fastJson = require('fast-json-stringify')
const stringify = fastJson(mySchema, { stripNull: true })
```
 
 Example code:
 ```js
const fastJson = require('fast-json-stringify')
const stringify = fastJson({
  title: "Example Schema",
  type: "object",
  properties: {
    firstName: { type: "string" },
    lastName: { type: "string" },
    age: { description: "Age in years", type: "integer" },
    reg: { type: "string" },
  },
}, { stripNull: true });

console.log(
  stringify({
    firstName: "Matteo",
    lastName: null,
    age: null,
    reg: null,
  })
);

// Default Output: {"firstName":"Matteo","lastName":"","age":0,"reg":""}
// Output with stripNull enabled: {"firstName":"Matteo"}
 ```
 
**Passes all the Tests**

### Benchmarks

FJS creation x 20,318 ops/sec ±0.49% (100 runs sampled)
CJS creation x 259,293 ops/sec ±3.12% (95 runs sampled)
AJV Serialize creation x 120,278,763 ops/sec ±2.47% (85 runs sampled)
JSON.stringify array x 13,608 ops/sec ±0.13% (99 runs sampled)
fast-json-stringify array default x 13,954 ops/sec ±0.17% (101 runs sampled)
fast-json-stringify array json-stringify x 14,091 ops/sec ±0.12% (101 runs sampled)
compile-json-stringify array x 13,019 ops/sec ±0.25% (96 runs sampled)
AJV Serialize array x 12,963 ops/sec ±0.29% (96 runs sampled)
JSON.stringify large array x 427 ops/sec ±1.88% (74 runs sampled)
fast-json-stringify large array default x 406 ops/sec ±0.15% (95 runs sampled)
fast-json-stringify large array json-stringify x 538 ops/sec ±2.54% (95 runs sampled)
compile-json-stringify large array x 598 ops/sec ±0.26% (91 runs sampled)
AJV Serialize large array x 204 ops/sec ±0.20% (88 runs sampled)
JSON.stringify long string x 14,807 ops/sec ±0.15% (98 runs sampled)
fast-json-stringify long string x 14,871 ops/sec ±0.10% (97 runs sampled)
compile-json-stringify long string x 14,867 ops/sec ±0.13% (98 runs sampled)
AJV Serialize long string x 33,026 ops/sec ±0.29% (99 runs sampled)
JSON.stringify short string x 19,658,361 ops/sec ±0.58% (98 runs sampled)
fast-json-stringify short string x 69,757,320 ops/sec ±1.50% (93 runs sampled)
compile-json-stringify short string x 44,706,903 ops/sec ±1.58% (87 runs sampled)
AJV Serialize short string x 33,010,212 ops/sec ±0.66% (94 runs sampled)
JSON.stringify obj x 7,650,782 ops/sec ±0.30% (98 runs sampled)
fast-json-stringify obj x 15,008,195 ops/sec ±0.48% (99 runs sampled)
compile-json-stringify obj x 30,258,985 ops/sec ±0.69% (95 runs sampled)
AJV Serialize obj x 16,646,933 ops/sec ±0.43% (96 runs sampled)
JSON stringify date x 1,267,891 ops/sec ±1.23% (98 runs sampled)
fast-json-stringify date format x 2,274,942 ops/sec ±0.21% (101 runs sampled)
compile-json-stringify date format x 1,279,989 ops/sec ±0.10% (100 runs sampled)
