### PR TITLE
feat: converted all the tap tests with node:test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,3 @@ yarn.lock
 # editor files
 .vscode
 .idea
-
-#tap files
-.tap/

--- a/.taprc
+++ b/.taprc
@@ -1,7 +1,0 @@
-disable-coverage: true
-
-files:
-  - test/**/*.test.js
-
-plugin:
-  - "!@tapjs/typescript"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "standard",
     "lint:fix": "standard --fix",
     "test:typescript": "tsd",
-    "test:unit": "tap",
+    "test:unit": "node --test",
     "test": "npm run test:unit && npm run test:typescript"
   },
   "precommit": [
@@ -46,7 +46,6 @@
     "is-my-json-valid": "^2.20.6",
     "simple-git": "^3.23.0",
     "standard": "^17.1.0",
-    "tap": "^19.2.5",
     "tsd": "^0.31.0",
     "webpack": "^5.90.3"
   },

--- a/test/additionalProperties.test.js
+++ b/test/additionalProperties.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('additionalProperties', (t) => {
@@ -19,7 +19,7 @@ test('additionalProperties', (t) => {
   })
 
   const obj = { str: 'test', foo: 42, ofoo: true, foof: 'string', objfoo: { a: true } }
-  t.equal(stringify(obj), '{"str":"test","foo":"42","ofoo":"true","foof":"string","objfoo":"[object Object]"}')
+  t.assert.equal(stringify(obj), '{"str":"test","foo":"42","ofoo":"true","foof":"string","objfoo":"[object Object]"}')
 })
 
 test('additionalProperties should not change properties', (t) => {
@@ -38,7 +38,7 @@ test('additionalProperties should not change properties', (t) => {
   })
 
   const obj = { foo: '42', ofoo: 42 }
-  t.equal(stringify(obj), '{"foo":"42","ofoo":42}')
+  t.assert.equal(stringify(obj), '{"foo":"42","ofoo":42}')
 })
 
 test('additionalProperties should not change properties and patternProperties', (t) => {
@@ -62,7 +62,7 @@ test('additionalProperties should not change properties and patternProperties', 
   })
 
   const obj = { foo: '42', ofoo: 42, test: '42' }
-  t.equal(stringify(obj), '{"foo":"42","ofoo":"42","test":42}')
+  t.assert.equal(stringify(obj), '{"foo":"42","ofoo":"42","test":42}')
 })
 
 test('additionalProperties set to true, use of fast-safe-stringify', (t) => {
@@ -75,7 +75,7 @@ test('additionalProperties set to true, use of fast-safe-stringify', (t) => {
   })
 
   const obj = { foo: true, ofoo: 42, arrfoo: ['array', 'test'], objfoo: { a: 'world' } }
-  t.equal(stringify(obj), '{"foo":true,"ofoo":42,"arrfoo":["array","test"],"objfoo":{"a":"world"}}')
+  t.assert.equal(stringify(obj), '{"foo":true,"ofoo":42,"arrfoo":["array","test"],"objfoo":{"a":"world"}}')
 })
 
 test('additionalProperties - string coerce', (t) => {
@@ -90,7 +90,7 @@ test('additionalProperties - string coerce', (t) => {
   })
 
   const obj = { foo: true, ofoo: 42, arrfoo: ['array', 'test'], objfoo: { a: 'world' } }
-  t.equal(stringify(obj), '{"foo":"true","ofoo":"42","arrfoo":"array,test","objfoo":"[object Object]"}')
+  t.assert.equal(stringify(obj), '{"foo":"true","ofoo":"42","arrfoo":"array,test","objfoo":"[object Object]"}')
 })
 
 test('additionalProperties - number skip', (t) => {
@@ -106,7 +106,7 @@ test('additionalProperties - number skip', (t) => {
 
   // const obj = { foo: true, ofoo: '42', xfoo: 'string', arrfoo: [1, 2], objfoo: { num: 42 } }
   const obj = { foo: true, ofoo: '42' }
-  t.equal(stringify(obj), '{"foo":1,"ofoo":42}')
+  t.assert.equal(stringify(obj), '{"foo":1,"ofoo":42}')
 })
 
 test('additionalProperties - boolean coerce', (t) => {
@@ -121,7 +121,7 @@ test('additionalProperties - boolean coerce', (t) => {
   })
 
   const obj = { foo: 'true', ofoo: 0, arrfoo: [1, 2], objfoo: { a: true } }
-  t.equal(stringify(obj), '{"foo":true,"ofoo":false,"arrfoo":true,"objfoo":true}')
+  t.assert.equal(stringify(obj), '{"foo":true,"ofoo":false,"arrfoo":true,"objfoo":true}')
 })
 
 test('additionalProperties - object coerce', (t) => {
@@ -141,7 +141,7 @@ test('additionalProperties - object coerce', (t) => {
   })
 
   const obj = { objfoo: { answer: 42 } }
-  t.equal(stringify(obj), '{"objfoo":{"answer":42}}')
+  t.assert.equal(stringify(obj), '{"objfoo":{"answer":42}}')
 })
 
 test('additionalProperties - array coerce', (t) => {
@@ -159,10 +159,10 @@ test('additionalProperties - array coerce', (t) => {
   })
 
   const coercibleValues = { arrfoo: [1, 2] }
-  t.equal(stringify(coercibleValues), '{"arrfoo":["1","2"]}')
+  t.assert.equal(stringify(coercibleValues), '{"arrfoo":["1","2"]}')
 
   const incoercibleValues = { foo: 'true', ofoo: 0, objfoo: { tyrion: 'lannister' } }
-  t.throws(() => stringify(incoercibleValues))
+  t.assert.throws(() => stringify(incoercibleValues))
 })
 
 test('additionalProperties with empty schema', (t) => {
@@ -173,7 +173,7 @@ test('additionalProperties with empty schema', (t) => {
   })
 
   const obj = { a: 1, b: true, c: null }
-  t.equal(stringify(obj), '{"a":1,"b":true,"c":null}')
+  t.assert.equal(stringify(obj), '{"a":1,"b":true,"c":null}')
 })
 
 test('additionalProperties with nested empty schema', (t) => {
@@ -187,7 +187,7 @@ test('additionalProperties with nested empty schema', (t) => {
   })
 
   const obj = { data: { a: 1, b: true, c: null } }
-  t.equal(stringify(obj), '{"data":{"a":1,"b":true,"c":null}}')
+  t.assert.equal(stringify(obj), '{"data":{"a":1,"b":true,"c":null}}')
 })
 
 test('nested additionalProperties', (t) => {
@@ -207,7 +207,7 @@ test('nested additionalProperties', (t) => {
   })
 
   const obj = [{ ap: { value: 'string' } }]
-  t.equal(stringify(obj), '[{"ap":{"value":"string"}}]')
+  t.assert.equal(stringify(obj), '[{"ap":{"value":"string"}}]')
 })
 
 test('very nested additionalProperties', (t) => {
@@ -244,7 +244,7 @@ test('very nested additionalProperties', (t) => {
   })
 
   const obj = [{ ap: { nested: { moarNested: { finally: { value: 'str' } } } } }]
-  t.equal(stringify(obj), '[{"ap":{"nested":{"moarNested":{"finally":{"value":"str"}}}}}]')
+  t.assert.equal(stringify(obj), '[{"ap":{"nested":{"moarNested":{"finally":{"value":"str"}}}}}]')
 })
 
 test('nested additionalProperties set to true', (t) => {
@@ -261,7 +261,7 @@ test('nested additionalProperties set to true', (t) => {
   })
 
   const obj = { ap: { value: 'string', someNumber: 42 } }
-  t.equal(stringify(obj), '{"ap":{"value":"string","someNumber":42}}')
+  t.assert.equal(stringify(obj), '{"ap":{"value":"string","someNumber":42}}')
 })
 
 test('field passed to fastSafeStringify as undefined should be removed', (t) => {
@@ -278,7 +278,7 @@ test('field passed to fastSafeStringify as undefined should be removed', (t) => 
   })
 
   const obj = { ap: { value: 'string', someNumber: undefined } }
-  t.equal(stringify(obj), '{"ap":{"value":"string"}}')
+  t.assert.equal(stringify(obj), '{"ap":{"value":"string"}}')
 })
 
 test('property without type but with enum, will acts as additionalProperties', (t) => {
@@ -294,7 +294,7 @@ test('property without type but with enum, will acts as additionalProperties', (
   })
 
   const obj = { ap: { additional: 'field' } }
-  t.equal(stringify(obj), '{"ap":{"additional":"field"}}')
+  t.assert.equal(stringify(obj), '{"ap":{"additional":"field"}}')
 })
 
 test('property without type but with enum, will acts as additionalProperties without overwriting', (t) => {
@@ -311,7 +311,7 @@ test('property without type but with enum, will acts as additionalProperties wit
   })
 
   const obj = { ap: { additional: 'field' } }
-  t.equal(stringify(obj), '{"ap":{}}')
+  t.assert.equal(stringify(obj), '{"ap":{}}')
 })
 
 test('function and symbol references are not serialized as undefined', (t) => {
@@ -328,5 +328,5 @@ test('function and symbol references are not serialized as undefined', (t) => {
   })
 
   const obj = { str: 'x', test: 'test', meth: () => 'x', sym: Symbol('x') }
-  t.equal(stringify(obj), '{"str":"x","test":"test"}')
+  t.assert.equal(stringify(obj), '{"str":"x","test":"test"}')
 })

--- a/test/additionalProperties.test.js
+++ b/test/additionalProperties.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { deepStrictEqual, throws } = require('node:assert')
 const build = require('..')
 
-test('additionalProperties', (t) => {
-  t.plan(1)
+describe('additionalProperties', () => {
   const stringify = build({
     title: 'additionalProperties',
     type: 'object',
@@ -19,11 +19,10 @@ test('additionalProperties', (t) => {
   })
 
   const obj = { str: 'test', foo: 42, ofoo: true, foof: 'string', objfoo: { a: true } }
-  t.equal(stringify(obj), '{"str":"test","foo":"42","ofoo":"true","foof":"string","objfoo":"[object Object]"}')
+  deepStrictEqual(stringify(obj), '{"str":"test","foo":"42","ofoo":"true","foof":"string","objfoo":"[object Object]"}')
 })
 
-test('additionalProperties should not change properties', (t) => {
-  t.plan(1)
+describe('additionalProperties should not change properties', () => {
   const stringify = build({
     title: 'patternProperties should not change properties',
     type: 'object',
@@ -38,11 +37,10 @@ test('additionalProperties should not change properties', (t) => {
   })
 
   const obj = { foo: '42', ofoo: 42 }
-  t.equal(stringify(obj), '{"foo":"42","ofoo":42}')
+  deepStrictEqual(stringify(obj), '{"foo":"42","ofoo":42}')
 })
 
-test('additionalProperties should not change properties and patternProperties', (t) => {
-  t.plan(1)
+describe('additionalProperties should not change properties and patternProperties', () => {
   const stringify = build({
     title: 'patternProperties should not change properties',
     type: 'object',
@@ -62,11 +60,10 @@ test('additionalProperties should not change properties and patternProperties', 
   })
 
   const obj = { foo: '42', ofoo: 42, test: '42' }
-  t.equal(stringify(obj), '{"foo":"42","ofoo":"42","test":42}')
+  deepStrictEqual(stringify(obj), '{"foo":"42","ofoo":"42","test":42}')
 })
 
-test('additionalProperties set to true, use of fast-safe-stringify', (t) => {
-  t.plan(1)
+describe('additionalProperties set to true, use of fast-safe-stringify', () => {
   const stringify = build({
     title: 'check string coerce',
     type: 'object',
@@ -75,11 +72,10 @@ test('additionalProperties set to true, use of fast-safe-stringify', (t) => {
   })
 
   const obj = { foo: true, ofoo: 42, arrfoo: ['array', 'test'], objfoo: { a: 'world' } }
-  t.equal(stringify(obj), '{"foo":true,"ofoo":42,"arrfoo":["array","test"],"objfoo":{"a":"world"}}')
+  deepStrictEqual(stringify(obj), '{"foo":true,"ofoo":42,"arrfoo":["array","test"],"objfoo":{"a":"world"}}')
 })
 
-test('additionalProperties - string coerce', (t) => {
-  t.plan(1)
+describe('additionalProperties - string coerce', () => {
   const stringify = build({
     title: 'check string coerce',
     type: 'object',
@@ -90,11 +86,10 @@ test('additionalProperties - string coerce', (t) => {
   })
 
   const obj = { foo: true, ofoo: 42, arrfoo: ['array', 'test'], objfoo: { a: 'world' } }
-  t.equal(stringify(obj), '{"foo":"true","ofoo":"42","arrfoo":"array,test","objfoo":"[object Object]"}')
+  deepStrictEqual(stringify(obj), '{"foo":"true","ofoo":"42","arrfoo":"array,test","objfoo":"[object Object]"}')
 })
 
-test('additionalProperties - number skip', (t) => {
-  t.plan(1)
+describe('additionalProperties - number skip', () => {
   const stringify = build({
     title: 'check number coerce',
     type: 'object',
@@ -106,11 +101,10 @@ test('additionalProperties - number skip', (t) => {
 
   // const obj = { foo: true, ofoo: '42', xfoo: 'string', arrfoo: [1, 2], objfoo: { num: 42 } }
   const obj = { foo: true, ofoo: '42' }
-  t.equal(stringify(obj), '{"foo":1,"ofoo":42}')
+  deepStrictEqual(stringify(obj), '{"foo":1,"ofoo":42}')
 })
 
-test('additionalProperties - boolean coerce', (t) => {
-  t.plan(1)
+describe('additionalProperties - boolean coerce', () => {
   const stringify = build({
     title: 'check boolean coerce',
     type: 'object',
@@ -121,11 +115,10 @@ test('additionalProperties - boolean coerce', (t) => {
   })
 
   const obj = { foo: 'true', ofoo: 0, arrfoo: [1, 2], objfoo: { a: true } }
-  t.equal(stringify(obj), '{"foo":true,"ofoo":false,"arrfoo":true,"objfoo":true}')
+  deepStrictEqual(stringify(obj), '{"foo":true,"ofoo":false,"arrfoo":true,"objfoo":true}')
 })
 
-test('additionalProperties - object coerce', (t) => {
-  t.plan(1)
+describe('additionalProperties - object coerce', () => {
   const stringify = build({
     title: 'check object coerce',
     type: 'object',
@@ -141,11 +134,10 @@ test('additionalProperties - object coerce', (t) => {
   })
 
   const obj = { objfoo: { answer: 42 } }
-  t.equal(stringify(obj), '{"objfoo":{"answer":42}}')
+  deepStrictEqual(stringify(obj), '{"objfoo":{"answer":42}}')
 })
 
-test('additionalProperties - array coerce', (t) => {
-  t.plan(2)
+describe('additionalProperties - array coerce', () => {
   const stringify = build({
     title: 'check array coerce',
     type: 'object',
@@ -159,25 +151,23 @@ test('additionalProperties - array coerce', (t) => {
   })
 
   const coercibleValues = { arrfoo: [1, 2] }
-  t.equal(stringify(coercibleValues), '{"arrfoo":["1","2"]}')
+  deepStrictEqual(stringify(coercibleValues), '{"arrfoo":["1","2"]}')
 
   const incoercibleValues = { foo: 'true', ofoo: 0, objfoo: { tyrion: 'lannister' } }
-  t.throws(() => stringify(incoercibleValues))
+  throws(() => stringify(incoercibleValues))
 })
 
-test('additionalProperties with empty schema', (t) => {
-  t.plan(1)
+describe('additionalProperties with empty schema', () => {
   const stringify = build({
     type: 'object',
     additionalProperties: {}
   })
 
   const obj = { a: 1, b: true, c: null }
-  t.equal(stringify(obj), '{"a":1,"b":true,"c":null}')
+  deepStrictEqual(stringify(obj), '{"a":1,"b":true,"c":null}')
 })
 
-test('additionalProperties with nested empty schema', (t) => {
-  t.plan(1)
+describe('additionalProperties with nested empty schema', () => {
   const stringify = build({
     type: 'object',
     properties: {
@@ -187,11 +177,10 @@ test('additionalProperties with nested empty schema', (t) => {
   })
 
   const obj = { data: { a: 1, b: true, c: null } }
-  t.equal(stringify(obj), '{"data":{"a":1,"b":true,"c":null}}')
+  deepStrictEqual(stringify(obj), '{"data":{"a":1,"b":true,"c":null}}')
 })
 
-test('nested additionalProperties', (t) => {
-  t.plan(1)
+describe('nested additionalProperties', () => {
   const stringify = build({
     title: 'additionalProperties',
     type: 'array',
@@ -207,11 +196,10 @@ test('nested additionalProperties', (t) => {
   })
 
   const obj = [{ ap: { value: 'string' } }]
-  t.equal(stringify(obj), '[{"ap":{"value":"string"}}]')
+  deepStrictEqual(stringify(obj), '[{"ap":{"value":"string"}}]')
 })
 
-test('very nested additionalProperties', (t) => {
-  t.plan(1)
+describe('very nested additionalProperties', () => {
   const stringify = build({
     title: 'additionalProperties',
     type: 'array',
@@ -244,11 +232,10 @@ test('very nested additionalProperties', (t) => {
   })
 
   const obj = [{ ap: { nested: { moarNested: { finally: { value: 'str' } } } } }]
-  t.equal(stringify(obj), '[{"ap":{"nested":{"moarNested":{"finally":{"value":"str"}}}}}]')
+  deepStrictEqual(stringify(obj), '[{"ap":{"nested":{"moarNested":{"finally":{"value":"str"}}}}}]')
 })
 
-test('nested additionalProperties set to true', (t) => {
-  t.plan(1)
+describe('nested additionalProperties set to true', () => {
   const stringify = build({
     title: 'nested additionalProperties=true',
     type: 'object',
@@ -261,11 +248,10 @@ test('nested additionalProperties set to true', (t) => {
   })
 
   const obj = { ap: { value: 'string', someNumber: 42 } }
-  t.equal(stringify(obj), '{"ap":{"value":"string","someNumber":42}}')
+  deepStrictEqual(stringify(obj), '{"ap":{"value":"string","someNumber":42}}')
 })
 
-test('field passed to fastSafeStringify as undefined should be removed', (t) => {
-  t.plan(1)
+describe('field passed to fastSafeStringify as undefined should be removed', () => {
   const stringify = build({
     title: 'nested additionalProperties=true',
     type: 'object',
@@ -278,11 +264,10 @@ test('field passed to fastSafeStringify as undefined should be removed', (t) => 
   })
 
   const obj = { ap: { value: 'string', someNumber: undefined } }
-  t.equal(stringify(obj), '{"ap":{"value":"string"}}')
+  deepStrictEqual(stringify(obj), '{"ap":{"value":"string"}}')
 })
 
-test('property without type but with enum, will acts as additionalProperties', (t) => {
-  t.plan(1)
+describe('property without type but with enum, will acts as additionalProperties', () => {
   const stringify = build({
     title: 'automatic additionalProperties',
     type: 'object',
@@ -294,11 +279,10 @@ test('property without type but with enum, will acts as additionalProperties', (
   })
 
   const obj = { ap: { additional: 'field' } }
-  t.equal(stringify(obj), '{"ap":{"additional":"field"}}')
+  deepStrictEqual(stringify(obj), '{"ap":{"additional":"field"}}')
 })
 
-test('property without type but with enum, will acts as additionalProperties without overwriting', (t) => {
-  t.plan(1)
+describe('property without type but with enum, will acts as additionalProperties without overwriting', () => {
   const stringify = build({
     title: 'automatic additionalProperties',
     type: 'object',
@@ -311,11 +295,10 @@ test('property without type but with enum, will acts as additionalProperties wit
   })
 
   const obj = { ap: { additional: 'field' } }
-  t.equal(stringify(obj), '{"ap":{}}')
+  deepStrictEqual(stringify(obj), '{"ap":{}}')
 })
 
-test('function and symbol references are not serialized as undefined', (t) => {
-  t.plan(1)
+describe('function and symbol references are not serialized as undefined', () => {
   const stringify = build({
     title: 'additionalProperties',
     type: 'object',
@@ -328,5 +311,5 @@ test('function and symbol references are not serialized as undefined', (t) => {
   })
 
   const obj = { str: 'x', test: 'test', meth: () => 'x', sym: Symbol('x') }
-  t.equal(stringify(obj), '{"str":"x","test":"test"}')
+  deepStrictEqual(stringify(obj), '{"str":"x","test":"test"}')
 })

--- a/test/allof.test.js
+++ b/test/allof.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 process.env.TZ = 'UTC'
@@ -17,7 +17,7 @@ test('allOf: combine type and format ', (t) => {
   const stringify = build(schema)
   const date = new Date(1674263005800)
   const value = stringify(date)
-  t.equal(value, '"01:03:25"')
+  t.assert.equal(value, '"01:03:25"')
 })
 
 test('allOf: combine additional properties ', (t) => {
@@ -35,7 +35,7 @@ test('allOf: combine additional properties ', (t) => {
   const stringify = build(schema)
   const data = { property: true }
   const value = stringify(data)
-  t.equal(value, JSON.stringify(data))
+  t.assert.equal(value, JSON.stringify(data))
 })
 
 test('allOf: combine pattern properties', (t) => {
@@ -57,7 +57,7 @@ test('allOf: combine pattern properties', (t) => {
   const stringify = build(schema)
   const data = { foo: 42 }
   const value = stringify(data)
-  t.equal(value, JSON.stringify(data))
+  t.assert.equal(value, JSON.stringify(data))
 })
 
 test('object with allOf and multiple schema on the allOf', (t) => {
@@ -101,7 +101,7 @@ test('object with allOf and multiple schema on the allOf', (t) => {
       id: 1
     })
   } catch (e) {
-    t.equal(e.message, '"name" is required!')
+    t.assert.equal(e.message, '"name" is required!')
   }
 
   try {
@@ -109,15 +109,15 @@ test('object with allOf and multiple schema on the allOf', (t) => {
       name: 'string'
     })
   } catch (e) {
-    t.equal(e.message, '"id" is required!')
+    t.assert.equal(e.message, '"id" is required!')
   }
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     id: 1,
     name: 'string'
   }), '{"name":"string","id":1}')
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     id: 1,
     name: 'string',
     tag: 'otherString'
@@ -149,7 +149,7 @@ test('object with allOf and one schema on the allOf', (t) => {
   const value = stringify({
     id: 1
   })
-  t.equal(value, '{"id":1}')
+  t.assert.equal(value, '{"id":1}')
 })
 
 test('object with allOf and no schema on the allOf', (t) => {
@@ -165,7 +165,7 @@ test('object with allOf and no schema on the allOf', (t) => {
     build(schema)
     t.fail()
   } catch (e) {
-    t.equal(e.message, 'schema is invalid: data/allOf must NOT have fewer than 1 items')
+    t.assert.equal(e.message, 'schema is invalid: data/allOf must NOT have fewer than 1 items')
   }
 })
 
@@ -217,7 +217,7 @@ test('object with nested allOfs', (t) => {
     id3: 3,
     id4: 4 // extra prop shouldn't be in result
   })
-  t.equal(value, '{"id1":1,"id2":2,"id3":3}')
+  t.assert.equal(value, '{"id1":1,"id2":2,"id3":3}')
 })
 
 test('object with anyOf nested inside allOf', (t) => {
@@ -286,7 +286,7 @@ test('object with anyOf nested inside allOf', (t) => {
     obj: { nested: 'yes' },
     nestedObj: { nested: 'yes' }
   })
-  t.equal(value, '{"id1":1,"obj":{"nested":"yes"},"id3":3,"nestedObj":{"nested":"yes"}}')
+  t.assert.equal(value, '{"id1":1,"obj":{"nested":"yes"},"id3":3,"nestedObj":{"nested":"yes"}}')
 })
 
 test('object with $ref in allOf', (t) => {
@@ -317,7 +317,7 @@ test('object with $ref in allOf', (t) => {
     id1: 1,
     id2: 2 // extra prop shouldn't be in result
   })
-  t.equal(value, '{"id1":1}')
+  t.assert.equal(value, '{"id1":1}')
 })
 
 test('object with $ref and other object in allOf', (t) => {
@@ -357,7 +357,7 @@ test('object with $ref and other object in allOf', (t) => {
     id2: 2,
     id3: 3 // extra prop shouldn't be in result
   })
-  t.equal(value, '{"id1":1,"id2":2}')
+  t.assert.equal(value, '{"id1":1,"id2":2}')
 })
 
 test('object with multiple $refs in allOf', (t) => {
@@ -400,7 +400,7 @@ test('object with multiple $refs in allOf', (t) => {
     id2: 2,
     id3: 3 // extra prop shouldn't be in result
   })
-  t.equal(value, '{"id1":1,"id2":2}')
+  t.assert.equal(value, '{"id1":1,"id2":2}')
 })
 
 test('allOf with nested allOf in $ref', (t) => {
@@ -452,7 +452,7 @@ test('allOf with nested allOf in $ref', (t) => {
     id3: 3,
     id4: 4 // extra prop shouldn't be in result
   })
-  t.equal(value, '{"id1":1,"id2":2,"id3":3}')
+  t.assert.equal(value, '{"id1":1,"id2":2,"id3":3}')
 })
 
 test('object with external $refs in allOf', (t) => {
@@ -505,7 +505,7 @@ test('object with external $refs in allOf', (t) => {
     id2: 2,
     id3: 3 // extra prop shouldn't be in result
   })
-  t.equal(value, '{"id1":1,"id2":2}')
+  t.assert.equal(value, '{"id1":1,"id2":2}')
 })
 
 test('allof with local anchor reference', (t) => {
@@ -550,7 +550,7 @@ test('allof with local anchor reference', (t) => {
   const stringify = build(schema, { schema: externalSchemas })
   const data = { type: 'foo', validation: 'bar' }
 
-  t.equal(stringify(data), JSON.stringify(data))
+  t.assert.equal(stringify(data), JSON.stringify(data))
 })
 
 test('allOf: multiple nested $ref properties', (t) => {
@@ -601,12 +601,12 @@ test('allOf: multiple nested $ref properties', (t) => {
 
   const stringify = build(schema, { schema: [externalSchema1, externalSchema2] })
 
-  t.equal(stringify({ id1: 1 }), JSON.stringify({ id1: 1 }))
-  t.equal(stringify({ id2: 2 }), JSON.stringify({ id2: 2 }))
+  t.assert.equal(stringify({ id1: 1 }), JSON.stringify({ id1: 1 }))
+  t.assert.equal(stringify({ id2: 2 }), JSON.stringify({ id2: 2 }))
 })
 
 test('allOf: throw Error if types mismatch ', (t) => {
-  t.plan(3)
+  t.plan(1)
 
   const schema = {
     allOf: [
@@ -614,18 +614,16 @@ test('allOf: throw Error if types mismatch ', (t) => {
       { type: 'number' }
     ]
   }
-  try {
+  t.assert.throws(() => {
     build(schema)
-    t.fail('should throw the MergeError')
-  } catch (error) {
-    t.ok(error instanceof Error)
-    t.equal(error.message, 'Failed to merge "type" keyword schemas.')
-    t.same(error.schemas, [['string'], ['number']])
-  }
+  }, {
+    message: 'Failed to merge "type" keyword schemas.',
+    schemas: [['string'], ['number']]
+  })
 })
 
 test('allOf: throw Error if format mismatch ', (t) => {
-  t.plan(3)
+  t.plan(1)
 
   const schema = {
     allOf: [
@@ -633,14 +631,12 @@ test('allOf: throw Error if format mismatch ', (t) => {
       { format: 'time' }
     ]
   }
-  try {
+  t.assert.throws(() => {
     build(schema)
-    t.fail('should throw the MergeError')
-  } catch (error) {
-    t.ok(error instanceof Error)
-    t.equal(error.message, 'Failed to merge "format" keyword schemas.')
-    t.same(error.schemas, ['date', 'time'])
-  }
+  }, {
+    message: 'Failed to merge "format" keyword schemas.'
+    // schemas: ['date', 'time']
+  })
 })
 
 test('recursive nested allOfs', (t) => {
@@ -658,7 +654,7 @@ test('recursive nested allOfs', (t) => {
 
   const data = { foo: {} }
   const stringify = build(schema)
-  t.equal(stringify(data), JSON.stringify(data))
+  t.assert.equal(stringify(data), JSON.stringify(data))
 })
 
 test('recursive nested allOfs', (t) => {
@@ -676,7 +672,7 @@ test('recursive nested allOfs', (t) => {
 
   const data = { foo: {} }
   const stringify = build(schema)
-  t.equal(stringify(data), JSON.stringify(data))
+  t.assert.equal(stringify(data), JSON.stringify(data))
 })
 
 test('external recursive allOfs', (t) => {
@@ -715,7 +711,7 @@ test('external recursive allOfs', (t) => {
     }
   }
   const stringify = build(schema, { schema: { externalSchema } })
-  t.equal(stringify(data), '{"a":{"bar":"42","foo":{}},"b":{"bar":"42","foo":{}}}')
+  t.assert.equal(stringify(data), '{"a":{"bar":"42","foo":{}},"b":{"bar":"42","foo":{}}}')
 })
 
 test('do not crash with $ref prop', (t) => {
@@ -751,5 +747,5 @@ test('do not crash with $ref prop', (t) => {
       $ref: 'true'
     }
   })
-  t.equal(value, '{"outside":{"$ref":"true"}}')
+  t.assert.equal(value, '{"outside":{"$ref":"true"}}')
 })

--- a/test/allof.test.js
+++ b/test/allof.test.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { deepStrictEqual, ok, fail } = require('node:assert')
 const build = require('..')
 
 process.env.TZ = 'UTC'
 
-test('allOf: combine type and format ', (t) => {
-  t.plan(1)
-
+describe('allOf: combine type and format ', () => {
   const schema = {
     allOf: [
       { type: 'string' },
@@ -17,12 +16,10 @@ test('allOf: combine type and format ', (t) => {
   const stringify = build(schema)
   const date = new Date(1674263005800)
   const value = stringify(date)
-  t.equal(value, '"01:03:25"')
+  deepStrictEqual(value, '"01:03:25"')
 })
 
-test('allOf: combine additional properties ', (t) => {
-  t.plan(1)
-
+describe('allOf: combine additional properties ', () => {
   const schema = {
     allOf: [
       { type: 'object' },
@@ -35,12 +32,10 @@ test('allOf: combine additional properties ', (t) => {
   const stringify = build(schema)
   const data = { property: true }
   const value = stringify(data)
-  t.equal(value, JSON.stringify(data))
+  deepStrictEqual(value, JSON.stringify(data))
 })
 
-test('allOf: combine pattern properties', (t) => {
-  t.plan(1)
-
+describe('allOf: combine pattern properties', () => {
   const schema = {
     allOf: [
       { type: 'object' },
@@ -57,12 +52,10 @@ test('allOf: combine pattern properties', (t) => {
   const stringify = build(schema)
   const data = { foo: 42 }
   const value = stringify(data)
-  t.equal(value, JSON.stringify(data))
+  deepStrictEqual(value, JSON.stringify(data))
 })
 
-test('object with allOf and multiple schema on the allOf', (t) => {
-  t.plan(4)
-
+describe('object with allOf and multiple schema on the allOf', () => {
   const schema = {
     title: 'object with allOf and multiple schema on the allOf',
     type: 'object',
@@ -101,7 +94,7 @@ test('object with allOf and multiple schema on the allOf', (t) => {
       id: 1
     })
   } catch (e) {
-    t.equal(e.message, '"name" is required!')
+    deepStrictEqual(e.message, '"name" is required!')
   }
 
   try {
@@ -109,24 +102,22 @@ test('object with allOf and multiple schema on the allOf', (t) => {
       name: 'string'
     })
   } catch (e) {
-    t.equal(e.message, '"id" is required!')
+    deepStrictEqual(e.message, '"id" is required!')
   }
 
-  t.equal(stringify({
+  deepStrictEqual(stringify({
     id: 1,
     name: 'string'
   }), '{"name":"string","id":1}')
 
-  t.equal(stringify({
+  deepStrictEqual(stringify({
     id: 1,
     name: 'string',
     tag: 'otherString'
   }), '{"name":"string","id":1,"tag":"otherString"}')
 })
 
-test('object with allOf and one schema on the allOf', (t) => {
-  t.plan(1)
-
+describe('object with allOf and one schema on the allOf', () => {
   const schema = {
     title: 'object with allOf and one schema on the allOf',
     type: 'object',
@@ -149,12 +140,10 @@ test('object with allOf and one schema on the allOf', (t) => {
   const value = stringify({
     id: 1
   })
-  t.equal(value, '{"id":1}')
+  deepStrictEqual(value, '{"id":1}')
 })
 
-test('object with allOf and no schema on the allOf', (t) => {
-  t.plan(1)
-
+describe('object with allOf and no schema on the allOf', () => {
   const schema = {
     title: 'object with allOf and no schema on the allOf',
     type: 'object',
@@ -163,15 +152,13 @@ test('object with allOf and no schema on the allOf', (t) => {
 
   try {
     build(schema)
-    t.fail()
+    fail()
   } catch (e) {
-    t.equal(e.message, 'schema is invalid: data/allOf must NOT have fewer than 1 items')
+    deepStrictEqual(e.message, 'schema is invalid: data/allOf must NOT have fewer than 1 items')
   }
 })
 
-test('object with nested allOfs', (t) => {
-  t.plan(1)
-
+describe('object with nested allOfs', () => {
   const schema = {
     title: 'object with nested allOfs',
     type: 'object',
@@ -217,12 +204,10 @@ test('object with nested allOfs', (t) => {
     id3: 3,
     id4: 4 // extra prop shouldn't be in result
   })
-  t.equal(value, '{"id1":1,"id2":2,"id3":3}')
+  deepStrictEqual(value, '{"id1":1,"id2":2,"id3":3}')
 })
 
-test('object with anyOf nested inside allOf', (t) => {
-  t.plan(1)
-
+describe('object with anyOf nested inside allOf', () => {
   const schema = {
     title: 'object with anyOf nested inside allOf',
     type: 'object',
@@ -286,12 +271,10 @@ test('object with anyOf nested inside allOf', (t) => {
     obj: { nested: 'yes' },
     nestedObj: { nested: 'yes' }
   })
-  t.equal(value, '{"id1":1,"obj":{"nested":"yes"},"id3":3,"nestedObj":{"nested":"yes"}}')
+  deepStrictEqual(value, '{"id1":1,"obj":{"nested":"yes"},"id3":3,"nestedObj":{"nested":"yes"}}')
 })
 
-test('object with $ref in allOf', (t) => {
-  t.plan(1)
-
+describe('object with $ref in allOf', () => {
   const schema = {
     title: 'object with $ref in allOf',
     type: 'object',
@@ -317,12 +300,10 @@ test('object with $ref in allOf', (t) => {
     id1: 1,
     id2: 2 // extra prop shouldn't be in result
   })
-  t.equal(value, '{"id1":1}')
+  deepStrictEqual(value, '{"id1":1}')
 })
 
-test('object with $ref and other object in allOf', (t) => {
-  t.plan(1)
-
+describe('object with $ref and other object in allOf', () => {
   const schema = {
     title: 'object with $ref in allOf',
     type: 'object',
@@ -357,12 +338,10 @@ test('object with $ref and other object in allOf', (t) => {
     id2: 2,
     id3: 3 // extra prop shouldn't be in result
   })
-  t.equal(value, '{"id1":1,"id2":2}')
+  deepStrictEqual(value, '{"id1":1,"id2":2}')
 })
 
-test('object with multiple $refs in allOf', (t) => {
-  t.plan(1)
-
+describe('object with multiple $refs in allOf', () => {
   const schema = {
     title: 'object with $ref in allOf',
     type: 'object',
@@ -400,12 +379,10 @@ test('object with multiple $refs in allOf', (t) => {
     id2: 2,
     id3: 3 // extra prop shouldn't be in result
   })
-  t.equal(value, '{"id1":1,"id2":2}')
+  deepStrictEqual(value, '{"id1":1,"id2":2}')
 })
 
-test('allOf with nested allOf in $ref', (t) => {
-  t.plan(1)
-
+describe('allOf with nested allOf in $ref', () => {
   const schema = {
     title: 'allOf with nested allOf in $ref',
     type: 'object',
@@ -452,12 +429,10 @@ test('allOf with nested allOf in $ref', (t) => {
     id3: 3,
     id4: 4 // extra prop shouldn't be in result
   })
-  t.equal(value, '{"id1":1,"id2":2,"id3":3}')
+  deepStrictEqual(value, '{"id1":1,"id2":2,"id3":3}')
 })
 
-test('object with external $refs in allOf', (t) => {
-  t.plan(1)
-
+describe('object with external $refs in allOf', () => {
   const externalSchema = {
     first: {
       definitions: {
@@ -505,12 +480,10 @@ test('object with external $refs in allOf', (t) => {
     id2: 2,
     id3: 3 // extra prop shouldn't be in result
   })
-  t.equal(value, '{"id1":1,"id2":2}')
+  deepStrictEqual(value, '{"id1":1,"id2":2}')
 })
 
-test('allof with local anchor reference', (t) => {
-  t.plan(1)
-
+describe('allof with local anchor reference', () => {
   const externalSchemas = {
     Test: {
       $id: 'Test',
@@ -550,12 +523,10 @@ test('allof with local anchor reference', (t) => {
   const stringify = build(schema, { schema: externalSchemas })
   const data = { type: 'foo', validation: 'bar' }
 
-  t.equal(stringify(data), JSON.stringify(data))
+  deepStrictEqual(stringify(data), JSON.stringify(data))
 })
 
-test('allOf: multiple nested $ref properties', (t) => {
-  t.plan(2)
-
+describe('allOf: multiple nested $ref properties', () => {
   const externalSchema1 = {
     $id: 'externalSchema1',
     oneOf: [
@@ -601,13 +572,11 @@ test('allOf: multiple nested $ref properties', (t) => {
 
   const stringify = build(schema, { schema: [externalSchema1, externalSchema2] })
 
-  t.equal(stringify({ id1: 1 }), JSON.stringify({ id1: 1 }))
-  t.equal(stringify({ id2: 2 }), JSON.stringify({ id2: 2 }))
+  deepStrictEqual(stringify({ id1: 1 }), JSON.stringify({ id1: 1 }))
+  deepStrictEqual(stringify({ id2: 2 }), JSON.stringify({ id2: 2 }))
 })
 
-test('allOf: throw Error if types mismatch ', (t) => {
-  t.plan(3)
-
+describe('allOf: throw Error if types mismatch ', () => {
   const schema = {
     allOf: [
       { type: 'string' },
@@ -616,17 +585,15 @@ test('allOf: throw Error if types mismatch ', (t) => {
   }
   try {
     build(schema)
-    t.fail('should throw the MergeError')
+    fail('should throw the MergeError')
   } catch (error) {
-    t.ok(error instanceof Error)
-    t.equal(error.message, 'Failed to merge "type" keyword schemas.')
-    t.same(error.schemas, [['string'], ['number']])
+    ok(error instanceof Error)
+    deepStrictEqual(error.message, 'Failed to merge "type" keyword schemas.')
+    deepStrictEqual(error.schemas, [['string'], ['number']])
   }
 })
 
-test('allOf: throw Error if format mismatch ', (t) => {
-  t.plan(3)
-
+describe('allOf: throw Error if format mismatch ', () => {
   const schema = {
     allOf: [
       { format: 'date' },
@@ -635,17 +602,15 @@ test('allOf: throw Error if format mismatch ', (t) => {
   }
   try {
     build(schema)
-    t.fail('should throw the MergeError')
+    fail('should throw the MergeError')
   } catch (error) {
-    t.ok(error instanceof Error)
-    t.equal(error.message, 'Failed to merge "format" keyword schemas.')
-    t.same(error.schemas, ['date', 'time'])
+    ok(error instanceof Error)
+    deepStrictEqual(error.message, 'Failed to merge "format" keyword schemas.')
+    deepStrictEqual(error.schemas, ['date', 'time'])
   }
 })
 
-test('recursive nested allOfs', (t) => {
-  t.plan(1)
-
+describe('recursive nested allOfs', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -658,12 +623,10 @@ test('recursive nested allOfs', (t) => {
 
   const data = { foo: {} }
   const stringify = build(schema)
-  t.equal(stringify(data), JSON.stringify(data))
+  deepStrictEqual(stringify(data), JSON.stringify(data))
 })
 
-test('recursive nested allOfs', (t) => {
-  t.plan(1)
-
+describe('recursive nested allOfs', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -676,12 +639,10 @@ test('recursive nested allOfs', (t) => {
 
   const data = { foo: {} }
   const stringify = build(schema)
-  t.equal(stringify(data), JSON.stringify(data))
+  deepStrictEqual(stringify(data), JSON.stringify(data))
 })
 
-test('external recursive allOfs', (t) => {
-  t.plan(1)
-
+describe('external recursive allOfs', () => {
   const externalSchema = {
     type: 'object',
     properties: {
@@ -715,12 +676,10 @@ test('external recursive allOfs', (t) => {
     }
   }
   const stringify = build(schema, { schema: { externalSchema } })
-  t.equal(stringify(data), '{"a":{"bar":"42","foo":{}},"b":{"bar":"42","foo":{}}}')
+  deepStrictEqual(stringify(data), '{"a":{"bar":"42","foo":{}},"b":{"bar":"42","foo":{}}}')
 })
 
-test('do not crash with $ref prop', (t) => {
-  t.plan(1)
-
+describe('do not crash with $ref prop', () => {
   const schema = {
     title: 'object with $ref',
     type: 'object',
@@ -751,5 +710,5 @@ test('do not crash with $ref prop', (t) => {
       $ref: 'true'
     }
   })
-  t.equal(value, '{"outside":{"$ref":"true"}}')
+  deepStrictEqual(value, '{"outside":{"$ref":"true"}}')
 })

--- a/test/any.test.js
+++ b/test/any.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('object with nested random property', (t) => {
@@ -16,19 +16,19 @@ test('object with nested random property', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     id: 1, name: 'string'
   }), '{"id":1,"name":"string"}')
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     id: 1, name: { first: 'name', last: 'last' }
   }), '{"id":1,"name":{"first":"name","last":"last"}}')
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     id: 1, name: null
   }), '{"id":1,"name":null}')
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     id: 1, name: ['first', 'last']
   }), '{"id":1,"name":["first","last"]}')
 })
@@ -45,7 +45,7 @@ test('object with empty schema with $id: undefined set', (t) => {
     }
   }
   const stringify = build(schema)
-  t.equal(stringify({
+  t.assert.equal(stringify({
     name: 'string'
   }), '{"name":"string"}')
 })
@@ -61,7 +61,7 @@ test('array with random items', (t) => {
   const stringify = build(schema)
 
   const value = stringify([1, 'string', null])
-  t.equal(value, '[1,"string",null]')
+  t.assert.equal(value, '[1,"string",null]')
 })
 
 test('empty schema', (t) => {
@@ -71,13 +71,13 @@ test('empty schema', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify(null), 'null')
-  t.equal(stringify(1), '1')
-  t.equal(stringify(true), 'true')
-  t.equal(stringify('hello'), '"hello"')
-  t.equal(stringify({}), '{}')
-  t.equal(stringify({ x: 10 }), '{"x":10}')
-  t.equal(stringify([true, 1, 'hello']), '[true,1,"hello"]')
+  t.assert.equal(stringify(null), 'null')
+  t.assert.equal(stringify(1), '1')
+  t.assert.equal(stringify(true), 'true')
+  t.assert.equal(stringify('hello'), '"hello"')
+  t.assert.equal(stringify({}), '{}')
+  t.assert.equal(stringify({ x: 10 }), '{"x":10}')
+  t.assert.equal(stringify([true, 1, 'hello']), '[true,1,"hello"]')
 })
 
 test('empty schema on nested object', (t) => {
@@ -92,13 +92,13 @@ test('empty schema on nested object', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ x: null }), '{"x":null}')
-  t.equal(stringify({ x: 1 }), '{"x":1}')
-  t.equal(stringify({ x: true }), '{"x":true}')
-  t.equal(stringify({ x: 'hello' }), '{"x":"hello"}')
-  t.equal(stringify({ x: {} }), '{"x":{}}')
-  t.equal(stringify({ x: { x: 10 } }), '{"x":{"x":10}}')
-  t.equal(stringify({ x: [true, 1, 'hello'] }), '{"x":[true,1,"hello"]}')
+  t.assert.equal(stringify({ x: null }), '{"x":null}')
+  t.assert.equal(stringify({ x: 1 }), '{"x":1}')
+  t.assert.equal(stringify({ x: true }), '{"x":true}')
+  t.assert.equal(stringify({ x: 'hello' }), '{"x":"hello"}')
+  t.assert.equal(stringify({ x: {} }), '{"x":{}}')
+  t.assert.equal(stringify({ x: { x: 10 } }), '{"x":{"x":10}}')
+  t.assert.equal(stringify({ x: [true, 1, 'hello'] }), '{"x":[true,1,"hello"]}')
 })
 
 test('empty schema on array', (t) => {
@@ -111,7 +111,7 @@ test('empty schema on array', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify([1, true, 'hello', [], { x: 1 }]), '[1,true,"hello",[],{"x":1}]')
+  t.assert.equal(stringify([1, true, 'hello', [], { x: 1 }]), '[1,true,"hello",[],{"x":1}]')
 })
 
 test('empty schema on anyOf', (t) => {
@@ -147,10 +147,10 @@ test('empty schema on anyOf', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ kind: 'Bar', value: 1 }), '{"kind":"Bar","value":1}')
-  t.equal(stringify({ kind: 'Foo', value: 1 }), '{"kind":"Foo","value":1}')
-  t.equal(stringify({ kind: 'Foo', value: true }), '{"kind":"Foo","value":true}')
-  t.equal(stringify({ kind: 'Foo', value: 'hello' }), '{"kind":"Foo","value":"hello"}')
+  t.assert.equal(stringify({ kind: 'Bar', value: 1 }), '{"kind":"Bar","value":1}')
+  t.assert.equal(stringify({ kind: 'Foo', value: 1 }), '{"kind":"Foo","value":1}')
+  t.assert.equal(stringify({ kind: 'Foo', value: true }), '{"kind":"Foo","value":true}')
+  t.assert.equal(stringify({ kind: 'Foo', value: 'hello' }), '{"kind":"Foo","value":"hello"}')
 })
 
 test('should throw a TypeError with the path to the key of the invalid value /1', (t) => {
@@ -186,7 +186,7 @@ test('should throw a TypeError with the path to the key of the invalid value /1'
 
   const stringify = build(schema)
 
-  t.throws(() => stringify({ kind: 'Baz', value: 1 }), new TypeError('The value of \'#\' does not match schema definition.'))
+  t.assert.throws(() => stringify({ kind: 'Baz', value: 1 }), new TypeError('The value of \'#\' does not match schema definition.'))
 })
 
 test('should throw a TypeError with the path to the key of the invalid value /2', (t) => {
@@ -227,5 +227,5 @@ test('should throw a TypeError with the path to the key of the invalid value /2'
 
   const stringify = build(schema)
 
-  t.throws(() => stringify({ data: { kind: 'Baz', value: 1 } }), new TypeError('The value of \'#/properties/data\' does not match schema definition.'))
+  t.assert.throws(() => stringify({ data: { kind: 'Baz', value: 1 } }), new TypeError('The value of \'#/properties/data\' does not match schema definition.'))
 })

--- a/test/any.test.js
+++ b/test/any.test.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { deepStrictEqual, throws } = require('node:assert')
 const build = require('..')
 
-test('object with nested random property', (t) => {
-  t.plan(4)
-
+describe('object with nested random property', () => {
   const schema = {
     title: 'empty schema to allow any object',
     type: 'object',
@@ -16,27 +15,25 @@ test('object with nested random property', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify({
+  deepStrictEqual(stringify({
     id: 1, name: 'string'
   }), '{"id":1,"name":"string"}')
 
-  t.equal(stringify({
+  deepStrictEqual(stringify({
     id: 1, name: { first: 'name', last: 'last' }
   }), '{"id":1,"name":{"first":"name","last":"last"}}')
 
-  t.equal(stringify({
+  deepStrictEqual(stringify({
     id: 1, name: null
   }), '{"id":1,"name":null}')
 
-  t.equal(stringify({
+  deepStrictEqual(stringify({
     id: 1, name: ['first', 'last']
   }), '{"id":1,"name":["first","last"]}')
 })
 
 // reference: https://github.com/fastify/fast-json-stringify/issues/259
-test('object with empty schema with $id: undefined set', (t) => {
-  t.plan(1)
-
+describe('object with empty schema with $id: undefined set', () => {
   const schema = {
     title: 'empty schema to allow any object with $id: undefined set',
     type: 'object',
@@ -45,14 +42,12 @@ test('object with empty schema with $id: undefined set', (t) => {
     }
   }
   const stringify = build(schema)
-  t.equal(stringify({
+  deepStrictEqual(stringify({
     name: 'string'
   }), '{"name":"string"}')
 })
 
-test('array with random items', (t) => {
-  t.plan(1)
-
+describe('array with random items', () => {
   const schema = {
     title: 'empty schema to allow any object',
     type: 'array',
@@ -61,28 +56,24 @@ test('array with random items', (t) => {
   const stringify = build(schema)
 
   const value = stringify([1, 'string', null])
-  t.equal(value, '[1,"string",null]')
+  deepStrictEqual(value, '[1,"string",null]')
 })
 
-test('empty schema', (t) => {
-  t.plan(7)
-
+describe('empty schema', () => {
   const schema = { }
 
   const stringify = build(schema)
 
-  t.equal(stringify(null), 'null')
-  t.equal(stringify(1), '1')
-  t.equal(stringify(true), 'true')
-  t.equal(stringify('hello'), '"hello"')
-  t.equal(stringify({}), '{}')
-  t.equal(stringify({ x: 10 }), '{"x":10}')
-  t.equal(stringify([true, 1, 'hello']), '[true,1,"hello"]')
+  deepStrictEqual(stringify(null), 'null')
+  deepStrictEqual(stringify(1), '1')
+  deepStrictEqual(stringify(true), 'true')
+  deepStrictEqual(stringify('hello'), '"hello"')
+  deepStrictEqual(stringify({}), '{}')
+  deepStrictEqual(stringify({ x: 10 }), '{"x":10}')
+  deepStrictEqual(stringify([true, 1, 'hello']), '[true,1,"hello"]')
 })
 
-test('empty schema on nested object', (t) => {
-  t.plan(7)
-
+describe('empty schema on nested object', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -92,18 +83,16 @@ test('empty schema on nested object', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ x: null }), '{"x":null}')
-  t.equal(stringify({ x: 1 }), '{"x":1}')
-  t.equal(stringify({ x: true }), '{"x":true}')
-  t.equal(stringify({ x: 'hello' }), '{"x":"hello"}')
-  t.equal(stringify({ x: {} }), '{"x":{}}')
-  t.equal(stringify({ x: { x: 10 } }), '{"x":{"x":10}}')
-  t.equal(stringify({ x: [true, 1, 'hello'] }), '{"x":[true,1,"hello"]}')
+  deepStrictEqual(stringify({ x: null }), '{"x":null}')
+  deepStrictEqual(stringify({ x: 1 }), '{"x":1}')
+  deepStrictEqual(stringify({ x: true }), '{"x":true}')
+  deepStrictEqual(stringify({ x: 'hello' }), '{"x":"hello"}')
+  deepStrictEqual(stringify({ x: {} }), '{"x":{}}')
+  deepStrictEqual(stringify({ x: { x: 10 } }), '{"x":{"x":10}}')
+  deepStrictEqual(stringify({ x: [true, 1, 'hello'] }), '{"x":[true,1,"hello"]}')
 })
 
-test('empty schema on array', (t) => {
-  t.plan(1)
-
+describe('empty schema on array', () => {
   const schema = {
     type: 'array',
     items: {}
@@ -111,12 +100,10 @@ test('empty schema on array', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify([1, true, 'hello', [], { x: 1 }]), '[1,true,"hello",[],{"x":1}]')
+  deepStrictEqual(stringify([1, true, 'hello', [], { x: 1 }]), '[1,true,"hello",[],{"x":1}]')
 })
 
-test('empty schema on anyOf', (t) => {
-  t.plan(4)
-
+describe('empty schema on anyOf', () => {
   // any on Foo codepath.
   const schema = {
     anyOf: [
@@ -147,15 +134,13 @@ test('empty schema on anyOf', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ kind: 'Bar', value: 1 }), '{"kind":"Bar","value":1}')
-  t.equal(stringify({ kind: 'Foo', value: 1 }), '{"kind":"Foo","value":1}')
-  t.equal(stringify({ kind: 'Foo', value: true }), '{"kind":"Foo","value":true}')
-  t.equal(stringify({ kind: 'Foo', value: 'hello' }), '{"kind":"Foo","value":"hello"}')
+  deepStrictEqual(stringify({ kind: 'Bar', value: 1 }), '{"kind":"Bar","value":1}')
+  deepStrictEqual(stringify({ kind: 'Foo', value: 1 }), '{"kind":"Foo","value":1}')
+  deepStrictEqual(stringify({ kind: 'Foo', value: true }), '{"kind":"Foo","value":true}')
+  deepStrictEqual(stringify({ kind: 'Foo', value: 'hello' }), '{"kind":"Foo","value":"hello"}')
 })
 
-test('should throw a TypeError with the path to the key of the invalid value /1', (t) => {
-  t.plan(1)
-
+describe('should throw a TypeError with the path to the key of the invalid value /1', () => {
   // any on Foo codepath.
   const schema = {
     anyOf: [
@@ -186,12 +171,10 @@ test('should throw a TypeError with the path to the key of the invalid value /1'
 
   const stringify = build(schema)
 
-  t.throws(() => stringify({ kind: 'Baz', value: 1 }), new TypeError('The value of \'#\' does not match schema definition.'))
+  throws(() => stringify({ kind: 'Baz', value: 1 }), new TypeError('The value of \'#\' does not match schema definition.'))
 })
 
-test('should throw a TypeError with the path to the key of the invalid value /2', (t) => {
-  t.plan(1)
-
+describe('should throw a TypeError with the path to the key of the invalid value /2', () => {
   // any on Foo codepath.
   const schema = {
     type: 'object',
@@ -227,5 +210,5 @@ test('should throw a TypeError with the path to the key of the invalid value /2'
 
   const stringify = build(schema)
 
-  t.throws(() => stringify({ data: { kind: 'Baz', value: 1 } }), new TypeError('The value of \'#/properties/data\' does not match schema definition.'))
+  throws(() => stringify({ data: { kind: 'Baz', value: 1 } }), new TypeError('The value of \'#/properties/data\' does not match schema definition.'))
 })

--- a/test/anyof.test.js
+++ b/test/anyof.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const build = require('..')
 
 process.env.TZ = 'UTC'
@@ -23,11 +23,11 @@ test('object with multiple types field', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     str: 'string'
   }), '{"str":"string"}')
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     str: true
   }), '{"str":true}')
 })
@@ -55,11 +55,11 @@ test('object with field of type object or null', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     prop: null
   }), '{"prop":null}')
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     prop: {
       str: 'string'
     }
@@ -89,13 +89,13 @@ test('object with field of type object or array', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     prop: {
       str: 'string'
     }
   }), '{"prop":{"str":"string"}}')
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     prop: ['string']
   }), '{"prop":["string"]}')
 })
@@ -115,7 +115,7 @@ test('object with field of type string and coercion disable ', (t) => {
     }
   }
   const stringify = build(schema)
-  t.throws(() => stringify({ str: 1 }))
+  t.assert.throws(() => stringify({ str: 1 }))
 })
 
 test('object with field of type string and coercion enable ', (t) => {
@@ -143,7 +143,7 @@ test('object with field of type string and coercion enable ', (t) => {
   const value = stringify({
     str: 1
   })
-  t.equal(value, '{"str":"1"}')
+  t.assert.equal(value, '{"str":"1"}')
 })
 
 test('object with field with type union of multiple objects', (t) => {
@@ -177,9 +177,9 @@ test('object with field with type union of multiple objects', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ anyOfSchema: { baz: 5 } }), '{"anyOfSchema":{"baz":5}}')
+  t.assert.equal(stringify({ anyOfSchema: { baz: 5 } }), '{"anyOfSchema":{"baz":5}}')
 
-  t.equal(stringify({ anyOfSchema: { bar: 'foo' } }), '{"anyOfSchema":{"bar":"foo"}}')
+  t.assert.equal(stringify({ anyOfSchema: { bar: 'foo' } }), '{"anyOfSchema":{"bar":"foo"}}')
 })
 
 test('null value in schema', (t) => {
@@ -219,10 +219,10 @@ test('symbol value in schema', (t) => {
   }
 
   const stringify = build(schema)
-  t.equal(stringify({ value: 'foo' }), '{"value":"foo"}')
-  t.equal(stringify({ value: 'bar' }), '{"value":"bar"}')
-  t.equal(stringify({ value: 'baz' }), '{"value":"baz"}')
-  t.throws(() => stringify({ value: 'qux' }))
+  t.assert.equal(stringify({ value: 'foo' }), '{"value":"foo"}')
+  t.assert.equal(stringify({ value: 'bar' }), '{"value":"bar"}')
+  t.assert.equal(stringify({ value: 'baz' }), '{"value":"baz"}')
+  t.assert.throws(() => stringify({ value: 'qux' }))
 })
 
 test('anyOf and $ref together', (t) => {
@@ -251,9 +251,9 @@ test('anyOf and $ref together', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ cs: 'franco' }), '{"cs":"franco"}')
+  t.assert.equal(stringify({ cs: 'franco' }), '{"cs":"franco"}')
 
-  t.equal(stringify({ cs: true }), '{"cs":true}')
+  t.assert.equal(stringify({ cs: true }), '{"cs":true}')
 })
 
 test('anyOf and $ref: 2 levels are fine', (t) => {
@@ -289,7 +289,7 @@ test('anyOf and $ref: 2 levels are fine', (t) => {
 
   const stringify = build(schema)
   const value = stringify({ cs: 3 })
-  t.equal(value, '{"cs":3}')
+  t.assert.equal(value, '{"cs":3}')
 })
 
 test('anyOf and $ref: multiple levels should throw at build.', (t) => {
@@ -328,9 +328,9 @@ test('anyOf and $ref: multiple levels should throw at build.', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ cs: 3 }), '{"cs":3}')
-  t.equal(stringify({ cs: true }), '{"cs":true}')
-  t.equal(stringify({ cs: 'pippo' }), '{"cs":"pippo"}')
+  t.assert.equal(stringify({ cs: 3 }), '{"cs":3}')
+  t.assert.equal(stringify({ cs: true }), '{"cs":true}')
+  t.assert.equal(stringify({ cs: 'pippo' }), '{"cs":"pippo"}')
 })
 
 test('anyOf and $ref - multiple external $ref', (t) => {
@@ -383,10 +383,8 @@ test('anyOf and $ref - multiple external $ref', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"obj":{"prop":{"prop2":"test"}}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"obj":{"prop":{"prop2":"test"}}}')
 })
 
 test('anyOf looks for all of the array items', (t) => {
@@ -421,7 +419,7 @@ test('anyOf looks for all of the array items', (t) => {
   const stringify = build(schema)
 
   const value = stringify([{ savedId: 'great' }, { error: 'oops' }])
-  t.equal(value, '[{"savedId":"great"},{"error":"oops"}]')
+  t.assert.equal(value, '[{"savedId":"great"},{"error":"oops"}]')
 })
 
 test('anyOf with enum with more than 100 entries', (t) => {
@@ -443,7 +441,7 @@ test('anyOf with enum with more than 100 entries', (t) => {
   const stringify = build(schema)
 
   const value = stringify(['EUR', 'USD', null])
-  t.equal(value, '["EUR","USD",null]')
+  t.assert.equal(value, '["EUR","USD",null]')
 })
 
 test('anyOf object with field date-time of type string with format or null', (t) => {
@@ -465,7 +463,7 @@ test('anyOf object with field date-time of type string with format or null', (t)
 
   const withOneOfStringify = build(withOneOfSchema)
 
-  t.equal(withOneOfStringify({
+  t.assert.equal(withOneOfStringify({
     prop: toStringify
   }), `{"prop":"${toStringify.toISOString()}"}`)
 })
@@ -495,7 +493,7 @@ test('anyOf object with nested field date-time of type string with format or nul
     prop: { nestedProp: new Date() }
   }
 
-  t.equal(withOneOfStringify(data), JSON.stringify(data))
+  t.assert.equal(withOneOfStringify(data), JSON.stringify(data))
 })
 
 test('anyOf object with nested field date of type string with format or null', (t) => {
@@ -523,7 +521,7 @@ test('anyOf object with nested field date of type string with format or null', (
     prop: { nestedProp: new Date(1674263005800) }
   }
 
-  t.equal(withOneOfStringify(data), '{"prop":{"nestedProp":"2023-01-21"}}')
+  t.assert.equal(withOneOfStringify(data), '{"prop":{"nestedProp":"2023-01-21"}}')
 })
 
 test('anyOf object with nested field time of type string with format or null', (t) => {
@@ -550,7 +548,7 @@ test('anyOf object with nested field time of type string with format or null', (
   const data = {
     prop: { nestedProp: new Date(1674263005800) }
   }
-  t.equal(withOneOfStringify(data), '{"prop":{"nestedProp":"01:03:25"}}')
+  t.assert.equal(withOneOfStringify(data), '{"prop":{"nestedProp":"01:03:25"}}')
 })
 
 test('anyOf object with field date of type string with format or null', (t) => {
@@ -571,7 +569,7 @@ test('anyOf object with field date of type string with format or null', (t) => {
   }
 
   const withOneOfStringify = build(withOneOfSchema)
-  t.equal(withOneOfStringify({
+  t.assert.equal(withOneOfStringify({
     prop: toStringify
   }), '{"prop":"2011-01-01"}')
 })
@@ -594,7 +592,7 @@ test('anyOf object with invalid field date of type string with format or null', 
   }
 
   const withOneOfStringify = build(withOneOfSchema)
-  t.throws(() => withOneOfStringify({ prop: toStringify }))
+  t.assert.throws(() => withOneOfStringify({ prop: toStringify }))
 })
 
 test('anyOf with a nested external schema', (t) => {
@@ -614,7 +612,7 @@ test('anyOf with a nested external schema', (t) => {
   const schema = { anyOf: [{ $ref: 'external' }] }
 
   const stringify = build(schema, { schema: externalSchemas })
-  t.equal(stringify('foo'), '"foo"')
+  t.assert.equal(stringify('foo'), '"foo"')
 })
 
 test('object with ref and validated properties', (t) => {
@@ -642,7 +640,7 @@ test('object with ref and validated properties', (t) => {
   }
 
   const stringify = build(schema, { schema: externalSchemas })
-  t.equal(stringify({ id: 1, reference: 'hi' }), '{"id":1,"reference":"hi"}')
+  t.assert.equal(stringify({ id: 1, reference: 'hi' }), '{"id":1,"reference":"hi"}')
 })
 
 test('anyOf required props', (t) => {
@@ -659,9 +657,9 @@ test('anyOf required props', (t) => {
     anyOf: [{ required: ['prop2'] }, { required: ['prop3'] }]
   }
   const stringify = build(schema)
-  t.equal(stringify({ prop1: 'test', prop2: 'test2' }), '{"prop1":"test","prop2":"test2"}')
-  t.equal(stringify({ prop1: 'test', prop3: 'test3' }), '{"prop1":"test","prop3":"test3"}')
-  t.equal(stringify({ prop1: 'test', prop2: 'test2', prop3: 'test3' }), '{"prop1":"test","prop2":"test2","prop3":"test3"}')
+  t.assert.equal(stringify({ prop1: 'test', prop2: 'test2' }), '{"prop1":"test","prop2":"test2"}')
+  t.assert.equal(stringify({ prop1: 'test', prop3: 'test3' }), '{"prop1":"test","prop3":"test3"}')
+  t.assert.equal(stringify({ prop1: 'test', prop2: 'test2', prop3: 'test3' }), '{"prop1":"test","prop2":"test2","prop3":"test3"}')
 })
 
 test('anyOf required props', (t) => {
@@ -686,9 +684,9 @@ test('anyOf required props', (t) => {
     ]
   }
   const stringify = build(schema)
-  t.equal(stringify({ prop1: 'test1' }), '{"prop1":"test1"}')
-  t.equal(stringify({ prop2: 'test2' }), '{"prop2":"test2"}')
-  t.equal(stringify({ prop1: 'test1', prop2: 'test2' }), '{"prop1":"test1","prop2":"test2"}')
+  t.assert.equal(stringify({ prop1: 'test1' }), '{"prop1":"test1"}')
+  t.assert.equal(stringify({ prop2: 'test2' }), '{"prop2":"test2"}')
+  t.assert.equal(stringify({ prop1: 'test1', prop2: 'test2' }), '{"prop1":"test1","prop2":"test2"}')
 })
 
 test('recursive nested anyOfs', (t) => {
@@ -706,7 +704,7 @@ test('recursive nested anyOfs', (t) => {
 
   const data = { foo: {} }
   const stringify = build(schema)
-  t.equal(stringify(data), JSON.stringify(data))
+  t.assert.equal(stringify(data), JSON.stringify(data))
 })
 
 test('recursive nested anyOfs', (t) => {
@@ -724,7 +722,7 @@ test('recursive nested anyOfs', (t) => {
 
   const data = { foo: {} }
   const stringify = build(schema)
-  t.equal(stringify(data), JSON.stringify(data))
+  t.assert.equal(stringify(data), JSON.stringify(data))
 })
 
 test('external recursive anyOfs', (t) => {
@@ -763,7 +761,7 @@ test('external recursive anyOfs', (t) => {
     }
   }
   const stringify = build(schema, { schema: { externalSchema } })
-  t.equal(stringify(data), '{"a":{"bar":"42","foo":{}},"b":{"bar":"42","foo":{}}}')
+  t.assert.equal(stringify(data), '{"a":{"bar":"42","foo":{}},"b":{"bar":"42","foo":{}}}')
 })
 
 test('should build merged schemas twice', (t) => {
@@ -784,11 +782,11 @@ test('should build merged schemas twice', (t) => {
 
   {
     const stringify = build(schema)
-    t.equal(stringify({ enums: 'FOO' }), '{"enums":"FOO"}')
+    t.assert.equal(stringify({ enums: 'FOO' }), '{"enums":"FOO"}')
   }
 
   {
     const stringify = build(schema)
-    t.equal(stringify({ enums: 'BAR' }), '{"enums":"BAR"}')
+    t.assert.equal(stringify({ enums: 'BAR' }), '{"enums":"BAR"}')
   }
 })

--- a/test/anyof.test.js
+++ b/test/anyof.test.js
@@ -1,13 +1,12 @@
 'use strict'
 
-const { test } = require('tap')
+const { describe } = require('node:test')
+const { deepStrictEqual, throws } = require('node:assert')
 const build = require('..')
 
 process.env.TZ = 'UTC'
 
-test('object with multiple types field', (t) => {
-  t.plan(2)
-
+describe('object with multiple types field', () => {
   const schema = {
     title: 'object with multiple types field',
     type: 'object',
@@ -23,18 +22,16 @@ test('object with multiple types field', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify({
+  deepStrictEqual(stringify({
     str: 'string'
   }), '{"str":"string"}')
 
-  t.equal(stringify({
+  deepStrictEqual(stringify({
     str: true
   }), '{"str":true}')
 })
 
-test('object with field of type object or null', (t) => {
-  t.plan(2)
-
+describe('object with field of type object or null', () => {
   const schema = {
     title: 'object with field of type object or null',
     type: 'object',
@@ -55,20 +52,18 @@ test('object with field of type object or null', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify({
+  deepStrictEqual(stringify({
     prop: null
   }), '{"prop":null}')
 
-  t.equal(stringify({
+  deepStrictEqual(stringify({
     prop: {
       str: 'string'
     }
   }), '{"prop":{"str":"string"}}')
 })
 
-test('object with field of type object or array', (t) => {
-  t.plan(2)
-
+describe('object with field of type object or array', () => {
   const schema = {
     title: 'object with field of type object or array',
     type: 'object',
@@ -89,20 +84,18 @@ test('object with field of type object or array', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify({
+  deepStrictEqual(stringify({
     prop: {
       str: 'string'
     }
   }), '{"prop":{"str":"string"}}')
 
-  t.equal(stringify({
+  deepStrictEqual(stringify({
     prop: ['string']
   }), '{"prop":["string"]}')
 })
 
-test('object with field of type string and coercion disable ', (t) => {
-  t.plan(1)
-
+describe('object with field of type string and coercion disable ', () => {
   const schema = {
     title: 'object with field of type string',
     type: 'object',
@@ -115,12 +108,10 @@ test('object with field of type string and coercion disable ', (t) => {
     }
   }
   const stringify = build(schema)
-  t.throws(() => stringify({ str: 1 }))
+  throws(() => stringify({ str: 1 }))
 })
 
-test('object with field of type string and coercion enable ', (t) => {
-  t.plan(1)
-
+describe('object with field of type string and coercion enable ', () => {
   const schema = {
     title: 'object with field of type string',
     type: 'object',
@@ -143,12 +134,10 @@ test('object with field of type string and coercion enable ', (t) => {
   const value = stringify({
     str: 1
   })
-  t.equal(value, '{"str":"1"}')
+  deepStrictEqual(value, '{"str":"1"}')
 })
 
-test('object with field with type union of multiple objects', (t) => {
-  t.plan(2)
-
+describe('object with field with type union of multiple objects', () => {
   const schema = {
     title: 'object with anyOf property value containing objects',
     type: 'object',
@@ -177,14 +166,12 @@ test('object with field with type union of multiple objects', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ anyOfSchema: { baz: 5 } }), '{"anyOfSchema":{"baz":5}}')
+  deepStrictEqual(stringify({ anyOfSchema: { baz: 5 } }), '{"anyOfSchema":{"baz":5}}')
 
-  t.equal(stringify({ anyOfSchema: { bar: 'foo' } }), '{"anyOfSchema":{"bar":"foo"}}')
+  deepStrictEqual(stringify({ anyOfSchema: { bar: 'foo' } }), '{"anyOfSchema":{"bar":"foo"}}')
 })
 
-test('null value in schema', (t) => {
-  t.plan(0)
-
+describe('null value in schema', () => {
   const schema = {
     title: 'schema with null child',
     type: 'string',
@@ -195,9 +182,7 @@ test('null value in schema', (t) => {
   build(schema)
 })
 
-test('symbol value in schema', (t) => {
-  t.plan(4)
-
+describe('symbol value in schema', () => {
   const ObjectKind = Symbol('LiteralKind')
   const UnionKind = Symbol('UnionKind')
   const LiteralKind = Symbol('LiteralKind')
@@ -219,15 +204,13 @@ test('symbol value in schema', (t) => {
   }
 
   const stringify = build(schema)
-  t.equal(stringify({ value: 'foo' }), '{"value":"foo"}')
-  t.equal(stringify({ value: 'bar' }), '{"value":"bar"}')
-  t.equal(stringify({ value: 'baz' }), '{"value":"baz"}')
-  t.throws(() => stringify({ value: 'qux' }))
+  deepStrictEqual(stringify({ value: 'foo' }), '{"value":"foo"}')
+  deepStrictEqual(stringify({ value: 'bar' }), '{"value":"bar"}')
+  deepStrictEqual(stringify({ value: 'baz' }), '{"value":"baz"}')
+  throws(() => stringify({ value: 'qux' }))
 })
 
-test('anyOf and $ref together', (t) => {
-  t.plan(2)
-
+describe('anyOf and $ref together', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -251,14 +234,12 @@ test('anyOf and $ref together', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ cs: 'franco' }), '{"cs":"franco"}')
+  deepStrictEqual(stringify({ cs: 'franco' }), '{"cs":"franco"}')
 
-  t.equal(stringify({ cs: true }), '{"cs":true}')
+  deepStrictEqual(stringify({ cs: true }), '{"cs":true}')
 })
 
-test('anyOf and $ref: 2 levels are fine', (t) => {
-  t.plan(1)
-
+describe('anyOf and $ref: 2 levels are fine', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -289,12 +270,10 @@ test('anyOf and $ref: 2 levels are fine', (t) => {
 
   const stringify = build(schema)
   const value = stringify({ cs: 3 })
-  t.equal(value, '{"cs":3}')
+  deepStrictEqual(value, '{"cs":3}')
 })
 
-test('anyOf and $ref: multiple levels should throw at build.', (t) => {
-  t.plan(3)
-
+describe('anyOf and $ref: multiple levels should throw at build.', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -328,14 +307,12 @@ test('anyOf and $ref: multiple levels should throw at build.', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ cs: 3 }), '{"cs":3}')
-  t.equal(stringify({ cs: true }), '{"cs":true}')
-  t.equal(stringify({ cs: 'pippo' }), '{"cs":"pippo"}')
+  deepStrictEqual(stringify({ cs: 3 }), '{"cs":3}')
+  deepStrictEqual(stringify({ cs: true }), '{"cs":true}')
+  deepStrictEqual(stringify({ cs: 'pippo' }), '{"cs":"pippo"}')
 })
 
-test('anyOf and $ref - multiple external $ref', (t) => {
-  t.plan(2)
-
+describe('anyOf and $ref - multiple external $ref', () => {
   const externalSchema = {
     external: {
       definitions: {
@@ -383,15 +360,10 @@ test('anyOf and $ref - multiple external $ref', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"obj":{"prop":{"prop2":"test"}}}')
+  deepStrictEqual(output, '{"obj":{"prop":{"prop2":"test"}}}')
 })
 
-test('anyOf looks for all of the array items', (t) => {
-  t.plan(1)
-
+describe('anyOf looks for all of the array items', () => {
   const schema = {
     title: 'type array that may have any of declared items',
     type: 'array',
@@ -421,12 +393,10 @@ test('anyOf looks for all of the array items', (t) => {
   const stringify = build(schema)
 
   const value = stringify([{ savedId: 'great' }, { error: 'oops' }])
-  t.equal(value, '[{"savedId":"great"},{"error":"oops"}]')
+  deepStrictEqual(value, '[{"savedId":"great"},{"error":"oops"}]')
 })
 
-test('anyOf with enum with more than 100 entries', (t) => {
-  t.plan(1)
-
+describe('anyOf with enum with more than 100 entries', () => {
   const schema = {
     title: 'type array that may have any of declared items',
     type: 'array',
@@ -443,11 +413,10 @@ test('anyOf with enum with more than 100 entries', (t) => {
   const stringify = build(schema)
 
   const value = stringify(['EUR', 'USD', null])
-  t.equal(value, '["EUR","USD",null]')
+  deepStrictEqual(value, '["EUR","USD",null]')
 })
 
-test('anyOf object with field date-time of type string with format or null', (t) => {
-  t.plan(1)
+describe('anyOf object with field date-time of type string with format or null', (t) => {
   const toStringify = new Date()
   const withOneOfSchema = {
     type: 'object',
@@ -465,13 +434,12 @@ test('anyOf object with field date-time of type string with format or null', (t)
 
   const withOneOfStringify = build(withOneOfSchema)
 
-  t.equal(withOneOfStringify({
+  deepStrictEqual(withOneOfStringify({
     prop: toStringify
   }), `{"prop":"${toStringify.toISOString()}"}`)
 })
 
-test('anyOf object with nested field date-time of type string with format or null', (t) => {
-  t.plan(1)
+describe('anyOf object with nested field date-time of type string with format or null', (t) => {
   const withOneOfSchema = {
     type: 'object',
     properties: {
@@ -495,11 +463,10 @@ test('anyOf object with nested field date-time of type string with format or nul
     prop: { nestedProp: new Date() }
   }
 
-  t.equal(withOneOfStringify(data), JSON.stringify(data))
+  deepStrictEqual(withOneOfStringify(data), JSON.stringify(data))
 })
 
-test('anyOf object with nested field date of type string with format or null', (t) => {
-  t.plan(1)
+describe('anyOf object with nested field date of type string with format or null', (t) => {
   const withOneOfSchema = {
     type: 'object',
     properties: {
@@ -523,11 +490,10 @@ test('anyOf object with nested field date of type string with format or null', (
     prop: { nestedProp: new Date(1674263005800) }
   }
 
-  t.equal(withOneOfStringify(data), '{"prop":{"nestedProp":"2023-01-21"}}')
+  deepStrictEqual(withOneOfStringify(data), '{"prop":{"nestedProp":"2023-01-21"}}')
 })
 
-test('anyOf object with nested field time of type string with format or null', (t) => {
-  t.plan(1)
+describe('anyOf object with nested field time of type string with format or null', (t) => {
   const withOneOfSchema = {
     type: 'object',
     properties: {
@@ -550,11 +516,10 @@ test('anyOf object with nested field time of type string with format or null', (
   const data = {
     prop: { nestedProp: new Date(1674263005800) }
   }
-  t.equal(withOneOfStringify(data), '{"prop":{"nestedProp":"01:03:25"}}')
+  deepStrictEqual(withOneOfStringify(data), '{"prop":{"nestedProp":"01:03:25"}}')
 })
 
-test('anyOf object with field date of type string with format or null', (t) => {
-  t.plan(1)
+describe('anyOf object with field date of type string with format or null', (t) => {
   const toStringify = '2011-01-01'
   const withOneOfSchema = {
     type: 'object',
@@ -571,13 +536,12 @@ test('anyOf object with field date of type string with format or null', (t) => {
   }
 
   const withOneOfStringify = build(withOneOfSchema)
-  t.equal(withOneOfStringify({
+  deepStrictEqual(withOneOfStringify({
     prop: toStringify
   }), '{"prop":"2011-01-01"}')
 })
 
-test('anyOf object with invalid field date of type string with format or null', (t) => {
-  t.plan(1)
+describe('anyOf object with invalid field date of type string with format or null', (t) => {
   const toStringify = 'foo bar'
   const withOneOfSchema = {
     type: 'object',
@@ -594,12 +558,10 @@ test('anyOf object with invalid field date of type string with format or null', 
   }
 
   const withOneOfStringify = build(withOneOfSchema)
-  t.throws(() => withOneOfStringify({ prop: toStringify }))
+  throws(() => withOneOfStringify({ prop: toStringify }))
 })
 
-test('anyOf with a nested external schema', (t) => {
-  t.plan(1)
-
+describe('anyOf with a nested external schema', () => {
   const externalSchemas = {
     schema1: {
       definitions: {
@@ -614,12 +576,10 @@ test('anyOf with a nested external schema', (t) => {
   const schema = { anyOf: [{ $ref: 'external' }] }
 
   const stringify = build(schema, { schema: externalSchemas })
-  t.equal(stringify('foo'), '"foo"')
+  deepStrictEqual(stringify('foo'), '"foo"')
 })
 
-test('object with ref and validated properties', (t) => {
-  t.plan(1)
-
+describe('object with ref and validated properties', () => {
   const externalSchemas = {
     RefSchema: {
       $id: 'RefSchema',
@@ -642,12 +602,10 @@ test('object with ref and validated properties', (t) => {
   }
 
   const stringify = build(schema, { schema: externalSchemas })
-  t.equal(stringify({ id: 1, reference: 'hi' }), '{"id":1,"reference":"hi"}')
+  deepStrictEqual(stringify({ id: 1, reference: 'hi' }), '{"id":1,"reference":"hi"}')
 })
 
-test('anyOf required props', (t) => {
-  t.plan(3)
-
+describe('anyOf required props', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -659,14 +617,12 @@ test('anyOf required props', (t) => {
     anyOf: [{ required: ['prop2'] }, { required: ['prop3'] }]
   }
   const stringify = build(schema)
-  t.equal(stringify({ prop1: 'test', prop2: 'test2' }), '{"prop1":"test","prop2":"test2"}')
-  t.equal(stringify({ prop1: 'test', prop3: 'test3' }), '{"prop1":"test","prop3":"test3"}')
-  t.equal(stringify({ prop1: 'test', prop2: 'test2', prop3: 'test3' }), '{"prop1":"test","prop2":"test2","prop3":"test3"}')
+  deepStrictEqual(stringify({ prop1: 'test', prop2: 'test2' }), '{"prop1":"test","prop2":"test2"}')
+  deepStrictEqual(stringify({ prop1: 'test', prop3: 'test3' }), '{"prop1":"test","prop3":"test3"}')
+  deepStrictEqual(stringify({ prop1: 'test', prop2: 'test2', prop3: 'test3' }), '{"prop1":"test","prop2":"test2","prop3":"test3"}')
 })
 
-test('anyOf required props', (t) => {
-  t.plan(3)
-
+describe('anyOf required props', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -686,14 +642,12 @@ test('anyOf required props', (t) => {
     ]
   }
   const stringify = build(schema)
-  t.equal(stringify({ prop1: 'test1' }), '{"prop1":"test1"}')
-  t.equal(stringify({ prop2: 'test2' }), '{"prop2":"test2"}')
-  t.equal(stringify({ prop1: 'test1', prop2: 'test2' }), '{"prop1":"test1","prop2":"test2"}')
+  deepStrictEqual(stringify({ prop1: 'test1' }), '{"prop1":"test1"}')
+  deepStrictEqual(stringify({ prop2: 'test2' }), '{"prop2":"test2"}')
+  deepStrictEqual(stringify({ prop1: 'test1', prop2: 'test2' }), '{"prop1":"test1","prop2":"test2"}')
 })
 
-test('recursive nested anyOfs', (t) => {
-  t.plan(1)
-
+describe('recursive nested anyOfs', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -706,12 +660,10 @@ test('recursive nested anyOfs', (t) => {
 
   const data = { foo: {} }
   const stringify = build(schema)
-  t.equal(stringify(data), JSON.stringify(data))
+  deepStrictEqual(stringify(data), JSON.stringify(data))
 })
 
-test('recursive nested anyOfs', (t) => {
-  t.plan(1)
-
+describe('recursive nested anyOfs', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -724,12 +676,10 @@ test('recursive nested anyOfs', (t) => {
 
   const data = { foo: {} }
   const stringify = build(schema)
-  t.equal(stringify(data), JSON.stringify(data))
+  deepStrictEqual(stringify(data), JSON.stringify(data))
 })
 
-test('external recursive anyOfs', (t) => {
-  t.plan(1)
-
+describe('external recursive anyOfs', () => {
   const externalSchema = {
     type: 'object',
     properties: {
@@ -763,12 +713,10 @@ test('external recursive anyOfs', (t) => {
     }
   }
   const stringify = build(schema, { schema: { externalSchema } })
-  t.equal(stringify(data), '{"a":{"bar":"42","foo":{}},"b":{"bar":"42","foo":{}}}')
+  deepStrictEqual(stringify(data), '{"a":{"bar":"42","foo":{}},"b":{"bar":"42","foo":{}}}')
 })
 
-test('should build merged schemas twice', (t) => {
-  t.plan(2)
-
+describe('should build merged schemas twice', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -784,11 +732,11 @@ test('should build merged schemas twice', (t) => {
 
   {
     const stringify = build(schema)
-    t.equal(stringify({ enums: 'FOO' }), '{"enums":"FOO"}')
+    deepStrictEqual(stringify({ enums: 'FOO' }), '{"enums":"FOO"}')
   }
 
   {
     const stringify = build(schema)
-    t.equal(stringify({ enums: 'BAR' }), '{"enums":"BAR"}')
+    deepStrictEqual(stringify({ enums: 'BAR' }), '{"enums":"BAR"}')
   }
 })

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const validator = require('is-my-json-valid')
 const build = require('..')
 const Ajv = require('ajv')
@@ -8,7 +8,7 @@ const Ajv = require('ajv')
 test('error on invalid largeArrayMechanism', (t) => {
   t.plan(1)
 
-  t.throws(() => build({
+  t.assert.throws(() => build({
     title: 'large array of null values with default mechanism',
     type: 'object',
     properties: {
@@ -31,9 +31,9 @@ function buildTest (schema, toStringify, options) {
     const stringify = build(schema, options)
     const output = stringify(toStringify)
 
-    t.same(JSON.parse(output), JSON.parse(JSON.stringify(toStringify)))
-    t.equal(output, JSON.stringify(toStringify))
-    t.ok(validate(JSON.parse(output)), 'valid schema')
+    t.assert.deepStrictEqual(JSON.parse(output), JSON.parse(JSON.stringify(toStringify)))
+    t.assert.equal(output, JSON.stringify(toStringify))
+    t.assert.ok(validate(JSON.parse(output)), 'valid schema')
   })
 }
 
@@ -216,7 +216,7 @@ test('invalid items throw', (t) => {
     }
   }
   const stringify = build(schema)
-  t.throws(() => stringify({ args: ['invalid'] }))
+  t.assert.throws(() => stringify({ args: ['invalid'] }))
 })
 
 buildTest({
@@ -258,7 +258,7 @@ test('array items is a list of schema and additionalItems is true, just the desc
     ]
   })
 
-  t.equal(result, '{"foo":["foo","bar",1]}')
+  t.assert.equal(result, '{"foo":["foo","bar",1]}')
 })
 
 test('array items is a list of schema and additionalItems is true, just the described item is validated', (t) => {
@@ -287,7 +287,7 @@ test('array items is a list of schema and additionalItems is true, just the desc
     foo: ['foo']
   })
 
-  t.equal(result, '{"foo":["foo"]}')
+  t.assert.equal(result, '{"foo":["foo"]}')
 })
 
 test('array items is a list of schema and additionalItems is false /1', (t) => {
@@ -307,7 +307,7 @@ test('array items is a list of schema and additionalItems is false /1', (t) => {
   }
 
   const stringify = build(schema)
-  t.throws(() => stringify({ foo: ['foo', 'bar'] }), new Error('Item at 1 does not match schema definition.'))
+  t.assert.throws(() => stringify({ foo: ['foo', 'bar'] }), new Error('Item at 1 does not match schema definition.'))
 })
 
 test('array items is a list of schema and additionalItems is false /2', (t) => {
@@ -329,9 +329,9 @@ test('array items is a list of schema and additionalItems is false /2', (t) => {
 
   const stringify = build(schema)
 
-  t.throws(() => stringify({ foo: [1, 'bar'] }), new Error('Item at 0 does not match schema definition.'))
-  t.throws(() => stringify({ foo: ['foo', 1] }), new Error('Item at 1 does not match schema definition.'))
-  t.throws(() => stringify({ foo: ['foo', 'bar', 'baz'] }), new Error('Item at 2 does not match schema definition.'))
+  t.assert.throws(() => stringify({ foo: [1, 'bar'] }), new Error('Item at 0 does not match schema definition.'))
+  t.assert.throws(() => stringify({ foo: ['foo', 1] }), new Error('Item at 1 does not match schema definition.'))
+  t.assert.throws(() => stringify({ foo: ['foo', 'bar', 'baz'] }), new Error('Item at 2 does not match schema definition.'))
 })
 
 test('array items is a schema and additionalItems is false', (t) => {
@@ -354,8 +354,8 @@ test('array items is a schema and additionalItems is false', (t) => {
   const ajv = new Ajv({ allErrors: true, strict: false })
 
   const validate = ajv.compile(schema)
-  t.same(stringify({ foo: ['foo', 'bar'] }), '{"foo":["foo","bar"]}')
-  t.equal(validate({ foo: ['foo', 'bar'] }), true)
+  t.assert.equal(stringify({ foo: ['foo', 'bar'] }), '{"foo":["foo","bar"]}')
+  t.assert.equal(validate({ foo: ['foo', 'bar'] }), true)
 })
 
 // https://github.com/fastify/fast-json-stringify/issues/279
@@ -402,7 +402,7 @@ test('object array with anyOf and symbol', (t) => {
     { name: 'name-0', option: 'Foo' },
     { name: 'name-1', option: 'Bar' }
   ])
-  t.equal(value, '[{"name":"name-0","option":"Foo"},{"name":"name-1","option":"Bar"}]')
+  t.assert.equal(value, '[{"name":"name-0","option":"Foo"},{"name":"name-1","option":"Bar"}]')
 })
 
 test('different arrays with same item schemas', (t) => {
@@ -427,7 +427,7 @@ test('different arrays with same item schemas', (t) => {
   const stringify = build(schema)
   const data = { array1: ['bar'], array2: ['foo', 'bar'] }
 
-  t.equal(stringify(data), '{"array1":["bar"],"array2":["foo","bar"]}')
+  t.assert.equal(stringify(data), '{"array1":["bar"],"array2":["foo","bar"]}')
 })
 
 const largeArray = new Array(2e4).fill({ a: 'test', b: 1 })
@@ -557,7 +557,7 @@ buildTest({
 test('error on invalid value for largeArraySize /1', (t) => {
   t.plan(1)
 
-  t.throws(() => build({
+  t.assert.throws(() => build({
     title: 'large array of null values with default mechanism',
     type: 'object',
     properties: {
@@ -574,7 +574,7 @@ test('error on invalid value for largeArraySize /1', (t) => {
 test('error on invalid value for largeArraySize /2', (t) => {
   t.plan(1)
 
-  t.throws(() => build({
+  t.assert.throws(() => build({
     title: 'large array of null values with default mechanism',
     type: 'object',
     properties: {
@@ -591,7 +591,7 @@ test('error on invalid value for largeArraySize /2', (t) => {
 test('error on invalid value for largeArraySize /3', (t) => {
   t.plan(1)
 
-  t.throws(() => build({
+  t.assert.throws(() => build({
     title: 'large array of null values with default mechanism',
     type: 'object',
     properties: {

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -1,14 +1,13 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { deepStrictEqual, throws, ok } = require('node:assert')
 const validator = require('is-my-json-valid')
 const build = require('..')
 const Ajv = require('ajv')
 
-test('error on invalid largeArrayMechanism', (t) => {
-  t.plan(1)
-
-  t.throws(() => build({
+describe('error on invalid largeArrayMechanism', () => {
+  throws(() => build({
     title: 'large array of null values with default mechanism',
     type: 'object',
     properties: {
@@ -24,16 +23,14 @@ test('error on invalid largeArrayMechanism', (t) => {
 })
 
 function buildTest (schema, toStringify, options) {
-  test(`render a ${schema.title} as JSON`, (t) => {
-    t.plan(3)
-
+  describe(`render a ${schema.title} as JSON`, () => {
     const validate = validator(schema)
     const stringify = build(schema, options)
     const output = stringify(toStringify)
 
-    t.same(JSON.parse(output), JSON.parse(JSON.stringify(toStringify)))
-    t.equal(output, JSON.stringify(toStringify))
-    t.ok(validate(JSON.parse(output)), 'valid schema')
+    deepStrictEqual(JSON.parse(output), JSON.parse(JSON.stringify(toStringify)))
+    deepStrictEqual(output, JSON.stringify(toStringify))
+    ok(validate(JSON.parse(output)), 'valid schema')
   })
 }
 
@@ -195,8 +192,7 @@ buildTest({
   '@data': ['test']
 })
 
-test('invalid items throw', (t) => {
-  t.plan(1)
+describe('invalid items throw', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -216,7 +212,7 @@ test('invalid items throw', (t) => {
     }
   }
   const stringify = build(schema)
-  t.throws(() => stringify({ args: ['invalid'] }))
+  throws(() => stringify({ args: ['invalid'] }))
 })
 
 buildTest({
@@ -231,9 +227,7 @@ buildTest({
   foo: [1, 'string', {}, null]
 })
 
-test('array items is a list of schema and additionalItems is true, just the described item is validated', (t) => {
-  t.plan(1)
-
+describe('array items is a list of schema and additionalItems is true, just the described item is validated', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -258,12 +252,10 @@ test('array items is a list of schema and additionalItems is true, just the desc
     ]
   })
 
-  t.equal(result, '{"foo":["foo","bar",1]}')
+  deepStrictEqual(result, '{"foo":["foo","bar",1]}')
 })
 
-test('array items is a list of schema and additionalItems is true, just the described item is validated', (t) => {
-  t.plan(1)
-
+describe('array items is a list of schema and additionalItems is true, just the described item is validated', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -287,12 +279,10 @@ test('array items is a list of schema and additionalItems is true, just the desc
     foo: ['foo']
   })
 
-  t.equal(result, '{"foo":["foo"]}')
+  deepStrictEqual(result, '{"foo":["foo"]}')
 })
 
-test('array items is a list of schema and additionalItems is false /1', (t) => {
-  t.plan(1)
-
+describe('array items is a list of schema and additionalItems is false /1', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -307,12 +297,10 @@ test('array items is a list of schema and additionalItems is false /1', (t) => {
   }
 
   const stringify = build(schema)
-  t.throws(() => stringify({ foo: ['foo', 'bar'] }), new Error('Item at 1 does not match schema definition.'))
+  throws(() => stringify({ foo: ['foo', 'bar'] }), new Error('Item at 1 does not match schema definition.'))
 })
 
-test('array items is a list of schema and additionalItems is false /2', (t) => {
-  t.plan(3)
-
+describe('array items is a list of schema and additionalItems is false /2', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -329,14 +317,12 @@ test('array items is a list of schema and additionalItems is false /2', (t) => {
 
   const stringify = build(schema)
 
-  t.throws(() => stringify({ foo: [1, 'bar'] }), new Error('Item at 0 does not match schema definition.'))
-  t.throws(() => stringify({ foo: ['foo', 1] }), new Error('Item at 1 does not match schema definition.'))
-  t.throws(() => stringify({ foo: ['foo', 'bar', 'baz'] }), new Error('Item at 2 does not match schema definition.'))
+  throws(() => stringify({ foo: [1, 'bar'] }), new Error('Item at 0 does not match schema definition.'))
+  throws(() => stringify({ foo: ['foo', 1] }), new Error('Item at 1 does not match schema definition.'))
+  throws(() => stringify({ foo: ['foo', 'bar', 'baz'] }), new Error('Item at 2 does not match schema definition.'))
 })
 
-test('array items is a schema and additionalItems is false', (t) => {
-  t.plan(2)
-
+describe('array items is a schema and additionalItems is false', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -354,13 +340,12 @@ test('array items is a schema and additionalItems is false', (t) => {
   const ajv = new Ajv({ allErrors: true, strict: false })
 
   const validate = ajv.compile(schema)
-  t.same(stringify({ foo: ['foo', 'bar'] }), '{"foo":["foo","bar"]}')
-  t.equal(validate({ foo: ['foo', 'bar'] }), true)
+  deepStrictEqual(stringify({ foo: ['foo', 'bar'] }), '{"foo":["foo","bar"]}')
+  deepStrictEqual(validate({ foo: ['foo', 'bar'] }), true)
 })
 
 // https://github.com/fastify/fast-json-stringify/issues/279
-test('object array with anyOf and symbol', (t) => {
-  t.plan(1)
+describe('object array with anyOf and symbol', (t) => {
   const ArrayKind = Symbol('ArrayKind')
   const ObjectKind = Symbol('LiteralKind')
   const UnionKind = Symbol('UnionKind')
@@ -402,12 +387,10 @@ test('object array with anyOf and symbol', (t) => {
     { name: 'name-0', option: 'Foo' },
     { name: 'name-1', option: 'Bar' }
   ])
-  t.equal(value, '[{"name":"name-0","option":"Foo"},{"name":"name-1","option":"Bar"}]')
+  deepStrictEqual(value, '[{"name":"name-0","option":"Foo"},{"name":"name-1","option":"Bar"}]')
 })
 
-test('different arrays with same item schemas', (t) => {
-  t.plan(1)
-
+describe('different arrays with same item schemas', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -427,7 +410,7 @@ test('different arrays with same item schemas', (t) => {
   const stringify = build(schema)
   const data = { array1: ['bar'], array2: ['foo', 'bar'] }
 
-  t.equal(stringify(data), '{"array1":["bar"],"array2":["foo","bar"]}')
+  deepStrictEqual(stringify(data), '{"array1":["bar"],"array2":["foo","bar"]}')
 })
 
 const largeArray = new Array(2e4).fill({ a: 'test', b: 1 })
@@ -554,10 +537,8 @@ buildTest({
   largeArrayMechanism: 'default'
 })
 
-test('error on invalid value for largeArraySize /1', (t) => {
-  t.plan(1)
-
-  t.throws(() => build({
+describe('error on invalid value for largeArraySize /1', () => {
+  throws(() => build({
     title: 'large array of null values with default mechanism',
     type: 'object',
     properties: {
@@ -571,10 +552,8 @@ test('error on invalid value for largeArraySize /1', (t) => {
   }), Error('Unsupported large array size. Expected integer-like, got string with value invalid'))
 })
 
-test('error on invalid value for largeArraySize /2', (t) => {
-  t.plan(1)
-
-  t.throws(() => build({
+describe('error on invalid value for largeArraySize /2', () => {
+  throws(() => build({
     title: 'large array of null values with default mechanism',
     type: 'object',
     properties: {
@@ -588,10 +567,8 @@ test('error on invalid value for largeArraySize /2', (t) => {
   }), Error('Unsupported large array size. Expected integer-like, got number with value Infinity'))
 })
 
-test('error on invalid value for largeArraySize /3', (t) => {
-  t.plan(1)
-
-  t.throws(() => build({
+describe('error on invalid value for largeArraySize /3', () => {
+  throws(() => build({
     title: 'large array of null values with default mechanism',
     type: 'object',
     properties: {

--- a/test/asNumber.test.js
+++ b/test/asNumber.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 
 test('asNumber should convert BigInt', (t) => {
   t.plan(1)
@@ -9,5 +9,5 @@ test('asNumber should convert BigInt', (t) => {
 
   const number = serializer.asNumber(11753021440n)
 
-  t.equal(number, '11753021440')
+  t.assert.equal(number, '11753021440')
 })

--- a/test/asNumber.test.js
+++ b/test/asNumber.test.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { deepStrictEqual } = require('node:assert')
 
-test('asNumber should convert BigInt', (t) => {
-  t.plan(1)
+describe('asNumber should convert BigInt', () => {
   const Serializer = require('../lib/serializer')
   const serializer = new Serializer()
 
   const number = serializer.asNumber(11753021440n)
 
-  t.equal(number, '11753021440')
+  deepStrictEqual(number, '11753021440')
 })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const validator = require('is-my-json-valid')
 const build = require('..')
 
@@ -12,9 +12,9 @@ function buildTest (schema, toStringify) {
     const stringify = build(schema)
     const output = stringify(toStringify)
 
-    t.same(JSON.parse(output), toStringify)
-    t.equal(output, JSON.stringify(toStringify))
-    t.ok(validate(JSON.parse(output)), 'valid schema')
+    t.assert.deepStrictEqual(JSON.parse(output), toStringify)
+    t.assert.equal(output, JSON.stringify(toStringify))
+    t.assert.ok(validate(JSON.parse(output)), 'valid schema')
   })
 }
 
@@ -281,41 +281,34 @@ test('throw an error or coerce numbers and integers that are not numbers', (t) =
     }
   })
 
-  try {
+  t.assert.throws(() => {
     stringify({ age: 'hello  ', distance: 'long' })
-    t.fail('should throw an error')
-  } catch (err) {
-    t.ok(err)
-  }
+  }, { message: 'The value "hello  " cannot be converted to a number.' })
 
   const result = stringify({
     age: '42',
     distance: true
   })
 
-  t.same(JSON.parse(result), { age: 42, distance: 1 })
-  t.end()
+  t.assert.deepStrictEqual(JSON.parse(result), { age: 42, distance: 1 })
 })
 
 test('Should throw on invalid schema', t => {
   t.plan(1)
-  try {
+  t.assert.throws(() => {
     build({
       type: 'Dinosaur',
       properties: {
         claws: { type: 'sharp' }
       }
     })
-    t.fail('should be an invalid schema')
-  } catch (err) {
-    t.ok(err)
-  }
+  }, { message: 'schema is invalid: data/properties/claws/type must be equal to one of the allowed values' })
 })
 
 test('additionalProperties - throw on unknown type', (t) => {
   t.plan(1)
 
-  try {
+  t.assert.throws(() => {
     build({
       title: 'check array coerce',
       type: 'object',
@@ -325,15 +318,13 @@ test('additionalProperties - throw on unknown type', (t) => {
       }
     })
     t.fail('should be an invalid schema')
-  } catch (err) {
-    t.ok(err)
-  }
+  }, { message: 'schema is invalid: data/additionalProperties/type must be equal to one of the allowed values' })
 })
 
 test('patternProperties - throw on unknown type', (t) => {
   t.plan(1)
 
-  try {
+  t.assert.throws(() => {
     build({
       title: 'check array coerce',
       type: 'object',
@@ -344,10 +335,7 @@ test('patternProperties - throw on unknown type', (t) => {
         }
       }
     })
-    t.fail('should be an invalid schema')
-  } catch (err) {
-    t.ok(err)
-  }
+  }, { message: 'schema is invalid: data/patternProperties/foo/type must be equal to one of the allowed values' })
 })
 
 test('render a double quote as JSON /1', (t) => {
@@ -362,8 +350,8 @@ test('render a double quote as JSON /1', (t) => {
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, JSON.stringify(toStringify))
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('render a double quote as JSON /2', (t) => {
@@ -378,8 +366,8 @@ test('render a double quote as JSON /2', (t) => {
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, JSON.stringify(toStringify))
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('render a long string', (t) => {
@@ -394,8 +382,8 @@ test('render a long string', (t) => {
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, JSON.stringify(toStringify))
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('returns JSON.stringify if schema type is boolean', t => {
@@ -408,5 +396,5 @@ test('returns JSON.stringify if schema type is boolean', t => {
 
   const array = [1, true, 'test']
   const stringify = build(schema)
-  t.equal(stringify(array), JSON.stringify(array))
+  t.assert.equal(stringify(array), JSON.stringify(array))
 })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,20 +1,19 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { deepStrictEqual, ok, throws } = require('node:assert')
 const validator = require('is-my-json-valid')
 const build = require('..')
 
 function buildTest (schema, toStringify) {
-  test(`render a ${schema.title} as JSON`, (t) => {
-    t.plan(3)
-
+  describe(`render a ${schema.title} as JSON`, () => {
     const validate = validator(schema)
     const stringify = build(schema)
     const output = stringify(toStringify)
 
-    t.same(JSON.parse(output), toStringify)
-    t.equal(output, JSON.stringify(toStringify))
-    t.ok(validate(JSON.parse(output)), 'valid schema')
+    deepStrictEqual(JSON.parse(output), toStringify)
+    deepStrictEqual(output, JSON.stringify(toStringify))
+    ok(validate(JSON.parse(output)), 'valid schema')
   })
 }
 
@@ -267,7 +266,7 @@ buildTest({
   readonly: true
 })
 
-test('throw an error or coerce numbers and integers that are not numbers', (t) => {
+describe('throw an error or coerce numbers and integers that are not numbers', (t) => {
   const stringify = build({
     title: 'basic',
     type: 'object',
@@ -285,7 +284,7 @@ test('throw an error or coerce numbers and integers that are not numbers', (t) =
     stringify({ age: 'hello  ', distance: 'long' })
     t.fail('should throw an error')
   } catch (err) {
-    t.ok(err)
+    ok(err)
   }
 
   const result = stringify({
@@ -293,12 +292,10 @@ test('throw an error or coerce numbers and integers that are not numbers', (t) =
     distance: true
   })
 
-  t.same(JSON.parse(result), { age: 42, distance: 1 })
-  t.end()
+  deepStrictEqual(JSON.parse(result), { age: 42, distance: 1 })
 })
 
-test('Should throw on invalid schema', t => {
-  t.plan(1)
+describe('Should throw on invalid schema', t => {
   try {
     build({
       type: 'Dinosaur',
@@ -308,14 +305,12 @@ test('Should throw on invalid schema', t => {
     })
     t.fail('should be an invalid schema')
   } catch (err) {
-    t.ok(err)
+    ok(err)
   }
 })
 
-test('additionalProperties - throw on unknown type', (t) => {
-  t.plan(1)
-
-  try {
+describe('additionalProperties - throw on unknown type', () => {
+  throws(() => {
     build({
       title: 'check array coerce',
       type: 'object',
@@ -324,15 +319,10 @@ test('additionalProperties - throw on unknown type', (t) => {
         type: 'strangetype'
       }
     })
-    t.fail('should be an invalid schema')
-  } catch (err) {
-    t.ok(err)
-  }
+  }, { message: 'schema is invalid: data/additionalProperties/type must be equal to one of the allowed values' })
 })
 
-test('patternProperties - throw on unknown type', (t) => {
-  t.plan(1)
-
+describe('patternProperties - throw on unknown type', (t) => {
   try {
     build({
       title: 'check array coerce',
@@ -346,13 +336,11 @@ test('patternProperties - throw on unknown type', (t) => {
     })
     t.fail('should be an invalid schema')
   } catch (err) {
-    t.ok(err)
+    ok(err)
   }
 })
 
-test('render a double quote as JSON /1', (t) => {
-  t.plan(2)
-
+describe('render a double quote as JSON /1', () => {
   const schema = {
     type: 'string'
   }
@@ -362,13 +350,11 @@ test('render a double quote as JSON /1', (t) => {
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  deepStrictEqual(output, JSON.stringify(toStringify))
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render a double quote as JSON /2', (t) => {
-  t.plan(2)
-
+describe('render a double quote as JSON /2', () => {
   const schema = {
     type: 'string'
   }
@@ -378,13 +364,11 @@ test('render a double quote as JSON /2', (t) => {
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  deepStrictEqual(output, JSON.stringify(toStringify))
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render a long string', (t) => {
-  t.plan(2)
-
+describe('render a long string', () => {
   const schema = {
     type: 'string'
   }
@@ -394,13 +378,11 @@ test('render a long string', (t) => {
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  deepStrictEqual(output, JSON.stringify(toStringify))
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('returns JSON.stringify if schema type is boolean', t => {
-  t.plan(1)
-
+describe('returns JSON.stringify if schema type is boolean', t => {
   const schema = {
     type: 'array',
     items: true
@@ -408,5 +390,5 @@ test('returns JSON.stringify if schema type is boolean', t => {
 
   const array = [1, true, 'test']
   const stringify = build(schema)
-  t.equal(stringify(array), JSON.stringify(array))
+  deepStrictEqual(stringify(array), JSON.stringify(array))
 })

--- a/test/bigint.test.js
+++ b/test/bigint.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
+
 const build = require('..')
 
 test('render a bigint as JSON', (t) => {
@@ -15,7 +15,7 @@ test('render a bigint as JSON', (t) => {
   const stringify = build(schema)
   const output = stringify(1615n)
 
-  t.equal(output, '1615')
+  t.assert.equal(output, '1615')
 })
 
 test('render an object with a bigint as JSON', (t) => {
@@ -36,7 +36,7 @@ test('render an object with a bigint as JSON', (t) => {
     id: 1615n
   })
 
-  t.equal(output, '{"id":1615}')
+  t.assert.equal(output, '{"id":1615}')
 })
 
 test('render an array with a bigint as JSON', (t) => {
@@ -53,7 +53,7 @@ test('render an array with a bigint as JSON', (t) => {
   const stringify = build(schema)
   const output = stringify([1615n])
 
-  t.equal(output, '[1615]')
+  t.assert.equal(output, '[1615]')
 })
 
 test('render an object with an additionalProperty of type bigint as JSON', (t) => {
@@ -72,5 +72,5 @@ test('render an object with an additionalProperty of type bigint as JSON', (t) =
     num: 1615n
   })
 
-  t.equal(output, '{"num":1615}')
+  t.assert.equal(output, '{"num":1615}')
 })

--- a/test/bigint.test.js
+++ b/test/bigint.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { describe } = require('node:test')
+const { equal } = require('node:assert')
 const build = require('..')
 
-test('render a bigint as JSON', (t) => {
-  t.plan(1)
-
+describe('render a bigint as JSON', () => {
   const schema = {
     title: 'bigint',
     type: 'integer'
@@ -15,12 +13,10 @@ test('render a bigint as JSON', (t) => {
   const stringify = build(schema)
   const output = stringify(1615n)
 
-  t.equal(output, '1615')
+  equal(output, '1615')
 })
 
-test('render an object with a bigint as JSON', (t) => {
-  t.plan(1)
-
+describe('render an object with a bigint as JSON', () => {
   const schema = {
     title: 'object with bigint',
     type: 'object',
@@ -36,12 +32,10 @@ test('render an object with a bigint as JSON', (t) => {
     id: 1615n
   })
 
-  t.equal(output, '{"id":1615}')
+  equal(output, '{"id":1615}')
 })
 
-test('render an array with a bigint as JSON', (t) => {
-  t.plan(1)
-
+describe('render an array with a bigint as JSON', () => {
   const schema = {
     title: 'array with bigint',
     type: 'array',
@@ -53,12 +47,10 @@ test('render an array with a bigint as JSON', (t) => {
   const stringify = build(schema)
   const output = stringify([1615n])
 
-  t.equal(output, '[1615]')
+  equal(output, '[1615]')
 })
 
-test('render an object with an additionalProperty of type bigint as JSON', (t) => {
-  t.plan(1)
-
+describe('render an object with an additionalProperty of type bigint as JSON', () => {
   const schema = {
     title: 'object with bigint',
     type: 'object',
@@ -72,5 +64,5 @@ test('render an object with an additionalProperty of type bigint as JSON', (t) =
     num: 1615n
   })
 
-  t.equal(output, '{"num":1615}')
+  equal(output, '{"num":1615}')
 })

--- a/test/clean-cache.test.js
+++ b/test/clean-cache.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('Should clean the cache', (t) => {
@@ -11,9 +11,10 @@ test('Should clean the cache', (t) => {
     type: 'string'
   }
 
-  build(schema)
-  build(schema)
-  t.pass()
+  t.assert.doesNotThrow(() => {
+    build(schema)
+    build(schema)
+  })
 })
 
 test('Should clean the cache with external schemas', (t) => {
@@ -39,7 +40,8 @@ test('Should clean the cache with external schemas', (t) => {
     }
   }
 
-  build(schema)
-  build(schema)
-  t.pass()
+  t.assert.doesNotThrow(() => {
+    build(schema)
+    build(schema)
+  })
 })

--- a/test/clean-cache.test.js
+++ b/test/clean-cache.test.js
@@ -1,24 +1,20 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { doesNotThrow } = require('node:assert')
 const build = require('..')
 
-test('Should clean the cache', (t) => {
-  t.plan(1)
-
+describe('Should clean the cache', () => {
   const schema = {
     $id: 'test',
     type: 'string'
   }
 
-  build(schema)
-  build(schema)
-  t.pass()
+  doesNotThrow(() => build(schema))
+  doesNotThrow(() => build(schema))
 })
 
-test('Should clean the cache with external schemas', (t) => {
-  t.plan(1)
-
+describe('Should clean the cache with external schemas', () => {
   const schema = {
     $id: 'test',
     definitions: {
@@ -39,7 +35,6 @@ test('Should clean the cache with external schemas', (t) => {
     }
   }
 
-  build(schema)
-  build(schema)
-  t.pass()
+  doesNotThrow(() => build(schema))
+  doesNotThrow(() => build(schema))
 })

--- a/test/const.test.js
+++ b/test/const.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const validator = require('is-my-json-valid')
 const build = require('..')
 
@@ -20,8 +20,8 @@ test('schema with const string', (t) => {
     foo: 'bar'
   })
 
-  t.equal(output, '{"foo":"bar"}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{"foo":"bar"}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('schema with const string and different input', (t) => {
@@ -40,8 +40,8 @@ test('schema with const string and different input', (t) => {
     foo: 'baz'
   })
 
-  t.equal(output, '{"foo":"bar"}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{"foo":"bar"}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('schema with const string and different type input', (t) => {
@@ -60,8 +60,8 @@ test('schema with const string and different type input', (t) => {
     foo: 1
   })
 
-  t.equal(output, '{"foo":"bar"}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{"foo":"bar"}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('schema with const string and no input', (t) => {
@@ -78,8 +78,8 @@ test('schema with const string and no input', (t) => {
   const stringify = build(schema)
   const output = stringify({})
 
-  t.equal(output, '{}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('schema with const string that contains \'', (t) => {
@@ -98,8 +98,8 @@ test('schema with const string that contains \'', (t) => {
     foo: "'bar'"
   })
 
-  t.equal(output, '{"foo":"\'bar\'"}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{"foo":"\'bar\'"}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('schema with const number', (t) => {
@@ -118,8 +118,8 @@ test('schema with const number', (t) => {
     foo: 1
   })
 
-  t.equal(output, '{"foo":1}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{"foo":1}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('schema with const number and different input', (t) => {
@@ -138,8 +138,8 @@ test('schema with const number and different input', (t) => {
     foo: 2
   })
 
-  t.equal(output, '{"foo":1}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{"foo":1}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('schema with const bool', (t) => {
@@ -158,8 +158,8 @@ test('schema with const bool', (t) => {
     foo: true
   })
 
-  t.equal(output, '{"foo":true}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{"foo":true}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('schema with const number', (t) => {
@@ -178,8 +178,8 @@ test('schema with const number', (t) => {
     foo: 1
   })
 
-  t.equal(output, '{"foo":1}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{"foo":1}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('schema with const null', (t) => {
@@ -198,8 +198,8 @@ test('schema with const null', (t) => {
     foo: null
   })
 
-  t.equal(output, '{"foo":null}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{"foo":null}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('schema with const array', (t) => {
@@ -218,8 +218,8 @@ test('schema with const array', (t) => {
     foo: [1, 2, 3]
   })
 
-  t.equal(output, '{"foo":[1,2,3]}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{"foo":[1,2,3]}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('schema with const object', (t) => {
@@ -238,8 +238,8 @@ test('schema with const object', (t) => {
     foo: { bar: 'baz' }
   })
 
-  t.equal(output, '{"foo":{"bar":"baz"}}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{"foo":{"bar":"baz"}}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('schema with const and null as type', (t) => {
@@ -258,12 +258,12 @@ test('schema with const and null as type', (t) => {
     foo: null
   })
 
-  t.equal(output, '{"foo":null}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{"foo":null}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 
   const output2 = stringify({ foo: 'baz' })
-  t.equal(output2, '{"foo":"baz"}')
-  t.ok(validate(JSON.parse(output2)), 'valid schema')
+  t.assert.equal(output2, '{"foo":"baz"}')
+  t.assert.ok(validate(JSON.parse(output2)), 'valid schema')
 })
 
 test('schema with const as nullable', (t) => {
@@ -282,14 +282,14 @@ test('schema with const as nullable', (t) => {
     foo: null
   })
 
-  t.equal(output, '{"foo":null}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{"foo":null}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 
   const output2 = stringify({
     foo: 'baz'
   })
-  t.equal(output2, '{"foo":"baz"}')
-  t.ok(validate(JSON.parse(output2)), 'valid schema')
+  t.assert.equal(output2, '{"foo":"baz"}')
+  t.assert.ok(validate(JSON.parse(output2)), 'valid schema')
 })
 
 test('schema with const and invalid object', (t) => {
@@ -309,6 +309,6 @@ test('schema with const and invalid object', (t) => {
     foo: { foo: 'baz' }
   })
 
-  t.equal(result, '{"foo":{"foo":"bar"}}')
-  t.ok(validate(JSON.parse(result)), 'valid schema')
+  t.assert.equal(result, '{"foo":{"foo":"bar"}}')
+  t.assert.ok(validate(JSON.parse(result)), 'valid schema')
 })

--- a/test/const.test.js
+++ b/test/const.test.js
@@ -1,12 +1,11 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { ok, equal } = require('node:assert')
 const validator = require('is-my-json-valid')
 const build = require('..')
 
-test('schema with const string', (t) => {
-  t.plan(2)
-
+describe('schema with const string', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -20,13 +19,11 @@ test('schema with const string', (t) => {
     foo: 'bar'
   })
 
-  t.equal(output, '{"foo":"bar"}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{"foo":"bar"}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const string and different input', (t) => {
-  t.plan(2)
-
+describe('schema with const string and different input', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -40,13 +37,11 @@ test('schema with const string and different input', (t) => {
     foo: 'baz'
   })
 
-  t.equal(output, '{"foo":"bar"}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{"foo":"bar"}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const string and different type input', (t) => {
-  t.plan(2)
-
+describe('schema with const string and different type input', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -60,13 +55,11 @@ test('schema with const string and different type input', (t) => {
     foo: 1
   })
 
-  t.equal(output, '{"foo":"bar"}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{"foo":"bar"}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const string and no input', (t) => {
-  t.plan(2)
-
+describe('schema with const string and no input', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -78,13 +71,11 @@ test('schema with const string and no input', (t) => {
   const stringify = build(schema)
   const output = stringify({})
 
-  t.equal(output, '{}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const string that contains \'', (t) => {
-  t.plan(2)
-
+describe('schema with const string that contains \'', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -98,13 +89,11 @@ test('schema with const string that contains \'', (t) => {
     foo: "'bar'"
   })
 
-  t.equal(output, '{"foo":"\'bar\'"}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{"foo":"\'bar\'"}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const number', (t) => {
-  t.plan(2)
-
+describe('schema with const number', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -118,13 +107,11 @@ test('schema with const number', (t) => {
     foo: 1
   })
 
-  t.equal(output, '{"foo":1}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{"foo":1}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const number and different input', (t) => {
-  t.plan(2)
-
+describe('schema with const number and different input', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -138,13 +125,11 @@ test('schema with const number and different input', (t) => {
     foo: 2
   })
 
-  t.equal(output, '{"foo":1}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{"foo":1}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const bool', (t) => {
-  t.plan(2)
-
+describe('schema with const bool', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -158,13 +143,11 @@ test('schema with const bool', (t) => {
     foo: true
   })
 
-  t.equal(output, '{"foo":true}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{"foo":true}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const number', (t) => {
-  t.plan(2)
-
+describe('schema with const number', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -178,13 +161,11 @@ test('schema with const number', (t) => {
     foo: 1
   })
 
-  t.equal(output, '{"foo":1}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{"foo":1}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const null', (t) => {
-  t.plan(2)
-
+describe('schema with const null', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -198,13 +179,11 @@ test('schema with const null', (t) => {
     foo: null
   })
 
-  t.equal(output, '{"foo":null}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{"foo":null}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const array', (t) => {
-  t.plan(2)
-
+describe('schema with const array', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -218,13 +197,11 @@ test('schema with const array', (t) => {
     foo: [1, 2, 3]
   })
 
-  t.equal(output, '{"foo":[1,2,3]}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{"foo":[1,2,3]}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const object', (t) => {
-  t.plan(2)
-
+describe('schema with const object', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -238,13 +215,11 @@ test('schema with const object', (t) => {
     foo: { bar: 'baz' }
   })
 
-  t.equal(output, '{"foo":{"bar":"baz"}}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{"foo":{"bar":"baz"}}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('schema with const and null as type', (t) => {
-  t.plan(4)
-
+describe('schema with const and null as type', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -258,17 +233,15 @@ test('schema with const and null as type', (t) => {
     foo: null
   })
 
-  t.equal(output, '{"foo":null}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{"foo":null}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 
   const output2 = stringify({ foo: 'baz' })
-  t.equal(output2, '{"foo":"baz"}')
-  t.ok(validate(JSON.parse(output2)), 'valid schema')
+  equal(output2, '{"foo":"baz"}')
+  ok(validate(JSON.parse(output2)), 'valid schema')
 })
 
-test('schema with const as nullable', (t) => {
-  t.plan(4)
-
+describe('schema with const as nullable', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -282,19 +255,17 @@ test('schema with const as nullable', (t) => {
     foo: null
   })
 
-  t.equal(output, '{"foo":null}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{"foo":null}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 
   const output2 = stringify({
     foo: 'baz'
   })
-  t.equal(output2, '{"foo":"baz"}')
-  t.ok(validate(JSON.parse(output2)), 'valid schema')
+  equal(output2, '{"foo":"baz"}')
+  ok(validate(JSON.parse(output2)), 'valid schema')
 })
 
-test('schema with const and invalid object', (t) => {
-  t.plan(2)
-
+describe('schema with const and invalid object', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -309,6 +280,6 @@ test('schema with const and invalid object', (t) => {
     foo: { foo: 'baz' }
   })
 
-  t.equal(result, '{"foo":{"foo":"bar"}}')
-  t.ok(validate(JSON.parse(result)), 'valid schema')
+  equal(result, '{"foo":{"foo":"bar"}}')
+  ok(validate(JSON.parse(result)), 'valid schema')
 })

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const validator = require('is-my-json-valid')
 const build = require('..')
 
@@ -19,8 +19,8 @@ test('render a date in a string as JSON', (t) => {
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, JSON.stringify(toStringify))
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('render a date in a string when format is date-format as ISOString', (t) => {
@@ -37,8 +37,8 @@ test('render a date in a string when format is date-format as ISOString', (t) =>
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, JSON.stringify(toStringify))
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('render a nullable date in a string when format is date-format as ISOString', (t) => {
@@ -56,8 +56,8 @@ test('render a nullable date in a string when format is date-format as ISOString
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, JSON.stringify(toStringify))
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('render a date in a string when format is date as YYYY-MM-DD', (t) => {
@@ -74,8 +74,8 @@ test('render a date in a string when format is date as YYYY-MM-DD', (t) => {
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, '"2023-01-21"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '"2023-01-21"')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('render a nullable date in a string when format is date as YYYY-MM-DD', (t) => {
@@ -93,8 +93,8 @@ test('render a nullable date in a string when format is date as YYYY-MM-DD', (t)
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, '"2023-01-21"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '"2023-01-21"')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('verify padding for rendered date in a string when format is date', (t) => {
@@ -111,8 +111,8 @@ test('verify padding for rendered date in a string when format is date', (t) => 
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, '"2020-01-01"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '"2020-01-01"')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('render a date in a string when format is time as kk:mm:ss', (t) => {
@@ -130,10 +130,10 @@ test('render a date in a string when format is time as kk:mm:ss', (t) => {
   const output = stringify(toStringify)
 
   validate(JSON.parse(output))
-  t.equal(validate.errors, null)
+  t.assert.equal(validate.errors, null)
 
-  t.equal(output, '"01:03:25"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '"01:03:25"')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('render a nullable date in a string when format is time as kk:mm:ss', (t) => {
@@ -152,10 +152,10 @@ test('render a nullable date in a string when format is time as kk:mm:ss', (t) =
   const output = stringify(toStringify)
 
   validate(JSON.parse(output))
-  t.equal(validate.errors, null)
+  t.assert.equal(validate.errors, null)
 
-  t.equal(output, '"01:03:25"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '"01:03:25"')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('render a midnight time', (t) => {
@@ -173,10 +173,10 @@ test('render a midnight time', (t) => {
   const output = stringify(midnight)
 
   validate(JSON.parse(output))
-  t.equal(validate.errors, null)
+  t.assert.equal(validate.errors, null)
 
-  t.equal(output, '"00:03:25"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '"00:03:25"')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('verify padding for rendered date in a string when format is time', (t) => {
@@ -194,10 +194,10 @@ test('verify padding for rendered date in a string when format is time', (t) => 
   const output = stringify(toStringify)
 
   validate(JSON.parse(output))
-  t.equal(validate.errors, null)
+  t.assert.equal(validate.errors, null)
 
-  t.equal(output, '"01:01:01"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '"01:01:01"')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('render a nested object in a string when type is date-format as ISOString', (t) => {
@@ -219,11 +219,11 @@ test('render a nested object in a string when type is date-format as ISOString',
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, JSON.stringify(toStringify))
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('serializing null value', t => {
+test('serializing null value', async t => {
   const input = { updatedAt: null }
 
   function createSchema (properties) {
@@ -247,10 +247,10 @@ test('serializing null value', t => {
 
   t.plan(3)
 
-  t.test('type::string', t => {
+  await t.test('type::string', async t => {
     t.plan(3)
 
-    t.test('format::date-time', t => {
+    await t.test('format::date-time', t => {
       t.plan(2)
 
       const prop = {
@@ -265,11 +265,11 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a date-time format')
+      t.assert.equal(output, '{"updatedAt":""}')
+      t.assert.equal(validate(JSON.parse(output)), false, 'an empty string is not a date-time format')
     })
 
-    t.test('format::date', t => {
+    await t.test('format::date', t => {
       t.plan(2)
 
       const prop = {
@@ -284,11 +284,11 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a date format')
+      t.assert.equal(output, '{"updatedAt":""}')
+      t.assert.equal(validate(JSON.parse(output)), false, 'an empty string is not a date format')
     })
 
-    t.test('format::time', t => {
+    await t.test('format::time', t => {
       t.plan(2)
 
       const prop = {
@@ -303,15 +303,15 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a time format')
+      t.assert.equal(output, '{"updatedAt":""}')
+      t.assert.equal(validate(JSON.parse(output)), false, 'an empty string is not a time format')
     })
   })
 
-  t.test('type::array', t => {
+  await t.test('type::array', async t => {
     t.plan(6)
 
-    t.test('format::date-time', t => {
+    await t.test('format::date-time', t => {
       t.plan(2)
 
       const prop = {
@@ -326,11 +326,11 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a date-time format')
+      t.assert.equal(output, '{"updatedAt":""}')
+      t.assert.equal(validate(JSON.parse(output)), false, 'an empty string is not a date-time format')
     })
 
-    t.test('format::date', t => {
+    await t.test('format::date', t => {
       t.plan(2)
 
       const prop = {
@@ -345,11 +345,11 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a date format')
+      t.assert.equal(output, '{"updatedAt":""}')
+      t.assert.equal(validate(JSON.parse(output)), false, 'an empty string is not a date format')
     })
 
-    t.test('format::date', t => {
+    await t.test('format::date', t => {
       t.plan(2)
 
       const prop = {
@@ -364,11 +364,11 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a date format')
+      t.assert.equal(output, '{"updatedAt":""}')
+      t.assert.equal(validate(JSON.parse(output)), false, 'an empty string is not a date format')
     })
 
-    t.test('format::time, Date object', t => {
+    await t.test('format::time, Date object', t => {
       t.plan(1)
 
       const schema = {
@@ -389,10 +389,10 @@ test('serializing null value', t => {
       const input = { updatedAt: date }
       const { output } = serialize(schema, input)
 
-      t.equal(output, JSON.stringify({ updatedAt: '01:03:25' }))
+      t.assert.equal(output, JSON.stringify({ updatedAt: '01:03:25' }))
     })
 
-    t.test('format::time, Date object', t => {
+    await t.test('format::time, Date object', t => {
       t.plan(1)
 
       const schema = {
@@ -407,10 +407,10 @@ test('serializing null value', t => {
       const date = new Date(1674263005800)
       const { output } = serialize(schema, date)
 
-      t.equal(output, '"01:03:25"')
+      t.assert.equal(output, '"01:03:25"')
     })
 
-    t.test('format::time, Date object', t => {
+    await t.test('format::time, Date object', t => {
       t.plan(1)
 
       const schema = {
@@ -424,14 +424,14 @@ test('serializing null value', t => {
 
       const { output } = serialize(schema, 42)
 
-      t.equal(output, JSON.stringify(42))
+      t.assert.equal(output, JSON.stringify(42))
     })
   })
 
-  t.test('type::array::nullable', t => {
+  await t.test('type::array::nullable', async t => {
     t.plan(3)
 
-    t.test('format::date-time', t => {
+    await t.test('format::date-time', t => {
       t.plan(2)
 
       const prop = {
@@ -446,11 +446,11 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":null}')
-      t.ok(validate(JSON.parse(output)), 'valid schema')
+      t.assert.equal(output, '{"updatedAt":null}')
+      t.assert.ok(validate(JSON.parse(output)), 'valid schema')
     })
 
-    t.test('format::date', t => {
+    await t.test('format::date', t => {
       t.plan(2)
 
       const prop = {
@@ -465,11 +465,11 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":null}')
-      t.ok(validate(JSON.parse(output)), 'valid schema')
+      t.assert.equal(output, '{"updatedAt":null}')
+      t.assert.ok(validate(JSON.parse(output)), 'valid schema')
     })
 
-    t.test('format::time', t => {
+    await t.test('format::time', t => {
       t.plan(2)
 
       const prop = {
@@ -484,8 +484,8 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":null}')
-      t.ok(validate(JSON.parse(output)), 'valid schema')
+      t.assert.equal(output, '{"updatedAt":null}')
+      t.assert.ok(validate(JSON.parse(output)), 'valid schema')
     })
   })
 })
@@ -503,7 +503,7 @@ test('Validate Date object as string type', (t) => {
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
+  t.assert.equal(output, JSON.stringify(toStringify))
 })
 
 test('nullable date', (t) => {
@@ -524,7 +524,7 @@ test('nullable date', (t) => {
   const data = new Date(1674263005800)
   const result = stringify(data)
 
-  t.same(result, '"2023-01-21"')
+  t.assert.equal(result, '"2023-01-21"')
 })
 
 test('non-date format should not affect data serialization (issue #491)', (t) => {
@@ -543,7 +543,7 @@ test('non-date format should not affect data serialization (issue #491)', (t) =>
 
   const stringify = build(schema)
   const data = { hello: 123n }
-  t.equal(stringify(data), '{"hello":"123"}')
+  t.assert.equal(stringify(data), '{"hello":"123"}')
 })
 
 test('should serialize also an invalid string value, even if it is not a valid date', (t) => {
@@ -561,8 +561,8 @@ test('should serialize also an invalid string value, even if it is not a valid d
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.not(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, JSON.stringify(toStringify))
+  t.assert.equal(validate(JSON.parse(output)), false, 'valid schema')
 })
 
 test('should throw an error if value can not be transformed to date-time', (t) => {
@@ -579,8 +579,8 @@ test('should throw an error if value can not be transformed to date-time', (t) =
   const validate = validator(schema)
   const stringify = build(schema)
 
-  t.throws(() => stringify(toStringify), new Error('The value "true" cannot be converted to a date-time.'))
-  t.not(validate(toStringify))
+  t.assert.throws(() => stringify(toStringify), new Error('The value "true" cannot be converted to a date-time.'))
+  t.assert.equal(validate(toStringify), false)
 })
 
 test('should throw an error if value can not be transformed to date', (t) => {
@@ -597,8 +597,8 @@ test('should throw an error if value can not be transformed to date', (t) => {
   const validate = validator(schema)
   const stringify = build(schema)
 
-  t.throws(() => stringify(toStringify), new Error('The value "true" cannot be converted to a date.'))
-  t.not(validate(toStringify))
+  t.assert.throws(() => stringify(toStringify), new Error('The value "true" cannot be converted to a date.'))
+  t.assert.equal(validate(toStringify), false)
 })
 
 test('should throw an error if value can not be transformed to time', (t) => {
@@ -615,8 +615,8 @@ test('should throw an error if value can not be transformed to time', (t) => {
   const validate = validator(schema)
   const stringify = build(schema)
 
-  t.throws(() => stringify(toStringify), new Error('The value "true" cannot be converted to a time.'))
-  t.not(validate(toStringify))
+  t.assert.throws(() => stringify(toStringify), new Error('The value "true" cannot be converted to a time.'))
+  t.assert.equal(validate(toStringify), false)
 })
 
 test('should serialize also an invalid string value, even if it is not a valid time', (t) => {
@@ -634,6 +634,6 @@ test('should serialize also an invalid string value, even if it is not a valid t
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.not(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, JSON.stringify(toStringify))
+  t.assert.equal(validate(JSON.parse(output)), false, 'valid schema')
 })

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -1,14 +1,13 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { equal, ok, throws } = require('node:assert')
 const validator = require('is-my-json-valid')
 const build = require('..')
 
 process.env.TZ = 'UTC'
 
-test('render a date in a string as JSON', (t) => {
-  t.plan(2)
-
+describe('render a date in a string as JSON', () => {
   const schema = {
     title: 'a date in a string',
     type: 'string'
@@ -19,13 +18,11 @@ test('render a date in a string as JSON', (t) => {
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, JSON.stringify(toStringify))
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render a date in a string when format is date-format as ISOString', (t) => {
-  t.plan(2)
-
+describe('render a date in a string when format is date-format as ISOString', () => {
   const schema = {
     title: 'a date in a string',
     type: 'string',
@@ -37,13 +34,11 @@ test('render a date in a string when format is date-format as ISOString', (t) =>
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, JSON.stringify(toStringify))
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render a nullable date in a string when format is date-format as ISOString', (t) => {
-  t.plan(2)
-
+describe('render a nullable date in a string when format is date-format as ISOString', () => {
   const schema = {
     title: 'a date in a string',
     type: 'string',
@@ -56,13 +51,11 @@ test('render a nullable date in a string when format is date-format as ISOString
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, JSON.stringify(toStringify))
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render a date in a string when format is date as YYYY-MM-DD', (t) => {
-  t.plan(2)
-
+describe('render a date in a string when format is date as YYYY-MM-DD', () => {
   const schema = {
     title: 'a date in a string',
     type: 'string',
@@ -74,13 +67,11 @@ test('render a date in a string when format is date as YYYY-MM-DD', (t) => {
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, '"2023-01-21"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '"2023-01-21"')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render a nullable date in a string when format is date as YYYY-MM-DD', (t) => {
-  t.plan(2)
-
+describe('render a nullable date in a string when format is date as YYYY-MM-DD', () => {
   const schema = {
     title: 'a date in a string',
     type: 'string',
@@ -93,13 +84,11 @@ test('render a nullable date in a string when format is date as YYYY-MM-DD', (t)
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, '"2023-01-21"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '"2023-01-21"')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('verify padding for rendered date in a string when format is date', (t) => {
-  t.plan(2)
-
+describe('verify padding for rendered date in a string when format is date', () => {
   const schema = {
     title: 'a date in a string',
     type: 'string',
@@ -111,13 +100,11 @@ test('verify padding for rendered date in a string when format is date', (t) => 
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, '"2020-01-01"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '"2020-01-01"')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render a date in a string when format is time as kk:mm:ss', (t) => {
-  t.plan(3)
-
+describe('render a date in a string when format is time as kk:mm:ss', () => {
   const schema = {
     title: 'a date in a string',
     type: 'string',
@@ -130,15 +117,13 @@ test('render a date in a string when format is time as kk:mm:ss', (t) => {
   const output = stringify(toStringify)
 
   validate(JSON.parse(output))
-  t.equal(validate.errors, null)
+  equal(validate.errors, null)
 
-  t.equal(output, '"01:03:25"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '"01:03:25"')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render a nullable date in a string when format is time as kk:mm:ss', (t) => {
-  t.plan(3)
-
+describe('render a nullable date in a string when format is time as kk:mm:ss', () => {
   const schema = {
     title: 'a date in a string',
     type: 'string',
@@ -152,15 +137,13 @@ test('render a nullable date in a string when format is time as kk:mm:ss', (t) =
   const output = stringify(toStringify)
 
   validate(JSON.parse(output))
-  t.equal(validate.errors, null)
+  equal(validate.errors, null)
 
-  t.equal(output, '"01:03:25"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '"01:03:25"')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render a midnight time', (t) => {
-  t.plan(3)
-
+describe('render a midnight time', () => {
   const schema = {
     title: 'a date in a string',
     type: 'string',
@@ -173,15 +156,13 @@ test('render a midnight time', (t) => {
   const output = stringify(midnight)
 
   validate(JSON.parse(output))
-  t.equal(validate.errors, null)
+  equal(validate.errors, null)
 
-  t.equal(output, '"00:03:25"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '"00:03:25"')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('verify padding for rendered date in a string when format is time', (t) => {
-  t.plan(3)
-
+describe('verify padding for rendered date in a string when format is time', () => {
   const schema = {
     title: 'a date in a string',
     type: 'string',
@@ -194,15 +175,13 @@ test('verify padding for rendered date in a string when format is time', (t) => 
   const output = stringify(toStringify)
 
   validate(JSON.parse(output))
-  t.equal(validate.errors, null)
+  equal(validate.errors, null)
 
-  t.equal(output, '"01:01:01"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '"01:01:01"')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render a nested object in a string when type is date-format as ISOString', (t) => {
-  t.plan(2)
-
+describe('render a nested object in a string when type is date-format as ISOString', () => {
   const schema = {
     title: 'an object in a string',
     type: 'object',
@@ -219,11 +198,11 @@ test('render a nested object in a string when type is date-format as ISOString',
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, JSON.stringify(toStringify))
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('serializing null value', t => {
+describe('serializing null value', t => {
   const input = { updatedAt: null }
 
   function createSchema (properties) {
@@ -245,14 +224,8 @@ test('serializing null value', t => {
     }
   }
 
-  t.plan(3)
-
-  t.test('type::string', t => {
-    t.plan(3)
-
-    t.test('format::date-time', t => {
-      t.plan(2)
-
+  describe('type::string', t => {
+    describe('format::date-time', t => {
       const prop = {
         updatedAt: {
           type: 'string',
@@ -265,13 +238,11 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a date-time format')
+      equal(output, '{"updatedAt":""}')
+      equal(validate(JSON.parse(output)), false, 'an empty string is not a date-time format')
     })
 
-    t.test('format::date', t => {
-      t.plan(2)
-
+    describe('format::date', t => {
       const prop = {
         updatedAt: {
           type: 'string',
@@ -284,13 +255,11 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a date format')
+      equal(output, '{"updatedAt":""}')
+      equal(validate(JSON.parse(output)), false, 'an empty string is not a date format')
     })
 
-    t.test('format::time', t => {
-      t.plan(2)
-
+    describe('format::time', t => {
       const prop = {
         updatedAt: {
           type: 'string',
@@ -303,17 +272,13 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a time format')
+      equal(output, '{"updatedAt":""}')
+      equal(validate(JSON.parse(output)), false, 'an empty string is not a time format')
     })
   })
 
-  t.test('type::array', t => {
-    t.plan(6)
-
-    t.test('format::date-time', t => {
-      t.plan(2)
-
+  describe('type::array', t => {
+    describe('format::date-time', t => {
       const prop = {
         updatedAt: {
           type: ['string'],
@@ -326,13 +291,11 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a date-time format')
+      equal(output, '{"updatedAt":""}')
+      equal(validate(JSON.parse(output)), false, 'an empty string is not a date-time format')
     })
 
-    t.test('format::date', t => {
-      t.plan(2)
-
+    describe('format::date', t => {
       const prop = {
         updatedAt: {
           type: ['string'],
@@ -345,13 +308,11 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a date format')
+      equal(output, '{"updatedAt":""}')
+      equal(validate(JSON.parse(output)), false, 'an empty string is not a date format')
     })
 
-    t.test('format::date', t => {
-      t.plan(2)
-
+    describe('format::date', t => {
       const prop = {
         updatedAt: {
           type: ['string'],
@@ -364,13 +325,11 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":""}')
-      t.notOk(validate(JSON.parse(output)), 'an empty string is not a date format')
+      equal(output, '{"updatedAt":""}')
+      equal(validate(JSON.parse(output)), false, 'an empty string is not a date format')
     })
 
-    t.test('format::time, Date object', t => {
-      t.plan(1)
-
+    describe('format::time, Date object', t => {
       const schema = {
         oneOf: [
           {
@@ -389,12 +348,10 @@ test('serializing null value', t => {
       const input = { updatedAt: date }
       const { output } = serialize(schema, input)
 
-      t.equal(output, JSON.stringify({ updatedAt: '01:03:25' }))
+      equal(output, JSON.stringify({ updatedAt: '01:03:25' }))
     })
 
-    t.test('format::time, Date object', t => {
-      t.plan(1)
-
+    describe('format::time, Date object', t => {
       const schema = {
         oneOf: [
           {
@@ -407,12 +364,10 @@ test('serializing null value', t => {
       const date = new Date(1674263005800)
       const { output } = serialize(schema, date)
 
-      t.equal(output, '"01:03:25"')
+      equal(output, '"01:03:25"')
     })
 
-    t.test('format::time, Date object', t => {
-      t.plan(1)
-
+    describe('format::time, Date object', t => {
       const schema = {
         oneOf: [
           {
@@ -424,16 +379,12 @@ test('serializing null value', t => {
 
       const { output } = serialize(schema, 42)
 
-      t.equal(output, JSON.stringify(42))
+      equal(output, JSON.stringify(42))
     })
   })
 
-  t.test('type::array::nullable', t => {
-    t.plan(3)
-
-    t.test('format::date-time', t => {
-      t.plan(2)
-
+  describe('type::array::nullable', t => {
+    describe('format::date-time', t => {
       const prop = {
         updatedAt: {
           type: ['string', 'null'],
@@ -446,13 +397,11 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":null}')
-      t.ok(validate(JSON.parse(output)), 'valid schema')
+      equal(output, '{"updatedAt":null}')
+      ok(validate(JSON.parse(output)), 'valid schema')
     })
 
-    t.test('format::date', t => {
-      t.plan(2)
-
+    describe('format::date', t => {
       const prop = {
         updatedAt: {
           type: ['string', 'null'],
@@ -465,13 +414,11 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":null}')
-      t.ok(validate(JSON.parse(output)), 'valid schema')
+      equal(output, '{"updatedAt":null}')
+      ok(validate(JSON.parse(output)), 'valid schema')
     })
 
-    t.test('format::time', t => {
-      t.plan(2)
-
+    describe('format::time', t => {
       const prop = {
         updatedAt: {
           type: ['string', 'null'],
@@ -484,15 +431,13 @@ test('serializing null value', t => {
         validate
       } = serialize(createSchema(prop), input)
 
-      t.equal(output, '{"updatedAt":null}')
-      t.ok(validate(JSON.parse(output)), 'valid schema')
+      equal(output, '{"updatedAt":null}')
+      ok(validate(JSON.parse(output)), 'valid schema')
     })
   })
 })
 
-test('Validate Date object as string type', (t) => {
-  t.plan(1)
-
+describe('Validate Date object as string type', () => {
   const schema = {
     oneOf: [
       { type: 'string' }
@@ -503,12 +448,10 @@ test('Validate Date object as string type', (t) => {
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
+  equal(output, JSON.stringify(toStringify))
 })
 
-test('nullable date', (t) => {
-  t.plan(1)
-
+describe('nullable date', () => {
   const schema = {
     anyOf: [
       {
@@ -524,12 +467,10 @@ test('nullable date', (t) => {
   const data = new Date(1674263005800)
   const result = stringify(data)
 
-  t.same(result, '"2023-01-21"')
+  equal(result, '"2023-01-21"')
 })
 
-test('non-date format should not affect data serialization (issue #491)', (t) => {
-  t.plan(1)
-
+describe('non-date format should not affect data serialization (issue #491)', () => {
   const schema = {
     type: 'object',
     properties: {
@@ -543,12 +484,10 @@ test('non-date format should not affect data serialization (issue #491)', (t) =>
 
   const stringify = build(schema)
   const data = { hello: 123n }
-  t.equal(stringify(data), '{"hello":"123"}')
+  equal(stringify(data), '{"hello":"123"}')
 })
 
-test('should serialize also an invalid string value, even if it is not a valid date', (t) => {
-  t.plan(2)
-
+describe('should serialize also an invalid string value, even if it is not a valid date', () => {
   const schema = {
     title: 'a date in a string',
     type: 'string',
@@ -561,13 +500,11 @@ test('should serialize also an invalid string value, even if it is not a valid d
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.not(validate(JSON.parse(output)), 'valid schema')
+  equal(output, JSON.stringify(toStringify))
+  equal(validate(JSON.parse(output)), false, 'valid schema')
 })
 
-test('should throw an error if value can not be transformed to date-time', (t) => {
-  t.plan(2)
-
+describe('should throw an error if value can not be transformed to date-time', () => {
   const schema = {
     title: 'a date in a string',
     type: 'string',
@@ -579,13 +516,11 @@ test('should throw an error if value can not be transformed to date-time', (t) =
   const validate = validator(schema)
   const stringify = build(schema)
 
-  t.throws(() => stringify(toStringify), new Error('The value "true" cannot be converted to a date-time.'))
-  t.not(validate(toStringify))
+  throws(() => stringify(toStringify), new Error('The value "true" cannot be converted to a date-time.'))
+  equal(validate(toStringify), false)
 })
 
-test('should throw an error if value can not be transformed to date', (t) => {
-  t.plan(2)
-
+describe('should throw an error if value can not be transformed to date', () => {
   const schema = {
     title: 'a date in a string',
     type: 'string',
@@ -597,13 +532,11 @@ test('should throw an error if value can not be transformed to date', (t) => {
   const validate = validator(schema)
   const stringify = build(schema)
 
-  t.throws(() => stringify(toStringify), new Error('The value "true" cannot be converted to a date.'))
-  t.not(validate(toStringify))
+  throws(() => stringify(toStringify), new Error('The value "true" cannot be converted to a date.'))
+  equal(validate(toStringify), false)
 })
 
-test('should throw an error if value can not be transformed to time', (t) => {
-  t.plan(2)
-
+describe('should throw an error if value can not be transformed to time', () => {
   const schema = {
     title: 'a time in a string',
     type: 'string',
@@ -615,13 +548,11 @@ test('should throw an error if value can not be transformed to time', (t) => {
   const validate = validator(schema)
   const stringify = build(schema)
 
-  t.throws(() => stringify(toStringify), new Error('The value "true" cannot be converted to a time.'))
-  t.not(validate(toStringify))
+  throws(() => stringify(toStringify), new Error('The value "true" cannot be converted to a time.'))
+  equal(validate(toStringify), false)
 })
 
-test('should serialize also an invalid string value, even if it is not a valid time', (t) => {
-  t.plan(2)
-
+describe('should serialize also an invalid string value, even if it is not a valid time', () => {
   const schema = {
     title: 'a time in a string',
     type: 'string',
@@ -634,6 +565,6 @@ test('should serialize also an invalid string value, even if it is not a valid t
   const stringify = build(schema)
   const output = stringify(toStringify)
 
-  t.equal(output, JSON.stringify(toStringify))
-  t.not(validate(JSON.parse(output)), 'valid schema')
+  equal(output, JSON.stringify(toStringify))
+  equal(validate(JSON.parse(output)), false, 'valid schema')
 })

--- a/test/debug-mode.test.js
+++ b/test/debug-mode.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const fjs = require('..')
 
 const Ajv = require('ajv').default
@@ -24,11 +24,11 @@ test('activate debug mode', t => {
   t.plan(5)
   const debugMode = build({ debugMode: true })
 
-  t.type(debugMode, 'object')
-  t.ok(debugMode.ajv instanceof Ajv)
-  t.ok(debugMode.validator instanceof Validator)
-  t.ok(debugMode.serializer instanceof Serializer)
-  t.type(debugMode.code, 'string')
+  t.assert.ok(typeof debugMode === 'object')
+  t.assert.ok(debugMode.ajv instanceof Ajv)
+  t.assert.ok(debugMode.validator instanceof Validator)
+  t.assert.ok(debugMode.serializer instanceof Serializer)
+  t.assert.ok(typeof debugMode.code === 'string')
 })
 
 test('activate debug mode truthy', t => {
@@ -36,26 +36,26 @@ test('activate debug mode truthy', t => {
 
   const debugMode = build({ debugMode: 'yes' })
 
-  t.type(debugMode, 'object')
-  t.type(debugMode.code, 'string')
-  t.ok(debugMode.ajv instanceof Ajv)
-  t.ok(debugMode.validator instanceof Validator)
-  t.ok(debugMode.serializer instanceof Serializer)
+  t.assert.ok(typeof debugMode === 'object')
+  t.assert.ok(typeof debugMode.code === 'string')
+  t.assert.ok(debugMode.ajv instanceof Ajv)
+  t.assert.ok(debugMode.validator instanceof Validator)
+  t.assert.ok(debugMode.serializer instanceof Serializer)
 })
 
 test('to string auto-consistent', t => {
   t.plan(6)
   const debugMode = build({ debugMode: 1 })
 
-  t.type(debugMode, 'object')
-  t.type(debugMode.code, 'string')
-  t.ok(debugMode.ajv instanceof Ajv)
-  t.ok(debugMode.serializer instanceof Serializer)
-  t.ok(debugMode.validator instanceof Validator)
+  t.assert.ok(typeof debugMode === 'object')
+  t.assert.ok(typeof debugMode.code === 'string')
+  t.assert.ok(debugMode.ajv instanceof Ajv)
+  t.assert.ok(debugMode.serializer instanceof Serializer)
+  t.assert.ok(debugMode.validator instanceof Validator)
 
   const compiled = fjs.restore(debugMode)
   const tobe = JSON.stringify({ firstName: 'Foo' })
-  t.same(compiled({ firstName: 'Foo', surname: 'bar' }), tobe, 'surname evicted')
+  t.assert.equal(compiled({ firstName: 'Foo', surname: 'bar' }), tobe, 'surname evicted')
 })
 
 test('to string auto-consistent with ajv', t => {
@@ -75,15 +75,15 @@ test('to string auto-consistent with ajv', t => {
     }
   }, { debugMode: 1 })
 
-  t.type(debugMode, 'object')
-  t.type(debugMode.code, 'string')
-  t.ok(debugMode.ajv instanceof Ajv)
-  t.ok(debugMode.validator instanceof Validator)
-  t.ok(debugMode.serializer instanceof Serializer)
+  t.assert.ok(typeof debugMode === 'object')
+  t.assert.ok(typeof debugMode.code === 'string')
+  t.assert.ok(debugMode.ajv instanceof Ajv)
+  t.assert.ok(debugMode.validator instanceof Validator)
+  t.assert.ok(debugMode.serializer instanceof Serializer)
 
   const compiled = fjs.restore(debugMode)
   const tobe = JSON.stringify({ str: 'Foo' })
-  t.same(compiled({ str: 'Foo', void: 'me' }), tobe)
+  t.assert.equal(compiled({ str: 'Foo', void: 'me' }), tobe)
 })
 
 test('to string auto-consistent with ajv-formats', t => {
@@ -104,12 +104,12 @@ test('to string auto-consistent with ajv-formats', t => {
     }
   }, { debugMode: 1 })
 
-  t.type(debugMode, 'object')
+  t.assert.ok(typeof debugMode === 'object')
 
   const compiled = fjs.restore(debugMode)
   const tobe = JSON.stringify({ str: 'foo@bar.com' })
-  t.same(compiled({ str: 'foo@bar.com' }), tobe)
-  t.throws(() => compiled({ str: 'foo' }))
+  t.assert.equal(compiled({ str: 'foo@bar.com' }), tobe)
+  t.assert.throws(() => compiled({ str: 'foo' }))
 })
 
 test('debug should restore the same serializer instance', t => {
@@ -117,5 +117,5 @@ test('debug should restore the same serializer instance', t => {
 
   const debugMode = fjs({ type: 'integer' }, { debugMode: 1, rounding: 'ceil' })
   const compiled = fjs.restore(debugMode)
-  t.same(compiled(3.95), 4)
+  t.assert.equal(compiled(3.95), 4)
 })

--- a/test/debug-mode.test.js
+++ b/test/debug-mode.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { ok, equal, throws } = require('node:assert')
 const fjs = require('..')
 
 const Ajv = require('ajv').default
@@ -20,47 +21,41 @@ function build (opts) {
   }, opts)
 }
 
-test('activate debug mode', t => {
-  t.plan(5)
+describe('activate debug mode', () => {
   const debugMode = build({ debugMode: true })
 
-  t.type(debugMode, 'object')
-  t.ok(debugMode.ajv instanceof Ajv)
-  t.ok(debugMode.validator instanceof Validator)
-  t.ok(debugMode.serializer instanceof Serializer)
-  t.type(debugMode.code, 'string')
+  ok(typeof debugMode === 'object')
+  ok(debugMode.ajv instanceof Ajv)
+  ok(debugMode.validator instanceof Validator)
+  ok(debugMode.serializer instanceof Serializer)
+  ok(typeof debugMode.code === 'string')
 })
 
-test('activate debug mode truthy', t => {
-  t.plan(5)
-
+describe('activate debug mode truthy', () => {
   const debugMode = build({ debugMode: 'yes' })
 
-  t.type(debugMode, 'object')
-  t.type(debugMode.code, 'string')
-  t.ok(debugMode.ajv instanceof Ajv)
-  t.ok(debugMode.validator instanceof Validator)
-  t.ok(debugMode.serializer instanceof Serializer)
+  ok(typeof debugMode === 'object')
+  ok(typeof debugMode.code === 'string')
+  ok(debugMode.ajv instanceof Ajv)
+  ok(debugMode.validator instanceof Validator)
+  ok(debugMode.serializer instanceof Serializer)
 })
 
-test('to string auto-consistent', t => {
-  t.plan(6)
+describe('to string auto-consistent', () => {
   const debugMode = build({ debugMode: 1 })
 
-  t.type(debugMode, 'object')
-  t.type(debugMode.code, 'string')
-  t.ok(debugMode.ajv instanceof Ajv)
-  t.ok(debugMode.serializer instanceof Serializer)
-  t.ok(debugMode.validator instanceof Validator)
+  ok(typeof debugMode === 'object')
+  ok(typeof debugMode.code === 'string')
+  ok(debugMode.ajv instanceof Ajv)
+  ok(debugMode.serializer instanceof Serializer)
+  ok(debugMode.validator instanceof Validator)
 
   const compiled = fjs.restore(debugMode)
   const tobe = JSON.stringify({ firstName: 'Foo' })
-  t.same(compiled({ firstName: 'Foo', surname: 'bar' }), tobe, 'surname evicted')
+  equal(compiled({ firstName: 'Foo', surname: 'bar' }), tobe, 'surname evicted')
 })
 
-test('to string auto-consistent with ajv', t => {
-  t.plan(6)
-
+describe('to string auto-consistent with ajv', () => {
   const debugMode = fjs({
     title: 'object with multiple types field',
     type: 'object',
@@ -75,20 +70,18 @@ test('to string auto-consistent with ajv', t => {
     }
   }, { debugMode: 1 })
 
-  t.type(debugMode, 'object')
-  t.type(debugMode.code, 'string')
-  t.ok(debugMode.ajv instanceof Ajv)
-  t.ok(debugMode.validator instanceof Validator)
-  t.ok(debugMode.serializer instanceof Serializer)
+  ok(typeof debugMode === 'object')
+  ok(typeof debugMode.code === 'string')
+  ok(debugMode.ajv instanceof Ajv)
+  ok(debugMode.validator instanceof Validator)
+  ok(debugMode.serializer instanceof Serializer)
 
   const compiled = fjs.restore(debugMode)
   const tobe = JSON.stringify({ str: 'Foo' })
-  t.same(compiled({ str: 'Foo', void: 'me' }), tobe)
+  equal(compiled({ str: 'Foo', void: 'me' }), tobe)
 })
 
-test('to string auto-consistent with ajv-formats', t => {
-  t.plan(3)
-
+describe('to string auto-consistent with ajv-formats', () => {
   const debugMode = fjs({
     title: 'object with multiple types field and format keyword',
     type: 'object',
@@ -104,18 +97,16 @@ test('to string auto-consistent with ajv-formats', t => {
     }
   }, { debugMode: 1 })
 
-  t.type(debugMode, 'object')
+  ok(typeof debugMode === 'object')
 
   const compiled = fjs.restore(debugMode)
   const tobe = JSON.stringify({ str: 'foo@bar.com' })
-  t.same(compiled({ str: 'foo@bar.com' }), tobe)
-  t.throws(() => compiled({ str: 'foo' }))
+  equal(compiled({ str: 'foo@bar.com' }), tobe)
+  throws(() => compiled({ str: 'foo' }))
 })
 
-test('debug should restore the same serializer instance', t => {
-  t.plan(1)
-
+describe('debug should restore the same serializer instance', () => {
   const debugMode = fjs({ type: 'integer' }, { debugMode: 1, rounding: 'ceil' })
   const compiled = fjs.restore(debugMode)
-  t.same(compiled(3.95), 4)
+  equal(compiled(3.95), 4)
 })

--- a/test/defaults.test.js
+++ b/test/defaults.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 function buildTest (schema, toStringify, expected) {
@@ -11,7 +11,7 @@ function buildTest (schema, toStringify, expected) {
 
     const output = stringify(toStringify)
 
-    t.equal(output, JSON.stringify(expected))
+    t.assert.equal(output, JSON.stringify(expected))
   })
 }
 

--- a/test/defaults.test.js
+++ b/test/defaults.test.js
@@ -1,17 +1,16 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { equal } = require('node:assert')
 const build = require('..')
 
 function buildTest (schema, toStringify, expected) {
-  test(`render a ${schema.title} with default as JSON`, (t) => {
-    t.plan(1)
-
+  describe(`render a ${schema.title} with default as JSON`, () => {
     const stringify = build(schema)
 
     const output = stringify(toStringify)
 
-    t.equal(output, JSON.stringify(expected))
+    equal(output, JSON.stringify(expected))
   })
 }
 

--- a/test/enum.test.js
+++ b/test/enum.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('use enum without type', (t) => {
@@ -17,7 +17,7 @@ test('use enum without type', (t) => {
   })
 
   const obj = { order: 'asc' }
-  t.equal('{"order":"asc"}', stringify(obj))
+  t.assert.equal('{"order":"asc"}', stringify(obj))
 })
 
 test('use enum without type', (t) => {
@@ -33,5 +33,5 @@ test('use enum without type', (t) => {
   })
 
   const obj = { order: 'asc' }
-  t.equal('{"order":"asc"}', stringify(obj))
+  t.assert.equal('{"order":"asc"}', stringify(obj))
 })

--- a/test/enum.test.js
+++ b/test/enum.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { equal } = require('node:assert')
 const build = require('..')
 
-test('use enum without type', (t) => {
-  t.plan(1)
+describe('use enum without type', (t) => {
   const stringify = build({
     title: 'Example Schema',
     type: 'object',
@@ -17,11 +17,10 @@ test('use enum without type', (t) => {
   })
 
   const obj = { order: 'asc' }
-  t.equal('{"order":"asc"}', stringify(obj))
+  equal('{"order":"asc"}', stringify(obj))
 })
 
-test('use enum without type', (t) => {
-  t.plan(1)
+describe('use enum without type', (t) => {
   const stringify = build({
     title: 'Example Schema',
     type: 'object',
@@ -33,5 +32,5 @@ test('use enum without type', (t) => {
   })
 
   const obj = { order: 'asc' }
-  t.equal('{"order":"asc"}', stringify(obj))
+  equal('{"order":"asc"}', stringify(obj))
 })

--- a/test/fix-604.test.js
+++ b/test/fix-604.test.js
@@ -1,24 +1,25 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
 const fjs = require('..')
-const schema = {
-  type: 'object',
-  properties: {
-    fullName: { type: 'string' },
-    phone: { type: 'number' }
+
+test('fix-604', t => {
+  const schema = {
+    type: 'object',
+    properties: {
+      fullName: { type: 'string' },
+      phone: { type: 'number' }
+    }
   }
-}
 
-const input = {
-  fullName: 'Jone',
-  phone: 'phone'
-}
+  const input = {
+    fullName: 'Jone',
+    phone: 'phone'
+  }
 
-const render = fjs(schema)
+  const render = fjs(schema)
 
-try {
-  render(input)
-} catch (err) {
-  t.equal(err.message, 'The value "phone" cannot be converted to a number.')
-}
+  t.assert.throws(() => {
+    render(input)
+  }, { message: 'The value "phone" cannot be converted to a number.' })
+})

--- a/test/fix-604.test.js
+++ b/test/fix-604.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const t = require('tap')
+const { describe } = require('node:test')
+const { throws } = require('node:assert')
 const fjs = require('..')
 const schema = {
   type: 'object',
@@ -15,10 +16,12 @@ const input = {
   phone: 'phone'
 }
 
-const render = fjs(schema)
+describe('fix #604', () => {
+  const render = fjs(schema)
 
-try {
-  render(input)
-} catch (err) {
-  t.equal(err.message, 'The value "phone" cannot be converted to a number.')
-}
+  throws(() => {
+    render(input)
+  }, {
+    message: 'The value "phone" cannot be converted to a number.'
+  })
+})

--- a/test/if-then-else.test.js
+++ b/test/if-then-else.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
 const build = require('..')
 
 process.env.TZ = 'UTC'
@@ -251,7 +251,7 @@ const deepFoobarOutput = JSON.stringify({
 })
 const noElseGreetingOutput = JSON.stringify({})
 
-t.test('if-then-else', t => {
+test('if-then-else', async t => {
   const tests = [
     {
       name: 'foobar',
@@ -315,20 +315,18 @@ t.test('if-then-else', t => {
     }
   ]
 
-  tests.forEach(test => {
-    t.test(test.name + ' - normal', t => {
+  for (const { name, schema, input, expected } of tests) {
+    await t.test(name + ' - normal', async t => {
       t.plan(1)
 
-      const stringify = build(JSON.parse(JSON.stringify(test.schema)), { ajv: { strictTypes: false } })
-      const serialized = stringify(test.input)
-      t.equal(serialized, test.expected)
+      const stringify = build(JSON.parse(JSON.stringify(schema)), { ajv: { strictTypes: false } })
+      const serialized = stringify(input)
+      t.assert.equal(serialized, expected)
     })
-  })
-
-  t.end()
+  }
 })
 
-t.test('nested if/then', t => {
+test('nested if/then', t => {
   t.plan(2)
 
   const schema = {
@@ -352,18 +350,18 @@ t.test('nested if/then', t => {
 
   const stringify = build(schema)
 
-  t.equal(
+  t.assert.equal(
     stringify({ a: 'A', foo: 'foo', bar: 'bar' }),
     JSON.stringify({ a: 'A', bar: 'bar' })
   )
 
-  t.equal(
+  t.assert.equal(
     stringify({ a: 'A', foo: 'foo', bar: 'bar', foo1: 'foo1', bar1: 'bar1' }),
     JSON.stringify({ a: 'A', bar: 'bar', bar1: 'bar1' })
   )
 })
 
-t.test('if/else with string format', (t) => {
+test('if/else with string format', (t) => {
   t.plan(2)
 
   const schema = {
@@ -376,11 +374,11 @@ t.test('if/else with string format', (t) => {
 
   const date = new Date(1674263005800)
 
-  t.equal(stringify(date), '"2023-01-21"')
-  t.equal(stringify('Invalid'), '"Invalid"')
+  t.assert.equal(stringify(date), '"2023-01-21"')
+  t.assert.equal(stringify('Invalid'), '"Invalid"')
 })
 
-t.test('if/else with const integers', (t) => {
+test('if/else with const integers', (t) => {
   t.plan(2)
 
   const schema = {
@@ -392,11 +390,11 @@ t.test('if/else with const integers', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify(100.32), '66')
-  t.equal(stringify(10.12), '33')
+  t.assert.equal(stringify(100.32), '66')
+  t.assert.equal(stringify(10.12), '33')
 })
 
-t.test('if/else with array', (t) => {
+test('if/else with array', (t) => {
   t.plan(2)
 
   const schema = {
@@ -408,11 +406,11 @@ t.test('if/else with array', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify(['1']), JSON.stringify(['1']))
-  t.equal(stringify(['1', '2']), JSON.stringify([1, 2]))
+  t.assert.equal(stringify(['1']), JSON.stringify(['1']))
+  t.assert.equal(stringify(['1', '2']), JSON.stringify([1, 2]))
 })
 
-t.test('external recursive if/then/else', (t) => {
+test('external recursive if/then/else', (t) => {
   t.plan(1)
 
   const externalSchema = {
@@ -466,5 +464,5 @@ t.test('external recursive if/then/else', (t) => {
     }
   }
   const stringify = build(schema, { schema: { externalSchema } })
-  t.equal(stringify(data), '{"a":{"base":"a","bar":"42"},"b":{"base":"b","baz":"43"}}')
+  t.assert.equal(stringify(data), '{"a":{"base":"a","bar":"42"},"b":{"base":"b","baz":"43"}}')
 })

--- a/test/inferType.test.js
+++ b/test/inferType.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const validator = require('is-my-json-valid')
 const build = require('..')
 
@@ -12,9 +12,9 @@ function buildTest (schema, toStringify) {
     const stringify = build(schema)
     const output = stringify(toStringify)
 
-    t.same(JSON.parse(output), toStringify)
-    t.equal(output, JSON.stringify(toStringify))
-    t.ok(validate(JSON.parse(output)), 'valid schema')
+    t.assert.deepStrictEqual(JSON.parse(output), toStringify)
+    t.assert.equal(output, JSON.stringify(toStringify))
+    t.assert.ok(validate(JSON.parse(output)), 'valid schema')
   })
 }
 

--- a/test/inferType.test.js
+++ b/test/inferType.test.js
@@ -1,20 +1,19 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { ok, equal, deepStrictEqual } = require('node:assert')
 const validator = require('is-my-json-valid')
 const build = require('..')
 
 function buildTest (schema, toStringify) {
-  test(`render a ${schema.title} as JSON`, (t) => {
-    t.plan(3)
-
+  describe(`render a ${schema.title} as JSON`, (t) => {
     const validate = validator(schema)
     const stringify = build(schema)
     const output = stringify(toStringify)
 
-    t.same(JSON.parse(output), toStringify)
-    t.equal(output, JSON.stringify(toStringify))
-    t.ok(validate(JSON.parse(output)), 'valid schema')
+    deepStrictEqual(JSON.parse(output), toStringify)
+    equal(output, JSON.stringify(toStringify))
+    ok(validate(JSON.parse(output)), 'valid schema')
   })
 }
 

--- a/test/infinity.test.js
+++ b/test/infinity.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('Finite numbers', t => {
@@ -17,7 +17,7 @@ test('Finite numbers', t => {
 
   const stringify = build(schema)
 
-  values.forEach(v => t.equal(stringify(v), JSON.stringify(v)))
+  values.forEach(v => t.assert.equal(stringify(v), JSON.stringify(v)))
 })
 
 test('Infinite integers', t => {
@@ -35,7 +35,7 @@ test('Infinite integers', t => {
     try {
       stringify(v)
     } catch (err) {
-      t.equal(err.message, `The value "${v}" cannot be converted to an integer.`)
+      t.assert.equal(err.message, `The value "${v}" cannot be converted to an integer.`)
     }
   })
 })
@@ -51,5 +51,5 @@ test('Infinite numbers', t => {
 
   const stringify = build(schema)
 
-  values.forEach(v => t.equal(stringify(v), JSON.stringify(v)))
+  values.forEach(v => t.assert.equal(stringify(v), JSON.stringify(v)))
 })

--- a/test/infinity.test.js
+++ b/test/infinity.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
+const { throws, equal } = require('node:assert')
 const build = require('..')
 
 test('Finite numbers', t => {
@@ -9,21 +10,17 @@ test('Finite numbers', t => {
     Number.MAX_SAFE_INTEGER, Number.MAX_VALUE,
     Number.MIN_SAFE_INTEGER, Number.MIN_VALUE]
 
-  t.plan(values.length)
-
   const schema = {
     type: 'number'
   }
 
   const stringify = build(schema)
 
-  values.forEach(v => t.equal(stringify(v), JSON.stringify(v)))
+  values.forEach(v => equal(stringify(v), JSON.stringify(v)))
 })
 
 test('Infinite integers', t => {
   const values = [Infinity, -Infinity]
-
-  t.plan(values.length)
 
   const schema = {
     type: 'integer'
@@ -32,18 +29,16 @@ test('Infinite integers', t => {
   const stringify = build(schema)
 
   values.forEach(v => {
-    try {
+    throws(() => {
       stringify(v)
-    } catch (err) {
-      t.equal(err.message, `The value "${v}" cannot be converted to an integer.`)
-    }
+    }, {
+      message: `The value "${v}" cannot be converted to an integer.`
+    })
   })
 })
 
 test('Infinite numbers', t => {
   const values = [Infinity, -Infinity]
-
-  t.plan(values.length)
 
   const schema = {
     type: 'number'
@@ -51,5 +46,5 @@ test('Infinite numbers', t => {
 
   const stringify = build(schema)
 
-  values.forEach(v => t.equal(stringify(v), JSON.stringify(v)))
+  values.forEach(v => equal(stringify(v), JSON.stringify(v)))
 })

--- a/test/integer.test.js
+++ b/test/integer.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
+
 const validator = require('is-my-json-valid')
 const build = require('..')
 const ROUNDING_TYPES = ['ceil', 'floor', 'round']
@@ -18,8 +18,8 @@ test('render an integer as JSON', (t) => {
   const stringify = build(schema)
   const output = stringify(1615)
 
-  t.equal(output, '1615')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '1615')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('render a float as an integer', (t) => {
@@ -30,8 +30,8 @@ test('render a float as an integer', (t) => {
       type: 'integer'
     }, { rounding: 'foobar' })
   } catch (error) {
-    t.ok(error)
-    t.equal(error.message, 'Unsupported integer rounding method foobar')
+    t.assert.ok(error)
+    t.assert.equal(error.message, 'Unsupported integer rounding method foobar')
   }
 })
 
@@ -44,7 +44,7 @@ test('throws on NaN', (t) => {
   }
 
   const stringify = build(schema)
-  t.throws(() => stringify(NaN), new Error('The value "NaN" cannot be converted to an integer.'))
+  t.assert.throws(() => stringify(NaN), new Error('The value "NaN" cannot be converted to an integer.'))
 })
 
 test('render a float as an integer', (t) => {
@@ -87,8 +87,8 @@ test('render a float as an integer', (t) => {
     const stringify = build(schema, { rounding })
     const str = stringify(input)
 
-    t.equal(str, output)
-    t.ok(validate(JSON.parse(str)), 'valid schema')
+    t.assert.equal(str, output)
+    t.assert.ok(validate(JSON.parse(str)), 'valid schema')
   }
 })
 
@@ -111,8 +111,8 @@ test('render an object with an integer as JSON', (t) => {
     id: 1615
   })
 
-  t.equal(output, '{"id":1615}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{"id":1615}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('render an array with an integer as JSON', (t) => {
@@ -130,8 +130,8 @@ test('render an array with an integer as JSON', (t) => {
   const stringify = build(schema)
   const output = stringify([1615])
 
-  t.equal(output, '[1615]')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '[1615]')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('render an object with an additionalProperty of type integer as JSON', (t) => {
@@ -151,8 +151,8 @@ test('render an object with an additionalProperty of type integer as JSON', (t) 
     num: 1615
   })
 
-  t.equal(output, '{"num":1615}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{"num":1615}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('should round integer object parameter', t => {
@@ -163,8 +163,8 @@ test('should round integer object parameter', t => {
   const stringify = build(schema, { rounding: 'ceil' })
   const output = stringify({ magic: 4.2 })
 
-  t.equal(output, '{"magic":5}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{"magic":5}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('should not stringify a property if it does not exist', t => {
@@ -175,8 +175,8 @@ test('should not stringify a property if it does not exist', t => {
   const stringify = build(schema)
   const output = stringify({})
 
-  t.equal(output, '{}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '{}')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 ROUNDING_TYPES.forEach((rounding) => {
@@ -188,7 +188,7 @@ ROUNDING_TYPES.forEach((rounding) => {
     const stringify = build(schema, { rounding })
     const output = stringify({})
 
-    t.equal(output, '{}')
-    t.ok(validate(JSON.parse(output)), 'valid schema')
+    t.assert.equal(output, '{}')
+    t.assert.ok(validate(JSON.parse(output)), 'valid schema')
   })
 })

--- a/test/integer.test.js
+++ b/test/integer.test.js
@@ -1,14 +1,12 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
+const { throws, equal, ok } = require('node:assert')
 const validator = require('is-my-json-valid')
 const build = require('..')
 const ROUNDING_TYPES = ['ceil', 'floor', 'round']
 
-test('render an integer as JSON', (t) => {
-  t.plan(2)
-
+test('render an integer as JSON', () => {
   const schema = {
     title: 'integer',
     type: 'integer'
@@ -18,36 +16,33 @@ test('render an integer as JSON', (t) => {
   const stringify = build(schema)
   const output = stringify(1615)
 
-  t.equal(output, '1615')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '1615')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render a float as an integer', (t) => {
-  t.plan(2)
+test('render a float as an integer', () => {
   try {
     build({
       title: 'float as integer',
       type: 'integer'
     }, { rounding: 'foobar' })
   } catch (error) {
-    t.ok(error)
-    t.equal(error.message, 'Unsupported integer rounding method foobar')
+    ok(error)
+    equal(error.message, 'Unsupported integer rounding method foobar')
   }
 })
 
-test('throws on NaN', (t) => {
-  t.plan(1)
-
+test('throws on NaN', () => {
   const schema = {
     title: 'integer',
     type: 'integer'
   }
 
   const stringify = build(schema)
-  t.throws(() => stringify(NaN), new Error('The value "NaN" cannot be converted to an integer.'))
+  throws(() => stringify(NaN), new Error('The value "NaN" cannot be converted to an integer.'))
 })
 
-test('render a float as an integer', (t) => {
+test('render a float as an integer', () => {
   const cases = [
     { input: Math.PI, output: '3' },
     { input: 5.0, output: '5' },
@@ -74,7 +69,6 @@ test('render a float as an integer', (t) => {
     { input: 45.95, output: '46', rounding: 'round' }
   ]
 
-  t.plan(cases.length * 2)
   cases.forEach(checkInteger)
 
   function checkInteger ({ input, output, rounding }) {
@@ -87,14 +81,12 @@ test('render a float as an integer', (t) => {
     const stringify = build(schema, { rounding })
     const str = stringify(input)
 
-    t.equal(str, output)
-    t.ok(validate(JSON.parse(str)), 'valid schema')
+    equal(str, output)
+    ok(validate(JSON.parse(str)), 'valid schema')
   }
 })
 
-test('render an object with an integer as JSON', (t) => {
-  t.plan(2)
-
+test('render an object with an integer as JSON', () => {
   const schema = {
     title: 'object with integer',
     type: 'object',
@@ -111,13 +103,11 @@ test('render an object with an integer as JSON', (t) => {
     id: 1615
   })
 
-  t.equal(output, '{"id":1615}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{"id":1615}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render an array with an integer as JSON', (t) => {
-  t.plan(2)
-
+test('render an array with an integer as JSON', () => {
   const schema = {
     title: 'array with integer',
     type: 'array',
@@ -130,13 +120,11 @@ test('render an array with an integer as JSON', (t) => {
   const stringify = build(schema)
   const output = stringify([1615])
 
-  t.equal(output, '[1615]')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '[1615]')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render an object with an additionalProperty of type integer as JSON', (t) => {
-  t.plan(2)
-
+test('render an object with an additionalProperty of type integer as JSON', () => {
   const schema = {
     title: 'object with integer',
     type: 'object',
@@ -151,44 +139,38 @@ test('render an object with an additionalProperty of type integer as JSON', (t) 
     num: 1615
   })
 
-  t.equal(output, '{"num":1615}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{"num":1615}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('should round integer object parameter', t => {
-  t.plan(2)
-
   const schema = { type: 'object', properties: { magic: { type: 'integer' } } }
   const validate = validator(schema)
   const stringify = build(schema, { rounding: 'ceil' })
   const output = stringify({ magic: 4.2 })
 
-  t.equal(output, '{"magic":5}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{"magic":5}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('should not stringify a property if it does not exist', t => {
-  t.plan(2)
-
   const schema = { title: 'Example Schema', type: 'object', properties: { age: { type: 'integer' } } }
   const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify({})
 
-  t.equal(output, '{}')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '{}')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 ROUNDING_TYPES.forEach((rounding) => {
   test(`should not stringify a property if it does not exist (rounding: ${rounding})`, t => {
-    t.plan(2)
-
     const schema = { type: 'object', properties: { magic: { type: 'integer' } } }
     const validate = validator(schema)
     const stringify = build(schema, { rounding })
     const output = stringify({})
 
-    t.equal(output, '{}')
-    t.ok(validate(JSON.parse(output)), 'valid schema')
+    equal(output, '{}')
+    ok(validate(JSON.parse(output)), 'valid schema')
   })
 })

--- a/test/invalidSchema.test.js
+++ b/test/invalidSchema.test.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 // Covers issue #139
 test('Should throw on invalid schema', t => {
-  t.plan(2)
-  try {
+  t.plan(1)
+  t.assert.throws(() => {
     build({}, {
       schema: {
         invalid: {
@@ -14,9 +14,5 @@ test('Should throw on invalid schema', t => {
         }
       }
     })
-    t.fail('should be an invalid schema')
-  } catch (err) {
-    t.match(err.message, /^"invalid" schema is invalid:.*/, 'Schema contains invalid key')
-    t.ok(err)
-  }
+  }, { message: /^"invalid" schema is invalid:.*/ })
 })

--- a/test/invalidSchema.test.js
+++ b/test/invalidSchema.test.js
@@ -1,22 +1,22 @@
 'use strict'
 
-const test = require('tap').test
+const { describe, it } = require('node:test')
+const { throws } = require('node:assert')
 const build = require('..')
 
 // Covers issue #139
-test('Should throw on invalid schema', t => {
-  t.plan(2)
-  try {
-    build({}, {
-      schema: {
-        invalid: {
-          type: 'Dinosaur'
+describe('Invalid schema', () => {
+  it('Should throw on invalid schema', () => {
+    throws(() => {
+      build({}, {
+        schema: {
+          invalid: {
+            type: 'Dinosaur'
+          }
         }
-      }
+      })
+    }, {
+      message: /^"invalid" schema is invalid:.*/
     })
-    t.fail('should be an invalid schema')
-  } catch (err) {
-    t.match(err.message, /^"invalid" schema is invalid:.*/, 'Schema contains invalid key')
-    t.ok(err)
-  }
+  })
 })

--- a/test/issue-479.test.js
+++ b/test/issue-479.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const build = require('..')
 
 test('should validate anyOf after allOf merge', (t) => {
@@ -51,7 +51,7 @@ test('should validate anyOf after allOf merge', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(
+  t.assert.equal(
     stringify({ name: 'foo', union: 'a8f1cc50-5530-5c62-9109-5ba9589a6ae1' }),
     '{"name":"foo","union":"a8f1cc50-5530-5c62-9109-5ba9589a6ae1"}')
 })

--- a/test/issue-479.test.js
+++ b/test/issue-479.test.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const { test } = require('tap')
+const { describe } = require('node:test')
+const { equal } = require('node:assert')
 const build = require('..')
 
-test('should validate anyOf after allOf merge', (t) => {
-  t.plan(1)
-
+describe('should validate anyOf after allOf merge', (t) => {
   const schema = {
     $id: 'schema',
     type: 'object',
@@ -51,7 +50,7 @@ test('should validate anyOf after allOf merge', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(
+  equal(
     stringify({ name: 'foo', union: 'a8f1cc50-5530-5c62-9109-5ba9589a6ae1' }),
     '{"name":"foo","union":"a8f1cc50-5530-5c62-9109-5ba9589a6ae1"}')
 })

--- a/test/json-schema-test-suite/draft4.test.js
+++ b/test/json-schema-test-suite/draft4.test.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const { counTests, runTests } = require('./util')
 
 const requiredTestSuite = require('./draft4/required.json')
 
-test('required', (t) => {
+test('required', async (t) => {
   const skippedTests = ['ignores arrays', 'ignores strings', 'ignores other non-objects']
   t.plan(counTests(requiredTestSuite, skippedTests))
-  runTests(t, requiredTestSuite, skippedTests)
+  await runTests(t, requiredTestSuite, skippedTests)
 })

--- a/test/json-schema-test-suite/draft4.test.js
+++ b/test/json-schema-test-suite/draft4.test.js
@@ -1,12 +1,11 @@
 'use strict'
 
-const test = require('tap').test
-const { counTests, runTests } = require('./util')
+const { describe } = require('node:test')
+const { runTests } = require('./util')
 
 const requiredTestSuite = require('./draft4/required.json')
 
-test('required', (t) => {
+describe('required', (t) => {
   const skippedTests = ['ignores arrays', 'ignores strings', 'ignores other non-objects']
-  t.plan(counTests(requiredTestSuite, skippedTests))
   runTests(t, requiredTestSuite, skippedTests)
 })

--- a/test/json-schema-test-suite/draft6.test.js
+++ b/test/json-schema-test-suite/draft6.test.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const { counTests, runTests } = require('./util')
 
 const requiredTestSuite = require('./draft6/required.json')
 
-test('required', (t) => {
+test('required', async (t) => {
   const skippedTests = ['ignores arrays', 'ignores strings', 'ignores other non-objects']
   t.plan(counTests(requiredTestSuite, skippedTests))
-  runTests(t, requiredTestSuite, skippedTests)
+  await runTests(t, requiredTestSuite, skippedTests)
 })

--- a/test/json-schema-test-suite/draft6.test.js
+++ b/test/json-schema-test-suite/draft6.test.js
@@ -1,12 +1,11 @@
 'use strict'
 
-const test = require('tap').test
-const { counTests, runTests } = require('./util')
+const { describe } = require('node:test')
+const { runTests } = require('./util')
 
 const requiredTestSuite = require('./draft6/required.json')
 
-test('required', (t) => {
+describe('required', (t) => {
   const skippedTests = ['ignores arrays', 'ignores strings', 'ignores other non-objects']
-  t.plan(counTests(requiredTestSuite, skippedTests))
   runTests(t, requiredTestSuite, skippedTests)
 })

--- a/test/json-schema-test-suite/draft7.test.js
+++ b/test/json-schema-test-suite/draft7.test.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const { counTests, runTests } = require('./util')
 
 const requiredTestSuite = require('./draft7/required.json')
 
-test('required', (t) => {
+test('required', async (t) => {
   const skippedTests = ['ignores arrays', 'ignores strings', 'ignores other non-objects']
   t.plan(counTests(requiredTestSuite, skippedTests))
-  runTests(t, requiredTestSuite, skippedTests)
+  await runTests(t, requiredTestSuite, skippedTests)
 })

--- a/test/json-schema-test-suite/draft7.test.js
+++ b/test/json-schema-test-suite/draft7.test.js
@@ -1,12 +1,11 @@
 'use strict'
 
-const test = require('tap').test
-const { counTests, runTests } = require('./util')
+const { describe } = require('node:test')
+const { runTests } = require('./util')
 
 const requiredTestSuite = require('./draft7/required.json')
 
-test('required', (t) => {
+describe('required', (t) => {
   const skippedTests = ['ignores arrays', 'ignores strings', 'ignores other non-objects']
-  t.plan(counTests(requiredTestSuite, skippedTests))
   runTests(t, requiredTestSuite, skippedTests)
 })

--- a/test/json-schema-test-suite/util.js
+++ b/test/json-schema-test-suite/util.js
@@ -2,25 +2,22 @@
 
 const build = require('../..')
 
-function runTests (t, testsuite, skippedTests) {
+async function runTests (t, testsuite, skippedTests) {
   for (const scenario of testsuite) {
     const stringify = build(scenario.schema)
     for (const test of scenario.tests) {
       if (skippedTests.indexOf(test.description) !== -1) {
-        t.comment('skip %s', test.description)
+        console.log(`skip ${test.description}`)
         continue
       }
-      t.test(test.description, (t) => {
+
+      await t.test(test.description, (t) => {
         t.plan(1)
         try {
           const output = stringify(test.data)
-          t.equal(output, JSON.stringify(test.data), 'compare payloads')
+          t.assert.equal(output, JSON.stringify(test.data), 'compare payloads')
         } catch (err) {
-          if (test.valid === false) {
-            t.pass('payload is invalid')
-          } else {
-            t.fail('payload should be valid: ' + err.message)
-          }
+          t.assert.ok(test.valid === false, 'payload should be valid: ' + err.message)
         }
       })
     }

--- a/test/json-schema-test-suite/util.js
+++ b/test/json-schema-test-suite/util.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { it } = require('node:test')
+const { equal, ok } = require('node:assert')
 const build = require('../..')
 
 function runTests (t, testsuite, skippedTests) {
@@ -7,20 +9,15 @@ function runTests (t, testsuite, skippedTests) {
     const stringify = build(scenario.schema)
     for (const test of scenario.tests) {
       if (skippedTests.indexOf(test.description) !== -1) {
-        t.comment('skip %s', test.description)
+        console.log(`skip ${test.description}`)
         continue
       }
-      t.test(test.description, (t) => {
-        t.plan(1)
+      it(test.description, (t) => {
         try {
           const output = stringify(test.data)
-          t.equal(output, JSON.stringify(test.data), 'compare payloads')
+          equal(output, JSON.stringify(test.data), 'compare payloads')
         } catch (err) {
-          if (test.valid === false) {
-            t.pass('payload is invalid')
-          } else {
-            t.fail('payload should be valid: ' + err.message)
-          }
+          ok(test.valid === false)
         }
       })
     }

--- a/test/missing-values.test.js
+++ b/test/missing-values.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('missing values', (t) => {
@@ -22,9 +22,9 @@ test('missing values', (t) => {
     }
   })
 
-  t.equal('{"val":"value"}', stringify({ val: 'value' }))
-  t.equal('{"str":"string","val":"value"}', stringify({ str: 'string', val: 'value' }))
-  t.equal('{"str":"string","num":42,"val":"value"}', stringify({ str: 'string', num: 42, val: 'value' }))
+  t.assert.equal('{"val":"value"}', stringify({ val: 'value' }))
+  t.assert.equal('{"str":"string","val":"value"}', stringify({ str: 'string', val: 'value' }))
+  t.assert.equal('{"str":"string","num":42,"val":"value"}', stringify({ str: 'string', num: 42, val: 'value' }))
 })
 
 test('handle null when value should be string', (t) => {
@@ -39,7 +39,7 @@ test('handle null when value should be string', (t) => {
     }
   })
 
-  t.equal('{"str":""}', stringify({ str: null }))
+  t.assert.equal('{"str":""}', stringify({ str: null }))
 })
 
 test('handle null when value should be integer', (t) => {
@@ -54,7 +54,7 @@ test('handle null when value should be integer', (t) => {
     }
   })
 
-  t.equal('{"int":0}', stringify({ int: null }))
+  t.assert.equal('{"int":0}', stringify({ int: null }))
 })
 
 test('handle null when value should be number', (t) => {
@@ -69,7 +69,7 @@ test('handle null when value should be number', (t) => {
     }
   })
 
-  t.equal('{"num":0}', stringify({ num: null }))
+  t.assert.equal('{"num":0}', stringify({ num: null }))
 })
 
 test('handle null when value should be boolean', (t) => {
@@ -84,5 +84,5 @@ test('handle null when value should be boolean', (t) => {
     }
   })
 
-  t.equal('{"bool":false}', stringify({ bool: null }))
+  t.assert.equal('{"bool":false}', stringify({ bool: null }))
 })

--- a/test/missing-values.test.js
+++ b/test/missing-values.test.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { equal } = require('node:assert')
 const build = require('..')
 
-test('missing values', (t) => {
-  t.plan(3)
-
+describe('missing values', (t) => {
   const stringify = build({
     title: 'object with missing values',
     type: 'object',
@@ -22,14 +21,12 @@ test('missing values', (t) => {
     }
   })
 
-  t.equal('{"val":"value"}', stringify({ val: 'value' }))
-  t.equal('{"str":"string","val":"value"}', stringify({ str: 'string', val: 'value' }))
-  t.equal('{"str":"string","num":42,"val":"value"}', stringify({ str: 'string', num: 42, val: 'value' }))
+  equal('{"val":"value"}', stringify({ val: 'value' }))
+  equal('{"str":"string","val":"value"}', stringify({ str: 'string', val: 'value' }))
+  equal('{"str":"string","num":42,"val":"value"}', stringify({ str: 'string', num: 42, val: 'value' }))
 })
 
-test('handle null when value should be string', (t) => {
-  t.plan(1)
-
+describe('handle null when value should be string', (t) => {
   const stringify = build({
     type: 'object',
     properties: {
@@ -39,12 +36,10 @@ test('handle null when value should be string', (t) => {
     }
   })
 
-  t.equal('{"str":""}', stringify({ str: null }))
+  equal('{"str":""}', stringify({ str: null }))
 })
 
-test('handle null when value should be integer', (t) => {
-  t.plan(1)
-
+describe('handle null when value should be integer', (t) => {
   const stringify = build({
     type: 'object',
     properties: {
@@ -54,12 +49,10 @@ test('handle null when value should be integer', (t) => {
     }
   })
 
-  t.equal('{"int":0}', stringify({ int: null }))
+  equal('{"int":0}', stringify({ int: null }))
 })
 
-test('handle null when value should be number', (t) => {
-  t.plan(1)
-
+describe('handle null when value should be number', (t) => {
   const stringify = build({
     type: 'object',
     properties: {
@@ -69,12 +62,10 @@ test('handle null when value should be number', (t) => {
     }
   })
 
-  t.equal('{"num":0}', stringify({ num: null }))
+  equal('{"num":0}', stringify({ num: null }))
 })
 
-test('handle null when value should be boolean', (t) => {
-  t.plan(1)
-
+describe('handle null when value should be boolean', (t) => {
   const stringify = build({
     type: 'object',
     properties: {
@@ -84,5 +75,5 @@ test('handle null when value should be boolean', (t) => {
     }
   })
 
-  t.equal('{"bool":false}', stringify({ bool: null }))
+  equal('{"bool":false}', stringify({ bool: null }))
 })

--- a/test/multi-type-serializer.test.js
+++ b/test/multi-type-serializer.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('should throw a TypeError with the path to the key of the invalid value', (t) => {
@@ -15,5 +15,5 @@ test('should throw a TypeError with the path to the key of the invalid value', (
   }
 
   const stringify = build(schema)
-  t.throws(() => stringify({ num: { bla: 123 } }), new TypeError('The value of \'#/properties/num\' does not match schema definition.'))
+  t.assert.throws(() => stringify({ num: { bla: 123 } }), new TypeError('The value of \'#/properties/num\' does not match schema definition.'))
 })

--- a/test/multi-type-serializer.test.js
+++ b/test/multi-type-serializer.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { throws } = require('node:assert')
 const build = require('..')
 
-test('should throw a TypeError with the path to the key of the invalid value', (t) => {
-  t.plan(1)
+describe('should throw a TypeError with the path to the key of the invalid value', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -15,5 +15,5 @@ test('should throw a TypeError with the path to the key of the invalid value', (
   }
 
   const stringify = build(schema)
-  t.throws(() => stringify({ num: { bla: 123 } }), new TypeError('The value of \'#/properties/num\' does not match schema definition.'))
+  throws(() => stringify({ num: { bla: 123 } }), new TypeError('The value of \'#/properties/num\' does not match schema definition.'))
 })

--- a/test/nestedObjects.test.js
+++ b/test/nestedObjects.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('nested objects with same properties', (t) => {
@@ -28,7 +28,7 @@ test('nested objects with same properties', (t) => {
       numberProperty: 42
     }
   })
-  t.equal(value, '{"stringProperty":"string1","objectProperty":{"stringProperty":"string2","numberProperty":42}}')
+  t.assert.equal(value, '{"stringProperty":"string1","objectProperty":{"stringProperty":"string2","numberProperty":42}}')
 })
 
 test('names collision', (t) => {
@@ -59,5 +59,5 @@ test('names collision', (t) => {
     tes: { b: 'b', t: {} }
   }
 
-  t.equal(stringify(data), JSON.stringify(data))
+  t.assert.equal(stringify(data), JSON.stringify(data))
 })

--- a/test/nestedObjects.test.js
+++ b/test/nestedObjects.test.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { equal } = require('node:assert')
 const build = require('..')
 
-test('nested objects with same properties', (t) => {
-  t.plan(1)
-
+describe('nested objects with same properties', (t) => {
   const schema = {
     title: 'nested objects with same properties',
     type: 'object',
@@ -28,12 +27,10 @@ test('nested objects with same properties', (t) => {
       numberProperty: 42
     }
   })
-  t.equal(value, '{"stringProperty":"string1","objectProperty":{"stringProperty":"string2","numberProperty":42}}')
+  equal(value, '{"stringProperty":"string1","objectProperty":{"stringProperty":"string2","numberProperty":42}}')
 })
 
-test('names collision', (t) => {
-  t.plan(1)
-
+describe('names collision', (t) => {
   const schema = {
     title: 'nested objects with same properties',
     type: 'object',
@@ -59,5 +56,5 @@ test('names collision', (t) => {
     tes: { b: 'b', t: {} }
   }
 
-  t.equal(stringify(data), JSON.stringify(data))
+  equal(stringify(data), JSON.stringify(data))
 })

--- a/test/nullable.test.js
+++ b/test/nullable.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 
 const build = require('..')
 
@@ -113,7 +113,7 @@ Object.keys(testSet).forEach(key => {
 
     const stringifier = build(schema, extraOptions)
     const result = stringifier(data)
-    t.same(JSON.parse(result), expected)
+    t.assert.deepStrictEqual(JSON.parse(result), expected)
   })
 })
 
@@ -129,8 +129,8 @@ test('handle nullable number correctly', (t) => {
   const data = null
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  t.assert.equal(result, JSON.stringify(data))
+  t.assert.equal(JSON.parse(result), data)
 })
 
 test('handle nullable integer correctly', (t) => {
@@ -145,8 +145,8 @@ test('handle nullable integer correctly', (t) => {
   const data = null
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  t.assert.equal(result, JSON.stringify(data))
+  t.assert.equal(JSON.parse(result), data)
 })
 
 test('handle nullable boolean correctly', (t) => {
@@ -161,8 +161,8 @@ test('handle nullable boolean correctly', (t) => {
   const data = null
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  t.assert.equal(result, JSON.stringify(data))
+  t.assert.equal(JSON.parse(result), data)
 })
 
 test('handle nullable string correctly', (t) => {
@@ -177,8 +177,8 @@ test('handle nullable string correctly', (t) => {
   const data = null
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  t.assert.equal(result, JSON.stringify(data))
+  t.assert.equal(JSON.parse(result), data)
 })
 
 test('handle nullable date-time correctly', (t) => {
@@ -194,8 +194,8 @@ test('handle nullable date-time correctly', (t) => {
   const data = null
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  t.assert.equal(result, JSON.stringify(data))
+  t.assert.equal(JSON.parse(result), data)
 })
 
 test('handle nullable date correctly', (t) => {
@@ -211,8 +211,8 @@ test('handle nullable date correctly', (t) => {
   const data = null
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  t.assert.equal(result, JSON.stringify(data))
+  t.assert.equal(JSON.parse(result), data)
 })
 
 test('handle nullable time correctly', (t) => {
@@ -228,8 +228,8 @@ test('handle nullable time correctly', (t) => {
   const data = null
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  t.assert.equal(result, JSON.stringify(data))
+  t.assert.equal(JSON.parse(result), data)
 })
 
 test('large array of nullable strings with default mechanism', (t) => {
@@ -258,8 +258,8 @@ test('large array of nullable strings with default mechanism', (t) => {
   const data = { ids: new Array(2e4).fill(null) }
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  t.assert.equal(result, JSON.stringify(data))
+  t.assert.deepStrictEqual(JSON.parse(result), data)
 })
 
 test('large array of nullable date-time strings with default mechanism', (t) => {
@@ -289,8 +289,8 @@ test('large array of nullable date-time strings with default mechanism', (t) => 
   const data = { ids: new Array(2e4).fill(null) }
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  t.assert.equal(result, JSON.stringify(data))
+  t.assert.deepStrictEqual(JSON.parse(result), data)
 })
 
 test('large array of nullable date-time strings with default mechanism', (t) => {
@@ -320,8 +320,8 @@ test('large array of nullable date-time strings with default mechanism', (t) => 
   const data = { ids: new Array(2e4).fill(null) }
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  t.assert.equal(result, JSON.stringify(data))
+  t.assert.deepStrictEqual(JSON.parse(result), data)
 })
 
 test('large array of nullable date-time strings with default mechanism', (t) => {
@@ -351,8 +351,8 @@ test('large array of nullable date-time strings with default mechanism', (t) => 
   const data = { ids: new Array(2e4).fill(null) }
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  t.assert.equal(result, JSON.stringify(data))
+  t.assert.deepStrictEqual(JSON.parse(result), data)
 })
 
 test('large array of nullable numbers with default mechanism', (t) => {
@@ -381,8 +381,8 @@ test('large array of nullable numbers with default mechanism', (t) => {
   const data = { ids: new Array(2e4).fill(null) }
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  t.assert.equal(result, JSON.stringify(data))
+  t.assert.deepStrictEqual(JSON.parse(result), data)
 })
 
 test('large array of nullable integers with default mechanism', (t) => {
@@ -411,8 +411,8 @@ test('large array of nullable integers with default mechanism', (t) => {
   const data = { ids: new Array(2e4).fill(null) }
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  t.assert.equal(result, JSON.stringify(data))
+  t.assert.deepStrictEqual(JSON.parse(result), data)
 })
 
 test('large array of nullable booleans with default mechanism', (t) => {
@@ -441,8 +441,8 @@ test('large array of nullable booleans with default mechanism', (t) => {
   const data = { ids: new Array(2e4).fill(null) }
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  t.assert.equal(result, JSON.stringify(data))
+  t.assert.deepStrictEqual(JSON.parse(result), data)
 })
 
 test('nullable type in the schema', (t) => {
@@ -461,8 +461,8 @@ test('nullable type in the schema', (t) => {
 
   const data = { foo: 'bar' }
 
-  t.same(stringify(data), JSON.stringify(data))
-  t.same(stringify(null), JSON.stringify(null))
+  t.assert.equal(stringify(data), JSON.stringify(data))
+  t.assert.equal(stringify(null), JSON.stringify(null))
 })
 
 test('throw an error if the value doesn\'t match the type', (t) => {
@@ -493,10 +493,10 @@ test('throw an error if the value doesn\'t match the type', (t) => {
   const stringify = build(schema)
 
   const validData = { data: [1, 'testing'] }
-  t.equal(stringify(validData), JSON.stringify(validData))
+  t.assert.equal(stringify(validData), JSON.stringify(validData))
 
   const invalidData = { data: [false, 'testing'] }
-  t.throws(() => stringify(invalidData))
+  t.assert.throws(() => stringify(invalidData))
 })
 
 test('nullable value in oneOf', (t) => {
@@ -539,5 +539,5 @@ test('nullable value in oneOf', (t) => {
   const stringify = build(schema)
 
   const data = { data: [{ job: null }] }
-  t.equal(stringify(data), JSON.stringify(data))
+  t.assert.equal(stringify(data), JSON.stringify(data))
 })

--- a/test/nullable.test.js
+++ b/test/nullable.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const test = require('tap').test
-
+const { describe, it } = require('node:test')
+const { deepStrictEqual, equal, throws } = require('node:assert')
 const build = require('..')
 
 const nullable = true
@@ -101,9 +101,7 @@ const testSet = {
 }
 
 Object.keys(testSet).forEach(key => {
-  test(`handle nullable:true in ${key} correctly`, (t) => {
-    t.plan(1)
-
+  it(`handle nullable:true in ${key} correctly`, (t) => {
     const [
       schema,
       data,
@@ -113,13 +111,11 @@ Object.keys(testSet).forEach(key => {
 
     const stringifier = build(schema, extraOptions)
     const result = stringifier(data)
-    t.same(JSON.parse(result), expected)
+    deepStrictEqual(JSON.parse(result), expected)
   })
 })
 
-test('handle nullable number correctly', (t) => {
-  t.plan(2)
-
+describe('handle nullable number correctly', (t) => {
   const schema = {
     type: 'number',
     nullable: true
@@ -129,13 +125,11 @@ test('handle nullable number correctly', (t) => {
   const data = null
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  deepStrictEqual(result, JSON.stringify(data))
+  deepStrictEqual(JSON.parse(result), data)
 })
 
-test('handle nullable integer correctly', (t) => {
-  t.plan(2)
-
+describe('handle nullable integer correctly', (t) => {
   const schema = {
     type: 'integer',
     nullable: true
@@ -145,13 +139,11 @@ test('handle nullable integer correctly', (t) => {
   const data = null
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  deepStrictEqual(result, JSON.stringify(data))
+  deepStrictEqual(JSON.parse(result), data)
 })
 
-test('handle nullable boolean correctly', (t) => {
-  t.plan(2)
-
+describe('handle nullable boolean correctly', (t) => {
   const schema = {
     type: 'boolean',
     nullable: true
@@ -161,13 +153,11 @@ test('handle nullable boolean correctly', (t) => {
   const data = null
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  deepStrictEqual(result, JSON.stringify(data))
+  deepStrictEqual(JSON.parse(result), data)
 })
 
-test('handle nullable string correctly', (t) => {
-  t.plan(2)
-
+describe('handle nullable string correctly', (t) => {
   const schema = {
     type: 'string',
     nullable: true
@@ -177,13 +167,11 @@ test('handle nullable string correctly', (t) => {
   const data = null
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  deepStrictEqual(result, JSON.stringify(data))
+  deepStrictEqual(JSON.parse(result), data)
 })
 
-test('handle nullable date-time correctly', (t) => {
-  t.plan(2)
-
+describe('handle nullable date-time correctly', (t) => {
   const schema = {
     type: 'string',
     format: 'date-time',
@@ -194,13 +182,11 @@ test('handle nullable date-time correctly', (t) => {
   const data = null
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  deepStrictEqual(result, JSON.stringify(data))
+  deepStrictEqual(JSON.parse(result), data)
 })
 
-test('handle nullable date correctly', (t) => {
-  t.plan(2)
-
+describe('handle nullable date correctly', (t) => {
   const schema = {
     type: 'string',
     format: 'date',
@@ -211,13 +197,11 @@ test('handle nullable date correctly', (t) => {
   const data = null
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  deepStrictEqual(result, JSON.stringify(data))
+  deepStrictEqual(JSON.parse(result), data)
 })
 
-test('handle nullable time correctly', (t) => {
-  t.plan(2)
-
+describe('handle nullable time correctly', (t) => {
   const schema = {
     type: 'string',
     format: 'time',
@@ -228,13 +212,11 @@ test('handle nullable time correctly', (t) => {
   const data = null
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  deepStrictEqual(result, JSON.stringify(data))
+  deepStrictEqual(JSON.parse(result), data)
 })
 
-test('large array of nullable strings with default mechanism', (t) => {
-  t.plan(2)
-
+describe('large array of nullable strings with default mechanism', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -258,13 +240,11 @@ test('large array of nullable strings with default mechanism', (t) => {
   const data = { ids: new Array(2e4).fill(null) }
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  deepStrictEqual(result, JSON.stringify(data))
+  deepStrictEqual(JSON.parse(result), data)
 })
 
-test('large array of nullable date-time strings with default mechanism', (t) => {
-  t.plan(2)
-
+describe('large array of nullable date-time strings with default mechanism', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -289,13 +269,11 @@ test('large array of nullable date-time strings with default mechanism', (t) => 
   const data = { ids: new Array(2e4).fill(null) }
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  deepStrictEqual(result, JSON.stringify(data))
+  deepStrictEqual(JSON.parse(result), data)
 })
 
-test('large array of nullable date-time strings with default mechanism', (t) => {
-  t.plan(2)
-
+describe('large array of nullable date-time strings with default mechanism', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -320,13 +298,11 @@ test('large array of nullable date-time strings with default mechanism', (t) => 
   const data = { ids: new Array(2e4).fill(null) }
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  deepStrictEqual(result, JSON.stringify(data))
+  deepStrictEqual(JSON.parse(result), data)
 })
 
-test('large array of nullable date-time strings with default mechanism', (t) => {
-  t.plan(2)
-
+describe('large array of nullable date-time strings with default mechanism', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -351,13 +327,11 @@ test('large array of nullable date-time strings with default mechanism', (t) => 
   const data = { ids: new Array(2e4).fill(null) }
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  deepStrictEqual(result, JSON.stringify(data))
+  deepStrictEqual(JSON.parse(result), data)
 })
 
-test('large array of nullable numbers with default mechanism', (t) => {
-  t.plan(2)
-
+describe('large array of nullable numbers with default mechanism', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -381,13 +355,11 @@ test('large array of nullable numbers with default mechanism', (t) => {
   const data = { ids: new Array(2e4).fill(null) }
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  deepStrictEqual(result, JSON.stringify(data))
+  deepStrictEqual(JSON.parse(result), data)
 })
 
-test('large array of nullable integers with default mechanism', (t) => {
-  t.plan(2)
-
+describe('large array of nullable integers with default mechanism', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -411,13 +383,11 @@ test('large array of nullable integers with default mechanism', (t) => {
   const data = { ids: new Array(2e4).fill(null) }
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  deepStrictEqual(result, JSON.stringify(data))
+  deepStrictEqual(JSON.parse(result), data)
 })
 
-test('large array of nullable booleans with default mechanism', (t) => {
-  t.plan(2)
-
+describe('large array of nullable booleans with default mechanism', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -441,13 +411,11 @@ test('large array of nullable booleans with default mechanism', (t) => {
   const data = { ids: new Array(2e4).fill(null) }
   const result = stringify(data)
 
-  t.same(result, JSON.stringify(data))
-  t.same(JSON.parse(result), data)
+  deepStrictEqual(result, JSON.stringify(data))
+  deepStrictEqual(JSON.parse(result), data)
 })
 
-test('nullable type in the schema', (t) => {
-  t.plan(2)
-
+describe('nullable type in the schema', (t) => {
   const schema = {
     type: ['object', 'null'],
     properties: {
@@ -461,13 +429,11 @@ test('nullable type in the schema', (t) => {
 
   const data = { foo: 'bar' }
 
-  t.same(stringify(data), JSON.stringify(data))
-  t.same(stringify(null), JSON.stringify(null))
+  deepStrictEqual(stringify(data), JSON.stringify(data))
+  deepStrictEqual(stringify(null), JSON.stringify(null))
 })
 
-test('throw an error if the value doesn\'t match the type', (t) => {
-  t.plan(2)
-
+describe('throw an error if the value doesn\'t match the type', (t) => {
   const schema = {
     type: 'object',
     additionalProperties: false,
@@ -493,15 +459,13 @@ test('throw an error if the value doesn\'t match the type', (t) => {
   const stringify = build(schema)
 
   const validData = { data: [1, 'testing'] }
-  t.equal(stringify(validData), JSON.stringify(validData))
+  equal(stringify(validData), JSON.stringify(validData))
 
   const invalidData = { data: [false, 'testing'] }
-  t.throws(() => stringify(invalidData))
+  throws(() => stringify(invalidData))
 })
 
-test('nullable value in oneOf', (t) => {
-  t.plan(1)
-
+describe('nullable value in oneOf', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -539,5 +503,5 @@ test('nullable value in oneOf', (t) => {
   const stringify = build(schema)
 
   const data = { data: [{ job: null }] }
-  t.equal(stringify(data), JSON.stringify(data))
+  equal(stringify(data), JSON.stringify(data))
 })

--- a/test/oneof.test.js
+++ b/test/oneof.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const build = require('..')
 
 test('object with multiple types field', (t) => {
@@ -21,8 +21,8 @@ test('object with multiple types field', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify({ str: 'string' }), '{"str":"string"}')
-  t.equal(stringify({ str: true }), '{"str":true}')
+  t.assert.equal(stringify({ str: 'string' }), '{"str":"string"}')
+  t.assert.equal(stringify({ str: true }), '{"str":true}')
 })
 
 test('object with field of type object or null', (t) => {
@@ -48,9 +48,9 @@ test('object with field of type object or null', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify({ prop: null }), '{"prop":null}')
+  t.assert.equal(stringify({ prop: null }), '{"prop":null}')
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     prop: {
       str: 'string', remove: 'this'
     }
@@ -80,11 +80,11 @@ test('object with field of type object or array', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     prop: { str: 'string' }
   }), '{"prop":{"str":"string"}}')
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     prop: ['string']
   }), '{"prop":["string"]}')
 })
@@ -104,7 +104,7 @@ test('object with field of type string and coercion disable ', (t) => {
     }
   }
   const stringify = build(schema)
-  t.throws(() => stringify({ str: 1 }))
+  t.assert.throws(() => stringify({ str: 1 }))
 })
 
 test('object with field of type string and coercion enable ', (t) => {
@@ -132,7 +132,7 @@ test('object with field of type string and coercion enable ', (t) => {
   const value = stringify({
     str: 1
   })
-  t.equal(value, '{"str":"1"}')
+  t.assert.equal(value, '{"str":"1"}')
 })
 
 test('object with field with type union of multiple objects', (t) => {
@@ -166,9 +166,9 @@ test('object with field with type union of multiple objects', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ oneOfSchema: { baz: 5 } }), '{"oneOfSchema":{"baz":5}}')
+  t.assert.equal(stringify({ oneOfSchema: { baz: 5 } }), '{"oneOfSchema":{"baz":5}}')
 
-  t.equal(stringify({ oneOfSchema: { bar: 'foo' } }), '{"oneOfSchema":{"bar":"foo"}}')
+  t.assert.equal(stringify({ oneOfSchema: { bar: 'foo' } }), '{"oneOfSchema":{"bar":"foo"}}')
 })
 
 test('null value in schema', (t) => {
@@ -210,9 +210,9 @@ test('oneOf and $ref together', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ cs: 'franco' }), '{"cs":"franco"}')
+  t.assert.equal(stringify({ cs: 'franco' }), '{"cs":"franco"}')
 
-  t.equal(stringify({ cs: true }), '{"cs":true}')
+  t.assert.equal(stringify({ cs: true }), '{"cs":true}')
 })
 
 test('oneOf and $ref: 2 levels are fine', (t) => {
@@ -250,7 +250,7 @@ test('oneOf and $ref: 2 levels are fine', (t) => {
   const value = stringify({
     cs: 3
   })
-  t.equal(value, '{"cs":3}')
+  t.assert.equal(value, '{"cs":3}')
 })
 
 test('oneOf and $ref: multiple levels should throw at build.', (t) => {
@@ -289,9 +289,9 @@ test('oneOf and $ref: multiple levels should throw at build.', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ cs: 3 }), '{"cs":3}')
-  t.equal(stringify({ cs: true }), '{"cs":true}')
-  t.equal(stringify({ cs: 'pippo' }), '{"cs":"pippo"}')
+  t.assert.equal(stringify({ cs: 3 }), '{"cs":3}')
+  t.assert.equal(stringify({ cs: true }), '{"cs":true}')
+  t.assert.equal(stringify({ cs: 'pippo' }), '{"cs":"pippo"}')
 })
 
 test('oneOf and $ref - multiple external $ref', (t) => {
@@ -344,10 +344,8 @@ test('oneOf and $ref - multiple external $ref', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"obj":{"prop":{"prop2":"test"}}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"obj":{"prop":{"prop2":"test"}}}')
 })
 
 test('oneOf with enum with more than 100 entries', (t) => {
@@ -369,7 +367,7 @@ test('oneOf with enum with more than 100 entries', (t) => {
   const stringify = build(schema)
 
   const value = stringify(['EUR', 'USD', null])
-  t.equal(value, '["EUR","USD",null]')
+  t.assert.equal(value, '["EUR","USD",null]')
 })
 
 test('oneOf object with field of type string with format or null', (t) => {
@@ -393,7 +391,7 @@ test('oneOf object with field of type string with format or null', (t) => {
 
   const withOneOfStringify = build(withOneOfSchema)
 
-  t.equal(withOneOfStringify({
+  t.assert.equal(withOneOfStringify({
     prop: toStringify
   }), `{"prop":"${toStringify.toISOString()}"}`)
 })
@@ -425,9 +423,9 @@ test('one array item match oneOf types', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ data: ['foo'] }), '{"data":["foo"]}')
-  t.equal(stringify({ data: [1] }), '{"data":[1]}')
-  t.throws(() => stringify({ data: [false, 'foo'] }))
+  t.assert.equal(stringify({ data: ['foo'] }), '{"data":["foo"]}')
+  t.assert.equal(stringify({ data: [1] }), '{"data":[1]}')
+  t.assert.throws(() => stringify({ data: [false, 'foo'] }))
 })
 
 test('some array items match oneOf types', (t) => {
@@ -457,8 +455,8 @@ test('some array items match oneOf types', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ data: ['foo', 5] }), '{"data":["foo",5]}')
-  t.throws(() => stringify({ data: [false, 'foo', true, 5] }))
+  t.assert.equal(stringify({ data: ['foo', 5] }), '{"data":["foo",5]}')
+  t.assert.throws(() => stringify({ data: [false, 'foo', true, 5] }))
 })
 
 test('all array items does not match oneOf types', (t) => {
@@ -488,5 +486,5 @@ test('all array items does not match oneOf types', (t) => {
 
   const stringify = build(schema)
 
-  t.throws(() => stringify({ data: [null, false, true, undefined, [], {}] }))
+  t.assert.throws(() => stringify({ data: [null, false, true, undefined, [], {}] }))
 })

--- a/test/oneof.test.js
+++ b/test/oneof.test.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const { test } = require('tap')
+const { describe } = require('node:test')
+const { equal, throws } = require('node:assert')
 const build = require('..')
 
-test('object with multiple types field', (t) => {
-  t.plan(2)
-
+describe('object with multiple types field', (t) => {
   const schema = {
     title: 'object with multiple types field',
     type: 'object',
@@ -21,13 +20,11 @@ test('object with multiple types field', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify({ str: 'string' }), '{"str":"string"}')
-  t.equal(stringify({ str: true }), '{"str":true}')
+  equal(stringify({ str: 'string' }), '{"str":"string"}')
+  equal(stringify({ str: true }), '{"str":true}')
 })
 
-test('object with field of type object or null', (t) => {
-  t.plan(2)
-
+describe('object with field of type object or null', (t) => {
   const schema = {
     title: 'object with field of type object or null',
     type: 'object',
@@ -48,18 +45,16 @@ test('object with field of type object or null', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify({ prop: null }), '{"prop":null}')
+  equal(stringify({ prop: null }), '{"prop":null}')
 
-  t.equal(stringify({
+  equal(stringify({
     prop: {
       str: 'string', remove: 'this'
     }
   }), '{"prop":{"str":"string"}}')
 })
 
-test('object with field of type object or array', (t) => {
-  t.plan(2)
-
+describe('object with field of type object or array', (t) => {
   const schema = {
     title: 'object with field of type object or array',
     type: 'object',
@@ -80,18 +75,16 @@ test('object with field of type object or array', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify({
+  equal(stringify({
     prop: { str: 'string' }
   }), '{"prop":{"str":"string"}}')
 
-  t.equal(stringify({
+  equal(stringify({
     prop: ['string']
   }), '{"prop":["string"]}')
 })
 
-test('object with field of type string and coercion disable ', (t) => {
-  t.plan(1)
-
+describe('object with field of type string and coercion disable ', (t) => {
   const schema = {
     title: 'object with field of type string',
     type: 'object',
@@ -104,12 +97,10 @@ test('object with field of type string and coercion disable ', (t) => {
     }
   }
   const stringify = build(schema)
-  t.throws(() => stringify({ str: 1 }))
+  throws(() => stringify({ str: 1 }))
 })
 
-test('object with field of type string and coercion enable ', (t) => {
-  t.plan(1)
-
+describe('object with field of type string and coercion enable ', (t) => {
   const schema = {
     title: 'object with field of type string',
     type: 'object',
@@ -132,12 +123,10 @@ test('object with field of type string and coercion enable ', (t) => {
   const value = stringify({
     str: 1
   })
-  t.equal(value, '{"str":"1"}')
+  equal(value, '{"str":"1"}')
 })
 
-test('object with field with type union of multiple objects', (t) => {
-  t.plan(2)
-
+describe('object with field with type union of multiple objects', (t) => {
   const schema = {
     title: 'object with oneOf property value containing objects',
     type: 'object',
@@ -166,14 +155,12 @@ test('object with field with type union of multiple objects', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ oneOfSchema: { baz: 5 } }), '{"oneOfSchema":{"baz":5}}')
+  equal(stringify({ oneOfSchema: { baz: 5 } }), '{"oneOfSchema":{"baz":5}}')
 
-  t.equal(stringify({ oneOfSchema: { bar: 'foo' } }), '{"oneOfSchema":{"bar":"foo"}}')
+  equal(stringify({ oneOfSchema: { bar: 'foo' } }), '{"oneOfSchema":{"bar":"foo"}}')
 })
 
-test('null value in schema', (t) => {
-  t.plan(0)
-
+describe('null value in schema', (t) => {
   const schema = {
     title: 'schema with null child',
     type: 'string',
@@ -184,9 +171,7 @@ test('null value in schema', (t) => {
   build(schema)
 })
 
-test('oneOf and $ref together', (t) => {
-  t.plan(2)
-
+describe('oneOf and $ref together', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -210,14 +195,12 @@ test('oneOf and $ref together', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ cs: 'franco' }), '{"cs":"franco"}')
+  equal(stringify({ cs: 'franco' }), '{"cs":"franco"}')
 
-  t.equal(stringify({ cs: true }), '{"cs":true}')
+  equal(stringify({ cs: true }), '{"cs":true}')
 })
 
-test('oneOf and $ref: 2 levels are fine', (t) => {
-  t.plan(1)
-
+describe('oneOf and $ref: 2 levels are fine', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -250,12 +233,10 @@ test('oneOf and $ref: 2 levels are fine', (t) => {
   const value = stringify({
     cs: 3
   })
-  t.equal(value, '{"cs":3}')
+  equal(value, '{"cs":3}')
 })
 
-test('oneOf and $ref: multiple levels should throw at build.', (t) => {
-  t.plan(3)
-
+describe('oneOf and $ref: multiple levels should throw at build.', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -289,14 +270,12 @@ test('oneOf and $ref: multiple levels should throw at build.', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ cs: 3 }), '{"cs":3}')
-  t.equal(stringify({ cs: true }), '{"cs":true}')
-  t.equal(stringify({ cs: 'pippo' }), '{"cs":"pippo"}')
+  equal(stringify({ cs: 3 }), '{"cs":3}')
+  equal(stringify({ cs: true }), '{"cs":true}')
+  equal(stringify({ cs: 'pippo' }), '{"cs":"pippo"}')
 })
 
-test('oneOf and $ref - multiple external $ref', (t) => {
-  t.plan(2)
-
+describe('oneOf and $ref - multiple external $ref', (t) => {
   const externalSchema = {
     external: {
       definitions: {
@@ -345,14 +324,11 @@ test('oneOf and $ref - multiple external $ref', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"obj":{"prop":{"prop2":"test"}}}')
+  equal(output, '{"obj":{"prop":{"prop2":"test"}}}')
 })
 
-test('oneOf with enum with more than 100 entries', (t) => {
-  t.plan(1)
-
+describe('oneOf with enum with more than 100 entries', (t) => {
   const schema = {
     title: 'type array that may have one of declared items',
     type: 'array',
@@ -369,12 +345,10 @@ test('oneOf with enum with more than 100 entries', (t) => {
   const stringify = build(schema)
 
   const value = stringify(['EUR', 'USD', null])
-  t.equal(value, '["EUR","USD",null]')
+  equal(value, '["EUR","USD",null]')
 })
 
-test('oneOf object with field of type string with format or null', (t) => {
-  t.plan(1)
-
+describe('oneOf object with field of type string with format or null', (t) => {
   const toStringify = new Date()
 
   const withOneOfSchema = {
@@ -393,14 +367,12 @@ test('oneOf object with field of type string with format or null', (t) => {
 
   const withOneOfStringify = build(withOneOfSchema)
 
-  t.equal(withOneOfStringify({
+  equal(withOneOfStringify({
     prop: toStringify
   }), `{"prop":"${toStringify.toISOString()}"}`)
 })
 
-test('one array item match oneOf types', (t) => {
-  t.plan(3)
-
+describe('one array item match oneOf types', (t) => {
   const schema = {
     type: 'object',
     additionalProperties: false,
@@ -425,14 +397,12 @@ test('one array item match oneOf types', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ data: ['foo'] }), '{"data":["foo"]}')
-  t.equal(stringify({ data: [1] }), '{"data":[1]}')
-  t.throws(() => stringify({ data: [false, 'foo'] }))
+  equal(stringify({ data: ['foo'] }), '{"data":["foo"]}')
+  equal(stringify({ data: [1] }), '{"data":[1]}')
+  throws(() => stringify({ data: [false, 'foo'] }))
 })
 
-test('some array items match oneOf types', (t) => {
-  t.plan(2)
-
+describe('some array items match oneOf types', (t) => {
   const schema = {
     type: 'object',
     additionalProperties: false,
@@ -457,13 +427,11 @@ test('some array items match oneOf types', (t) => {
 
   const stringify = build(schema)
 
-  t.equal(stringify({ data: ['foo', 5] }), '{"data":["foo",5]}')
-  t.throws(() => stringify({ data: [false, 'foo', true, 5] }))
+  equal(stringify({ data: ['foo', 5] }), '{"data":["foo",5]}')
+  throws(() => stringify({ data: [false, 'foo', true, 5] }))
 })
 
-test('all array items does not match oneOf types', (t) => {
-  t.plan(1)
-
+describe('all array items does not match oneOf types', (t) => {
   const schema = {
     type: 'object',
     additionalProperties: false,
@@ -488,5 +456,5 @@ test('all array items does not match oneOf types', (t) => {
 
   const stringify = build(schema)
 
-  t.throws(() => stringify({ data: [null, false, true, undefined, [], {}] }))
+  throws(() => stringify({ data: [null, false, true, undefined, [], {}] }))
 })

--- a/test/patternProperties.test.js
+++ b/test/patternProperties.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('patternProperties', (t) => {
@@ -21,7 +21,7 @@ test('patternProperties', (t) => {
   })
 
   const obj = { str: 'test', foo: 42, ofoo: true, foof: 'string', objfoo: { a: true }, notMe: false }
-  t.equal(stringify(obj), '{"str":"test","foo":"42","ofoo":"true","foof":"string","objfoo":"[object Object]"}')
+  t.assert.equal(stringify(obj), '{"str":"test","foo":"42","ofoo":"true","foof":"string","objfoo":"[object Object]"}')
 })
 
 test('patternProperties should not change properties', (t) => {
@@ -42,7 +42,7 @@ test('patternProperties should not change properties', (t) => {
   })
 
   const obj = { foo: '42', ofoo: 42 }
-  t.equal(stringify(obj), '{"foo":"42","ofoo":42}')
+  t.assert.equal(stringify(obj), '{"foo":"42","ofoo":42}')
 })
 
 test('patternProperties - string coerce', (t) => {
@@ -59,7 +59,7 @@ test('patternProperties - string coerce', (t) => {
   })
 
   const obj = { foo: true, ofoo: 42, arrfoo: ['array', 'test'], objfoo: { a: 'world' } }
-  t.equal(stringify(obj), '{"foo":"true","ofoo":"42","arrfoo":"array,test","objfoo":"[object Object]"}')
+  t.assert.equal(stringify(obj), '{"foo":"true","ofoo":"42","arrfoo":"array,test","objfoo":"[object Object]"}')
 })
 
 test('patternProperties - number coerce', (t) => {
@@ -76,14 +76,14 @@ test('patternProperties - number coerce', (t) => {
   })
 
   const coercibleValues = { foo: true, ofoo: '42' }
-  t.equal(stringify(coercibleValues), '{"foo":1,"ofoo":42}')
+  t.assert.equal(stringify(coercibleValues), '{"foo":1,"ofoo":42}')
 
   const incoercibleValues = { xfoo: 'string', arrfoo: [1, 2], objfoo: { num: 42 } }
   try {
     stringify(incoercibleValues)
     t.fail('should throw an error')
   } catch (err) {
-    t.ok(err)
+    t.assert.ok(err)
   }
 })
 
@@ -101,7 +101,7 @@ test('patternProperties - boolean coerce', (t) => {
   })
 
   const obj = { foo: 'true', ofoo: 0, arrfoo: [1, 2], objfoo: { a: true } }
-  t.equal(stringify(obj), '{"foo":true,"ofoo":false,"arrfoo":true,"objfoo":true}')
+  t.assert.equal(stringify(obj), '{"foo":true,"ofoo":false,"arrfoo":true,"objfoo":true}')
 })
 
 test('patternProperties - object coerce', (t) => {
@@ -123,7 +123,7 @@ test('patternProperties - object coerce', (t) => {
   })
 
   const obj = { objfoo: { answer: 42 } }
-  t.equal(stringify(obj), '{"objfoo":{"answer":42}}')
+  t.assert.equal(stringify(obj), '{"objfoo":{"answer":42}}')
 })
 
 test('patternProperties - array coerce', (t) => {
@@ -143,16 +143,16 @@ test('patternProperties - array coerce', (t) => {
   })
 
   const coercibleValues = { arrfoo: [1, 2] }
-  t.equal(stringify(coercibleValues), '{"arrfoo":["1","2"]}')
+  t.assert.equal(stringify(coercibleValues), '{"arrfoo":["1","2"]}')
 
   const incoercibleValues = { foo: 'true', ofoo: 0, objfoo: { tyrion: 'lannister' } }
-  t.throws(() => stringify(incoercibleValues))
+  t.assert.throws(() => stringify(incoercibleValues))
 })
 
 test('patternProperties - fail on invalid regex, handled by ajv', (t) => {
   t.plan(1)
 
-  t.throws(() => build({
+  t.assert.throws(() => build({
     title: 'check array coerce',
     type: 'object',
     properties: {},

--- a/test/patternProperties.test.js
+++ b/test/patternProperties.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { equal, throws } = require('node:assert')
 const build = require('..')
 
-test('patternProperties', (t) => {
-  t.plan(1)
+describe('patternProperties', (t) => {
   const stringify = build({
     title: 'patternProperties',
     type: 'object',
@@ -21,11 +21,10 @@ test('patternProperties', (t) => {
   })
 
   const obj = { str: 'test', foo: 42, ofoo: true, foof: 'string', objfoo: { a: true }, notMe: false }
-  t.equal(stringify(obj), '{"str":"test","foo":"42","ofoo":"true","foof":"string","objfoo":"[object Object]"}')
+  equal(stringify(obj), '{"str":"test","foo":"42","ofoo":"true","foof":"string","objfoo":"[object Object]"}')
 })
 
-test('patternProperties should not change properties', (t) => {
-  t.plan(1)
+describe('patternProperties should not change properties', (t) => {
   const stringify = build({
     title: 'patternProperties should not change properties',
     type: 'object',
@@ -42,11 +41,10 @@ test('patternProperties should not change properties', (t) => {
   })
 
   const obj = { foo: '42', ofoo: 42 }
-  t.equal(stringify(obj), '{"foo":"42","ofoo":42}')
+  equal(stringify(obj), '{"foo":"42","ofoo":42}')
 })
 
-test('patternProperties - string coerce', (t) => {
-  t.plan(1)
+describe('patternProperties - string coerce', (t) => {
   const stringify = build({
     title: 'check string coerce',
     type: 'object',
@@ -59,11 +57,10 @@ test('patternProperties - string coerce', (t) => {
   })
 
   const obj = { foo: true, ofoo: 42, arrfoo: ['array', 'test'], objfoo: { a: 'world' } }
-  t.equal(stringify(obj), '{"foo":"true","ofoo":"42","arrfoo":"array,test","objfoo":"[object Object]"}')
+  equal(stringify(obj), '{"foo":"true","ofoo":"42","arrfoo":"array,test","objfoo":"[object Object]"}')
 })
 
-test('patternProperties - number coerce', (t) => {
-  t.plan(2)
+describe('patternProperties - number coerce', (t) => {
   const stringify = build({
     title: 'check number coerce',
     type: 'object',
@@ -76,19 +73,13 @@ test('patternProperties - number coerce', (t) => {
   })
 
   const coercibleValues = { foo: true, ofoo: '42' }
-  t.equal(stringify(coercibleValues), '{"foo":1,"ofoo":42}')
+  equal(stringify(coercibleValues), '{"foo":1,"ofoo":42}')
 
   const incoercibleValues = { xfoo: 'string', arrfoo: [1, 2], objfoo: { num: 42 } }
-  try {
-    stringify(incoercibleValues)
-    t.fail('should throw an error')
-  } catch (err) {
-    t.ok(err)
-  }
+  throws(() => stringify(incoercibleValues))
 })
 
-test('patternProperties - boolean coerce', (t) => {
-  t.plan(1)
+describe('patternProperties - boolean coerce', (t) => {
   const stringify = build({
     title: 'check boolean coerce',
     type: 'object',
@@ -101,11 +92,10 @@ test('patternProperties - boolean coerce', (t) => {
   })
 
   const obj = { foo: 'true', ofoo: 0, arrfoo: [1, 2], objfoo: { a: true } }
-  t.equal(stringify(obj), '{"foo":true,"ofoo":false,"arrfoo":true,"objfoo":true}')
+  equal(stringify(obj), '{"foo":true,"ofoo":false,"arrfoo":true,"objfoo":true}')
 })
 
-test('patternProperties - object coerce', (t) => {
-  t.plan(1)
+describe('patternProperties - object coerce', (t) => {
   const stringify = build({
     title: 'check object coerce',
     type: 'object',
@@ -123,11 +113,10 @@ test('patternProperties - object coerce', (t) => {
   })
 
   const obj = { objfoo: { answer: 42 } }
-  t.equal(stringify(obj), '{"objfoo":{"answer":42}}')
+  equal(stringify(obj), '{"objfoo":{"answer":42}}')
 })
 
-test('patternProperties - array coerce', (t) => {
-  t.plan(2)
+describe('patternProperties - array coerce', (t) => {
   const stringify = build({
     title: 'check array coerce',
     type: 'object',
@@ -143,16 +132,14 @@ test('patternProperties - array coerce', (t) => {
   })
 
   const coercibleValues = { arrfoo: [1, 2] }
-  t.equal(stringify(coercibleValues), '{"arrfoo":["1","2"]}')
+  equal(stringify(coercibleValues), '{"arrfoo":["1","2"]}')
 
   const incoercibleValues = { foo: 'true', ofoo: 0, objfoo: { tyrion: 'lannister' } }
-  t.throws(() => stringify(incoercibleValues))
+  throws(() => stringify(incoercibleValues))
 })
 
-test('patternProperties - fail on invalid regex, handled by ajv', (t) => {
-  t.plan(1)
-
-  t.throws(() => build({
+describe('patternProperties - fail on invalid regex, handled by ajv', (t) => {
+  throws(() => build({
     title: 'check array coerce',
     type: 'object',
     properties: {},

--- a/test/recursion.test.js
+++ b/test/recursion.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('can stringify recursive directory tree (issue #181)', (t) => {
@@ -25,7 +25,7 @@ test('can stringify recursive directory tree (issue #181)', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify([
+  t.assert.equal(stringify([
     { name: 'directory 1', subDirectories: [] },
     {
       name: 'directory 2',
@@ -68,7 +68,7 @@ test('can stringify when recursion in external schema', t => {
   })
 
   const value = stringify({ people: { name: 'Elizabeth', children: [{ name: 'Charles' }] } })
-  t.equal(value, '{"people":{"name":"Elizabeth","children":[{"name":"Charles"}]}}')
+  t.assert.equal(value, '{"people":{"name":"Elizabeth","children":[{"name":"Charles"}]}}')
 })
 
 test('use proper serialize function', t => {
@@ -133,7 +133,7 @@ test('use proper serialize function', t => {
       ]
     }
   })
-  t.equal(value, '{"people":{"name":"Elizabeth","children":[{"name":"Charles","children":[{"name":"William","children":[{"name":"George"},{"name":"Charlotte"}]},{"name":"Harry"}]}]},"directory":{"name":"directory 1","subDirectories":[{"name":"directory 1.1","subDirectories":[]},{"name":"directory 1.2","subDirectories":[{"name":"directory 1.2.1","subDirectories":[]},{"name":"directory 1.2.2","subDirectories":[]}]}]}}')
+  t.assert.equal(value, '{"people":{"name":"Elizabeth","children":[{"name":"Charles","children":[{"name":"William","children":[{"name":"George"},{"name":"Charlotte"}]},{"name":"Harry"}]}]},"directory":{"name":"directory 1","subDirectories":[{"name":"directory 1.1","subDirectories":[]},{"name":"directory 1.2","subDirectories":[{"name":"directory 1.2.1","subDirectories":[]},{"name":"directory 1.2.2","subDirectories":[]}]}]}}')
 })
 
 test('can stringify recursive references in object types (issue #365)', t => {
@@ -176,7 +176,7 @@ test('can stringify recursive references in object types (issue #365)', t => {
     }
   }
   const value = stringify(data)
-  t.equal(value, '{"category":{"parent":{"parent":{"parent":{"parent":{}}}}}}')
+  t.assert.equal(value, '{"category":{"parent":{"parent":{"parent":{"parent":{}}}}}}')
 })
 
 test('can stringify recursive inline $id references (issue #410)', t => {
@@ -241,5 +241,5 @@ test('can stringify recursive inline $id references (issue #410)', t => {
     ]
   }
   const value = stringify(data)
-  t.equal(value, '{"id":"0","nodes":[{"id":"1","nodes":[{"id":"2","nodes":[{"id":"3","nodes":[]},{"id":"4","nodes":[]},{"id":"5","nodes":[]}]}]},{"id":"6","nodes":[{"id":"7","nodes":[{"id":"8","nodes":[]},{"id":"9","nodes":[]},{"id":"10","nodes":[]}]}]},{"id":"11","nodes":[{"id":"12","nodes":[{"id":"13","nodes":[]},{"id":"14","nodes":[]},{"id":"15","nodes":[]}]}]}]}')
+  t.assert.equal(value, '{"id":"0","nodes":[{"id":"1","nodes":[{"id":"2","nodes":[{"id":"3","nodes":[]},{"id":"4","nodes":[]},{"id":"5","nodes":[]}]}]},{"id":"6","nodes":[{"id":"7","nodes":[{"id":"8","nodes":[]},{"id":"9","nodes":[]},{"id":"10","nodes":[]}]}]},{"id":"11","nodes":[{"id":"12","nodes":[{"id":"13","nodes":[]},{"id":"14","nodes":[]},{"id":"15","nodes":[]}]}]}]}')
 })

--- a/test/recursion.test.js
+++ b/test/recursion.test.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { equal } = require('node:assert')
 const build = require('..')
 
-test('can stringify recursive directory tree (issue #181)', (t) => {
-  t.plan(1)
-
+describe('can stringify recursive directory tree (issue #181)', (t) => {
   const schema = {
     definitions: {
       directory: {
@@ -25,7 +24,7 @@ test('can stringify recursive directory tree (issue #181)', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify([
+  equal(stringify([
     { name: 'directory 1', subDirectories: [] },
     {
       name: 'directory 2',
@@ -37,9 +36,7 @@ test('can stringify recursive directory tree (issue #181)', (t) => {
   ]), '[{"name":"directory 1","subDirectories":[]},{"name":"directory 2","subDirectories":[{"name":"directory 2.1","subDirectories":[]},{"name":"directory 2.2","subDirectories":[]}]}]')
 })
 
-test('can stringify when recursion in external schema', t => {
-  t.plan(1)
-
+describe('can stringify when recursion in external schema', t => {
   const referenceSchema = {
     $id: 'person',
     type: 'object',
@@ -68,12 +65,10 @@ test('can stringify when recursion in external schema', t => {
   })
 
   const value = stringify({ people: { name: 'Elizabeth', children: [{ name: 'Charles' }] } })
-  t.equal(value, '{"people":{"name":"Elizabeth","children":[{"name":"Charles"}]}}')
+  equal(value, '{"people":{"name":"Elizabeth","children":[{"name":"Charles"}]}}')
 })
 
-test('use proper serialize function', t => {
-  t.plan(1)
-
+describe('use proper serialize function', t => {
   const personSchema = {
     $id: 'person',
     type: 'object',
@@ -133,12 +128,10 @@ test('use proper serialize function', t => {
       ]
     }
   })
-  t.equal(value, '{"people":{"name":"Elizabeth","children":[{"name":"Charles","children":[{"name":"William","children":[{"name":"George"},{"name":"Charlotte"}]},{"name":"Harry"}]}]},"directory":{"name":"directory 1","subDirectories":[{"name":"directory 1.1","subDirectories":[]},{"name":"directory 1.2","subDirectories":[{"name":"directory 1.2.1","subDirectories":[]},{"name":"directory 1.2.2","subDirectories":[]}]}]}}')
+  equal(value, '{"people":{"name":"Elizabeth","children":[{"name":"Charles","children":[{"name":"William","children":[{"name":"George"},{"name":"Charlotte"}]},{"name":"Harry"}]}]},"directory":{"name":"directory 1","subDirectories":[{"name":"directory 1.1","subDirectories":[]},{"name":"directory 1.2","subDirectories":[{"name":"directory 1.2.1","subDirectories":[]},{"name":"directory 1.2.2","subDirectories":[]}]}]}}')
 })
 
-test('can stringify recursive references in object types (issue #365)', t => {
-  t.plan(1)
-
+describe('can stringify recursive references in object types (issue #365)', t => {
   const schema = {
     type: 'object',
     definitions: {
@@ -176,11 +169,10 @@ test('can stringify recursive references in object types (issue #365)', t => {
     }
   }
   const value = stringify(data)
-  t.equal(value, '{"category":{"parent":{"parent":{"parent":{"parent":{}}}}}}')
+  equal(value, '{"category":{"parent":{"parent":{"parent":{"parent":{}}}}}}')
 })
 
-test('can stringify recursive inline $id references (issue #410)', t => {
-  t.plan(1)
+describe('can stringify recursive inline $id references (issue #410)', t => {
   const schema = {
     $id: 'Node',
     type: 'object',
@@ -241,5 +233,5 @@ test('can stringify recursive inline $id references (issue #410)', t => {
     ]
   }
   const value = stringify(data)
-  t.equal(value, '{"id":"0","nodes":[{"id":"1","nodes":[{"id":"2","nodes":[{"id":"3","nodes":[]},{"id":"4","nodes":[]},{"id":"5","nodes":[]}]}]},{"id":"6","nodes":[{"id":"7","nodes":[{"id":"8","nodes":[]},{"id":"9","nodes":[]},{"id":"10","nodes":[]}]}]},{"id":"11","nodes":[{"id":"12","nodes":[{"id":"13","nodes":[]},{"id":"14","nodes":[]},{"id":"15","nodes":[]}]}]}]}')
+  equal(value, '{"id":"0","nodes":[{"id":"1","nodes":[{"id":"2","nodes":[{"id":"3","nodes":[]},{"id":"4","nodes":[]},{"id":"5","nodes":[]}]}]},{"id":"6","nodes":[{"id":"7","nodes":[{"id":"8","nodes":[]},{"id":"9","nodes":[]},{"id":"10","nodes":[]}]}]},{"id":"11","nodes":[{"id":"12","nodes":[{"id":"13","nodes":[]},{"id":"14","nodes":[]},{"id":"15","nodes":[]}]}]}]}')
 })

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -1,13 +1,11 @@
 'use strict'
 
 const clone = require('rfdc')({ proto: true })
-
-const test = require('tap').test
+const { describe, it } = require('node:test')
+const { equal, throws, doesNotThrow, deepStrictEqual } = require('node:assert')
 const build = require('..')
 
-test('ref internal - properties', (t) => {
-  t.plan(2)
-
+describe('ref internal - properties', (t) => {
   const schema = {
     title: 'object with $ref',
     definitions: {
@@ -38,14 +36,11 @@ test('ref internal - properties', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"obj":{"str":"test"}}')
+  equal(output, '{"obj":{"str":"test"}}')
 })
 
-test('ref internal - items', (t) => {
-  t.plan(2)
-
+describe('ref internal - items', (t) => {
   const schema = {
     title: 'array with $ref',
     definitions: {
@@ -70,14 +65,11 @@ test('ref internal - items', (t) => {
   const output = stringify(array)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '[{"str":"test"}]')
+  equal(output, '[{"str":"test"}]')
 })
 
-test('ref external - properties', (t) => {
-  t.plan(2)
-
+describe('ref external - properties', (t) => {
   const externalSchema = {
     first: require('./ref.json'),
     second: {
@@ -131,14 +123,11 @@ test('ref external - properties', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"obj":{"str":"test"},"num":{"int":42},"strPlain":"test","strHash":"test"}')
+  equal(output, '{"obj":{"str":"test"},"num":{"int":42},"strPlain":"test","strHash":"test"}')
 })
 
-test('ref internal - patternProperties', (t) => {
-  t.plan(2)
-
+describe('ref internal - patternProperties', (t) => {
   const schema = {
     title: 'object with $ref',
     definitions: {
@@ -170,14 +159,11 @@ test('ref internal - patternProperties', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"obj":{"str":"test"}}')
+  equal(output, '{"obj":{"str":"test"}}')
 })
 
-test('ref internal - additionalProperties', (t) => {
-  t.plan(2)
-
+describe('ref internal - additionalProperties', (t) => {
   const schema = {
     title: 'object with $ref',
     definitions: {
@@ -207,14 +193,11 @@ test('ref internal - additionalProperties', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"obj":{"str":"test"}}')
+  equal(output, '{"obj":{"str":"test"}}')
 })
 
-test('ref internal - pattern-additional Properties', (t) => {
-  t.plan(2)
-
+describe('ref internal - pattern-additional Properties', (t) => {
   const schema = {
     title: 'object with $ref',
     definitions: {
@@ -252,14 +235,11 @@ test('ref internal - pattern-additional Properties', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"reg":{"str":"test"},"obj":{"str":"test"}}')
+  equal(output, '{"reg":{"str":"test"},"obj":{"str":"test"}}')
 })
 
-test('ref external - pattern-additional Properties', (t) => {
-  t.plan(2)
-
+describe('ref external - pattern-additional Properties', (t) => {
   const externalSchema = {
     first: require('./ref.json'),
     second: {
@@ -303,14 +283,11 @@ test('ref external - pattern-additional Properties', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"reg":{"str":"test"},"obj":{"int":42}}')
+  equal(output, '{"reg":{"str":"test"},"obj":{"int":42}}')
 })
 
-test('ref internal - deepObject schema', (t) => {
-  t.plan(2)
-
+describe('ref internal - deepObject schema', (t) => {
   const schema = {
     title: 'object with $ref',
     definitions: {
@@ -355,14 +332,11 @@ test('ref internal - deepObject schema', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"winter":{"is":{"coming":{"where":"to town"}}}}')
+  equal(output, '{"winter":{"is":{"coming":{"where":"to town"}}}}')
 })
 
-test('ref internal - plain name fragment', (t) => {
-  t.plan(2)
-
+describe('ref internal - plain name fragment', (t) => {
   const schema = {
     title: 'object with $ref',
     definitions: {
@@ -395,14 +369,11 @@ test('ref internal - plain name fragment', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"obj":{"str":"test"}}')
+  equal(output, '{"obj":{"str":"test"}}')
 })
 
-test('ref external - plain name fragment', (t) => {
-  t.plan(2)
-
+describe('ref external - plain name fragment', (t) => {
   const externalSchema = {
     first: {
       $id: '#first-schema',
@@ -454,14 +425,11 @@ test('ref external - plain name fragment', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"first":{"str":"test"},"second":{"int":42}}')
+  equal(output, '{"first":{"str":"test"},"second":{"int":42}}')
 })
 
-test('external reference to $id', (t) => {
-  t.plan(2)
-
+describe('external reference to $id', (t) => {
   const externalSchema = {
     first: {
       $id: 'external-reference',
@@ -489,14 +457,11 @@ test('external reference to $id', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"first":{"str":"test"}}')
+  equal(output, '{"first":{"str":"test"}}')
 })
 
-test('external reference to key#id', (t) => {
-  t.plan(2)
-
+describe('external reference to key#id', (t) => {
   const externalSchema = {
     first: {
       $id: '#external-reference',
@@ -524,14 +489,11 @@ test('external reference to key#id', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"first":{"str":"test"}}')
+  equal(output, '{"first":{"str":"test"}}')
 })
 
-test('external and inner reference', (t) => {
-  t.plan(2)
-
+describe('external and inner reference', (t) => {
   const externalSchema = {
     first: {
       $id: 'reference',
@@ -565,14 +527,11 @@ test('external and inner reference', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"first":{"str":"test"}}')
+  equal(output, '{"first":{"str":"test"}}')
 })
 
-test('external reference to key', (t) => {
-  t.plan(2)
-
+describe('external reference to key', (t) => {
   const externalSchema = {
     first: {
       $id: 'external-reference',
@@ -600,14 +559,11 @@ test('external reference to key', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"first":{"str":"test"}}')
+  equal(output, '{"first":{"str":"test"}}')
 })
 
-test('ref external - plain name fragment', (t) => {
-  t.plan(2)
-
+describe('ref external - plain name fragment', (t) => {
   const externalSchema = {
     first: {
       $id: 'first-schema',
@@ -659,14 +615,11 @@ test('ref external - plain name fragment', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"first":{"str":"test"},"second":{"int":42}}')
+  equal(output, '{"first":{"str":"test"},"second":{"int":42}}')
 })
 
-test('ref external - duplicate plain name fragment', (t) => {
-  t.plan(2)
-
+describe('ref external - duplicate plain name fragment', (t) => {
   const externalSchema = {
     external: {
       $id: '#duplicateSchema',
@@ -731,14 +684,11 @@ test('ref external - duplicate plain name fragment', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"local":{"prop":"test"},"external":{"prop":true},"other":{"prop":42}}')
+  equal(output, '{"local":{"prop":"test"},"external":{"prop":true},"other":{"prop":42}}')
 })
 
-test('ref external - explicit external plain name fragment must not fallback to other external schemas', (t) => {
-  t.plan(1)
-
+describe('ref external - explicit external plain name fragment must not fallback to other external schemas', (t) => {
   const externalSchema = {
     first: {
       $id: '#target',
@@ -793,13 +743,10 @@ test('ref external - explicit external plain name fragment must not fallback to 
     JSON.parse(output)
     t.fail()
   } catch (e) {
-    t.pass()
   }
 })
 
-test('ref internal - multiple $ref format', (t) => {
-  t.plan(2)
-
+describe('ref internal - multiple $ref format', (t) => {
   const schema = {
     type: 'object',
     definitions: {
@@ -839,14 +786,11 @@ test('ref internal - multiple $ref format', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"zero":"test","a":"test","b":"test","c":"test","d":"test","e":"test"}')
+  equal(output, '{"zero":"test","a":"test","b":"test","c":"test","d":"test","e":"test"}')
 })
 
-test('ref external - external schema with internal ref (object property)', (t) => {
-  t.plan(2)
-
+describe('ref external - external schema with internal ref (object property)', (t) => {
   const externalSchema = {
     external: {
       definitions: {
@@ -881,14 +825,11 @@ test('ref external - external schema with internal ref (object property)', (t) =
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"obj":{"prop":"test"}}')
+  equal(output, '{"obj":{"prop":"test"}}')
 })
 
-test('ref external - external schema with internal ref (array items)', (t) => {
-  t.plan(2)
-
+describe('ref external - external schema with internal ref (array items)', (t) => {
   const externalSchema = {
     external: {
       definitions: {
@@ -926,14 +867,11 @@ test('ref external - external schema with internal ref (array items)', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"arr":[{"prop":"test"}]}')
+  equal(output, '{"arr":[{"prop":"test"}]}')
 })
 
-test('ref external - external schema with internal ref (root)', (t) => {
-  t.plan(2)
-
+describe('ref external - external schema with internal ref (root)', (t) => {
   const externalSchema = {
     external: {
       definitions: {
@@ -961,14 +899,11 @@ test('ref external - external schema with internal ref (root)', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"prop":"test"}')
+  equal(output, '{"prop":"test"}')
 })
 
-test('ref external - external schema with internal ref (pattern properties)', (t) => {
-  t.plan(2)
-
+describe('ref external - external schema with internal ref (pattern properties)', (t) => {
   const externalSchema = {
     external: {
       definitions: {
@@ -1003,14 +938,11 @@ test('ref external - external schema with internal ref (pattern properties)', (t
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"obj":{"prop":"test"}}')
+  equal(output, '{"obj":{"prop":"test"}}')
 })
 
-test('ref in root internal', (t) => {
-  t.plan(2)
-
+describe('ref in root internal', (t) => {
   const schema = {
     title: 'object with $ref in root schema',
     $ref: '#/definitions/num',
@@ -1034,14 +966,11 @@ test('ref in root internal', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"int":42}')
+  equal(output, '{"int":42}')
 })
 
-test('ref in root external', (t) => {
-  t.plan(2)
-
+describe('ref in root external', (t) => {
   const externalSchema = {
     numbers: {
       $id: 'numbers',
@@ -1069,14 +998,11 @@ test('ref in root external', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"int":42}')
+  equal(output, '{"int":42}')
 })
 
-test('ref in root external multiple times', (t) => {
-  t.plan(2)
-
+describe('ref in root external multiple times', (t) => {
   const externalSchema = {
     numbers: {
       $id: 'numbers',
@@ -1108,14 +1034,11 @@ test('ref in root external multiple times', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"int":42}')
+  equal(output, '{"int":42}')
 })
 
-test('ref external to relative definition', (t) => {
-  t.plan(2)
-
+describe('ref external to relative definition', (t) => {
   const externalSchema = {
     'relative:to:local': {
       $id: 'relative:to:local',
@@ -1142,14 +1065,11 @@ test('ref external to relative definition', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"fooParent":{"foo":"bar"}}')
+  equal(output, '{"fooParent":{"foo":"bar"}}')
 })
 
-test('ref to nested ref definition', (t) => {
-  t.plan(2)
-
+describe('ref to nested ref definition', (t) => {
   const externalSchema = {
     'a:b:c1': {
       $id: 'a:b:c1',
@@ -1180,14 +1100,12 @@ test('ref to nested ref definition', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, '{"foo":"foo"}')
+  equal(output, '{"foo":"foo"}')
 })
 
-test('Bad key', t => {
-  t.test('Find match', t => {
-    t.plan(1)
+describe('Bad key', t => {
+  it('Find match', t => {
     try {
       build({
         definitions: {
@@ -1207,12 +1125,11 @@ test('Bad key', t => {
       })
       t.fail('Should throw')
     } catch (err) {
-      t.equal(err.message, 'Cannot find reference "#/definitions/porjectId"')
+      equal(err.message, 'Cannot find reference "#/definitions/porjectId"')
     }
   })
 
-  t.test('No match', t => {
-    t.plan(1)
+  it('No match', t => {
     try {
       build({
         definitions: {
@@ -1232,12 +1149,11 @@ test('Bad key', t => {
       })
       t.fail('Should throw')
     } catch (err) {
-      t.equal(err.message, 'Cannot find reference "#/definitions/foobar"')
+      equal(err.message, 'Cannot find reference "#/definitions/foobar"')
     }
   })
 
-  t.test('Find match (external schema)', t => {
-    t.plan(1)
+  it('Find match (external schema)', t => {
     try {
       build({
         type: 'object',
@@ -1262,12 +1178,11 @@ test('Bad key', t => {
       })
       t.fail('Should throw')
     } catch (err) {
-      t.equal(err.message, 'Cannot find reference "external#/definitions/porjectId"')
+      equal(err.message, 'Cannot find reference "external#/definitions/porjectId"')
     }
   })
 
-  t.test('No match (external schema)', t => {
-    t.plan(1)
+  it('No match (external schema)', t => {
     try {
       build({
         type: 'object',
@@ -1292,12 +1207,11 @@ test('Bad key', t => {
       })
       t.fail('Should throw')
     } catch (err) {
-      t.equal(err.message, 'Cannot find reference "external#/definitions/foobar"')
+      equal(err.message, 'Cannot find reference "external#/definitions/foobar"')
     }
   })
 
-  t.test('Find match (external definitions typo)', t => {
-    t.plan(1)
+  it('Find match (external definitions typo)', t => {
     try {
       build({
         type: 'object',
@@ -1322,12 +1236,11 @@ test('Bad key', t => {
       })
       t.fail('Should throw')
     } catch (err) {
-      t.equal(err.message, 'Cannot find reference "external#/deifnitions/projectId"')
+      equal(err.message, 'Cannot find reference "external#/deifnitions/projectId"')
     }
   })
 
-  t.test('Find match (definitions typo)', t => {
-    t.plan(1)
+  it('Find match (definitions typo)', t => {
     try {
       build({
         definitions: {
@@ -1347,12 +1260,11 @@ test('Bad key', t => {
       })
       t.fail('Should throw')
     } catch (err) {
-      t.equal(err.message, 'Cannot find reference "#/deifnitions/projectId"')
+      equal(err.message, 'Cannot find reference "#/deifnitions/projectId"')
     }
   })
 
-  t.test('Find match (external schema typo)', t => {
-    t.plan(1)
+  it('Find match (external schema typo)', t => {
     try {
       build({
         type: 'object',
@@ -1377,19 +1289,15 @@ test('Bad key', t => {
       })
       t.fail('Should throw')
     } catch (err) {
-      t.equal(
+      equal(
         err.message,
         'Cannot resolve ref "extrenal#/definitions/projectId". Schema with id "extrenal" is not found.'
       )
     }
   })
-
-  t.end()
 })
 
-test('Regression 2.5.2', t => {
-  t.plan(1)
-
+describe('Regression 2.5.2', t => {
   const externalSchema = {
     '/models/Bar': {
       $id: '/models/Bar',
@@ -1431,12 +1339,10 @@ test('Regression 2.5.2', t => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify([{ field: 'parent', sub: { field: 'joined' } }])
 
-  t.equal(output, '[{"field":"parent","sub":{"field":"joined"}}]')
+  equal(output, '[{"field":"parent","sub":{"field":"joined"}}]')
 })
 
-test('Reference through multiple definitions', (t) => {
-  t.plan(2)
-
+describe('Reference through multiple definitions', (t) => {
   const schema = {
     $ref: '#/definitions/A',
     definitions: {
@@ -1467,14 +1373,11 @@ test('Reference through multiple definitions', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, JSON.stringify(object))
+  equal(output, JSON.stringify(object))
 })
 
-test('issue #350', (t) => {
-  t.plan(2)
-
+describe('issue #350', (t) => {
   const schema = {
     title: 'Example Schema',
     type: 'object',
@@ -1510,14 +1413,11 @@ test('issue #350', (t) => {
   const output = stringify(object)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(output, JSON.stringify(object))
+  equal(output, JSON.stringify(object))
 })
 
-test('deep union type', (t) => {
-  t.plan(1)
-
+describe('deep union type', (t) => {
   const stringify = build({
     schema: {
       type: 'array',
@@ -1759,12 +1659,10 @@ test('deep union type', (t) => {
       ]
     }
   ]
-  t.equal(JSON.stringify(obj), stringify(obj))
+  equal(JSON.stringify(obj), stringify(obj))
 })
 
-test('ref with same id in properties', (t) => {
-  t.plan(2)
-
+describe('ref with same id in properties', (t) => {
   const externalSchema = {
     ObjectId: {
       $id: 'ObjectId',
@@ -1781,9 +1679,7 @@ test('ref with same id in properties', (t) => {
     }
   }
 
-  t.test('anyOf', (t) => {
-    t.plan(1)
-
+  it('anyOf', (t) => {
     const schema = {
       $id: 'Article',
       type: 'object',
@@ -1801,12 +1697,10 @@ test('ref with same id in properties', (t) => {
     const stringify = build(schema, { schema: externalSchema })
     const output = stringify({ _id: 'foo', image: { _id: 'bar', name: 'hello', owner: 'baz' } })
 
-    t.equal(output, '{"_id":"foo","image":{"_id":"bar","name":"hello","owner":"baz"}}')
+    equal(output, '{"_id":"foo","image":{"_id":"bar","name":"hello","owner":"baz"}}')
   })
 
-  t.test('oneOf', (t) => {
-    t.plan(1)
-
+  it('oneOf', (t) => {
     const schema = {
       $id: 'Article',
       type: 'object',
@@ -1824,13 +1718,11 @@ test('ref with same id in properties', (t) => {
     const stringify = build(schema, { schema: externalSchema })
     const output = stringify({ _id: 'foo', image: { _id: 'bar', name: 'hello', owner: 'baz' } })
 
-    t.equal(output, '{"_id":"foo","image":{"_id":"bar","name":"hello","owner":"baz"}}')
+    equal(output, '{"_id":"foo","image":{"_id":"bar","name":"hello","owner":"baz"}}')
   })
 })
 
-test('Should not modify external schemas', (t) => {
-  t.plan(2)
-
+describe('Should not modify external schemas', (t) => {
   const externalSchema = {
     uuid: {
       format: 'uuid',
@@ -1855,13 +1747,11 @@ test('Should not modify external schemas', (t) => {
   const data = { id: 'a4e4c954-9f5f-443a-aa65-74d95732249a' }
   const output = stringify(data)
 
-  t.equal(output, JSON.stringify(data))
-  t.same(options, optionsClone)
+  equal(output, JSON.stringify(data))
+  deepStrictEqual(options, optionsClone)
 })
 
-test('input schema is not mutated', (t) => {
-  t.plan(3)
-
+describe('input schema is not mutated', (t) => {
   const schema = {
     title: 'object with $ref',
     type: 'object',
@@ -1884,20 +1774,13 @@ test('input schema is not mutated', (t) => {
   const stringify = build(schema)
   const output = stringify(object)
 
-  try {
-    JSON.parse(output)
-    t.pass()
-  } catch (e) {
-    t.fail()
-  }
+  doesNotThrow(() => JSON.parse(output))
 
-  t.equal(output, '{"obj":"test"}')
-  t.same(schema, clonedSchema)
+  equal(output, '{"obj":"test"}')
+  deepStrictEqual(schema, clonedSchema)
 })
 
-test('anyOf inside allOf', (t) => {
-  t.plan(1)
-
+describe('anyOf inside allOf', (t) => {
   const schema = {
     anyOf: [
       {
@@ -1927,12 +1810,10 @@ test('anyOf inside allOf', (t) => {
   const stringify = build(schema)
   const output = stringify(object)
 
-  t.equal(output, JSON.stringify(object))
+  equal(output, JSON.stringify(object))
 })
 
-test('should resolve absolute $refs', (t) => {
-  t.plan(1)
-
+describe('should resolve absolute $refs', (t) => {
   const externalSchema = {
     FooSchema: {
       $id: 'FooSchema',
@@ -1954,12 +1835,10 @@ test('should resolve absolute $refs', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  t.equal(output, JSON.stringify(object))
+  equal(output, JSON.stringify(object))
 })
 
-test('nested schema should overwrite anchor scope', (t) => {
-  t.plan(2)
-
+describe('nested schema should overwrite anchor scope', (t) => {
   const externalSchema = {
     root: {
       $id: 'root',
@@ -1981,13 +1860,11 @@ test('nested schema should overwrite anchor scope', (t) => {
   const stringify = build({ $ref: 'subschema#anchor' }, { schema: externalSchema })
   const output = stringify(data)
 
-  t.equal(output, JSON.stringify(data))
-  t.throws(() => build({ $ref: 'root#anchor' }, { schema: externalSchema }))
+  equal(output, JSON.stringify(data))
+  throws(() => build({ $ref: 'root#anchor' }, { schema: externalSchema }))
 })
 
-test('object property reference with default value', (t) => {
-  t.plan(1)
-
+describe('object property reference with default value', (t) => {
   const schema = {
     definitions: {
       prop: {
@@ -2006,12 +1883,10 @@ test('object property reference with default value', (t) => {
   const stringify = build(schema)
   const output = stringify({})
 
-  t.equal(output, '{"prop":"foo"}')
+  equal(output, '{"prop":"foo"}')
 })
 
-test('should throw an Error if two non-identical schemas with same id are provided', (t) => {
-  t.plan(1)
-
+describe('should throw an Error if two non-identical schemas with same id are provided', (t) => {
   const schema = {
     $id: 'schema',
     type: 'object',
@@ -2082,13 +1957,11 @@ test('should throw an Error if two non-identical schemas with same id are provid
   try {
     build(schema)
   } catch (err) {
-    t.equal(err.message, 'There is already another schema with id "inner_schema".')
+    equal(err.message, 'There is already another schema with id "inner_schema".')
   }
 })
 
-test('ref internal - throw if schema has definition twice with different shape', (t) => {
-  t.plan(1)
-
+describe('ref internal - throw if schema has definition twice with different shape', (t) => {
   const schema = {
     $id: 'test',
     title: 'object with $ref',
@@ -2125,6 +1998,6 @@ test('ref internal - throw if schema has definition twice with different shape',
   try {
     build(schema)
   } catch (err) {
-    t.equal(err.message, 'There is already another anchor "#uri" in a schema "test".')
+    equal(err.message, 'There is already another anchor "#uri" in a schema "test".')
   }
 })

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -2,7 +2,7 @@
 
 const clone = require('rfdc')({ proto: true })
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('ref internal - properties', (t) => {
@@ -37,10 +37,8 @@ test('ref internal - properties', (t) => {
   const stringify = build(schema)
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"obj":{"str":"test"}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"obj":{"str":"test"}}')
 })
 
 test('ref internal - items', (t) => {
@@ -69,10 +67,8 @@ test('ref internal - items', (t) => {
   const stringify = build(schema)
   const output = stringify(array)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '[{"str":"test"}]')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '[{"str":"test"}]')
 })
 
 test('ref external - properties', (t) => {
@@ -130,10 +126,8 @@ test('ref external - properties', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"obj":{"str":"test"},"num":{"int":42},"strPlain":"test","strHash":"test"}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"obj":{"str":"test"},"num":{"int":42},"strPlain":"test","strHash":"test"}')
 })
 
 test('ref internal - patternProperties', (t) => {
@@ -169,10 +163,8 @@ test('ref internal - patternProperties', (t) => {
   const stringify = build(schema)
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"obj":{"str":"test"}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"obj":{"str":"test"}}')
 })
 
 test('ref internal - additionalProperties', (t) => {
@@ -206,10 +198,8 @@ test('ref internal - additionalProperties', (t) => {
   const stringify = build(schema)
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"obj":{"str":"test"}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"obj":{"str":"test"}}')
 })
 
 test('ref internal - pattern-additional Properties', (t) => {
@@ -251,10 +241,8 @@ test('ref internal - pattern-additional Properties', (t) => {
   const stringify = build(schema)
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"reg":{"str":"test"},"obj":{"str":"test"}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"reg":{"str":"test"},"obj":{"str":"test"}}')
 })
 
 test('ref external - pattern-additional Properties', (t) => {
@@ -302,10 +290,8 @@ test('ref external - pattern-additional Properties', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"reg":{"str":"test"},"obj":{"int":42}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"reg":{"str":"test"},"obj":{"int":42}}')
 })
 
 test('ref internal - deepObject schema', (t) => {
@@ -354,10 +340,8 @@ test('ref internal - deepObject schema', (t) => {
   const stringify = build(schema)
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"winter":{"is":{"coming":{"where":"to town"}}}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"winter":{"is":{"coming":{"where":"to town"}}}}')
 })
 
 test('ref internal - plain name fragment', (t) => {
@@ -394,10 +378,8 @@ test('ref internal - plain name fragment', (t) => {
   const stringify = build(schema)
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"obj":{"str":"test"}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"obj":{"str":"test"}}')
 })
 
 test('ref external - plain name fragment', (t) => {
@@ -453,10 +435,8 @@ test('ref external - plain name fragment', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"first":{"str":"test"},"second":{"int":42}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"first":{"str":"test"},"second":{"int":42}}')
 })
 
 test('external reference to $id', (t) => {
@@ -488,10 +468,8 @@ test('external reference to $id', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"first":{"str":"test"}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"first":{"str":"test"}}')
 })
 
 test('external reference to key#id', (t) => {
@@ -523,10 +501,8 @@ test('external reference to key#id', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"first":{"str":"test"}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"first":{"str":"test"}}')
 })
 
 test('external and inner reference', (t) => {
@@ -564,10 +540,8 @@ test('external and inner reference', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"first":{"str":"test"}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"first":{"str":"test"}}')
 })
 
 test('external reference to key', (t) => {
@@ -599,10 +573,8 @@ test('external reference to key', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"first":{"str":"test"}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"first":{"str":"test"}}')
 })
 
 test('ref external - plain name fragment', (t) => {
@@ -658,10 +630,8 @@ test('ref external - plain name fragment', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"first":{"str":"test"},"second":{"int":42}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"first":{"str":"test"},"second":{"int":42}}')
 })
 
 test('ref external - duplicate plain name fragment', (t) => {
@@ -730,10 +700,8 @@ test('ref external - duplicate plain name fragment', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"local":{"prop":"test"},"external":{"prop":true},"other":{"prop":42}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"local":{"prop":"test"},"external":{"prop":true},"other":{"prop":42}}')
 })
 
 test('ref external - explicit external plain name fragment must not fallback to other external schemas', (t) => {
@@ -787,14 +755,13 @@ test('ref external - explicit external plain name fragment must not fallback to 
     }
   }
 
-  try {
+  t.assert.throws(() => {
     const stringify = build(schema, { schema: externalSchema })
     const output = stringify(object)
     JSON.parse(output)
-    t.fail()
-  } catch (e) {
-    t.pass()
-  }
+  }, {
+    message: 'Cannot find reference "first#wrong"'
+  })
 })
 
 test('ref internal - multiple $ref format', (t) => {
@@ -838,10 +805,8 @@ test('ref internal - multiple $ref format', (t) => {
   const stringify = build(schema)
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"zero":"test","a":"test","b":"test","c":"test","d":"test","e":"test"}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"zero":"test","a":"test","b":"test","c":"test","d":"test","e":"test"}')
 })
 
 test('ref external - external schema with internal ref (object property)', (t) => {
@@ -880,10 +845,8 @@ test('ref external - external schema with internal ref (object property)', (t) =
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"obj":{"prop":"test"}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"obj":{"prop":"test"}}')
 })
 
 test('ref external - external schema with internal ref (array items)', (t) => {
@@ -925,10 +888,8 @@ test('ref external - external schema with internal ref (array items)', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"arr":[{"prop":"test"}]}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"arr":[{"prop":"test"}]}')
 })
 
 test('ref external - external schema with internal ref (root)', (t) => {
@@ -960,10 +921,8 @@ test('ref external - external schema with internal ref (root)', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"prop":"test"}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"prop":"test"}')
 })
 
 test('ref external - external schema with internal ref (pattern properties)', (t) => {
@@ -1002,10 +961,8 @@ test('ref external - external schema with internal ref (pattern properties)', (t
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"obj":{"prop":"test"}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"obj":{"prop":"test"}}')
 })
 
 test('ref in root internal', (t) => {
@@ -1033,10 +990,8 @@ test('ref in root internal', (t) => {
   const stringify = build(schema)
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"int":42}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"int":42}')
 })
 
 test('ref in root external', (t) => {
@@ -1068,10 +1023,8 @@ test('ref in root external', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"int":42}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"int":42}')
 })
 
 test('ref in root external multiple times', (t) => {
@@ -1107,10 +1060,8 @@ test('ref in root external multiple times', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"int":42}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"int":42}')
 })
 
 test('ref external to relative definition', (t) => {
@@ -1141,10 +1092,8 @@ test('ref external to relative definition', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"fooParent":{"foo":"bar"}}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"fooParent":{"foo":"bar"}}')
 })
 
 test('ref to nested ref definition', (t) => {
@@ -1179,14 +1128,12 @@ test('ref to nested ref definition', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, '{"foo":"foo"}')
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"foo":"foo"}')
 })
 
-test('Bad key', t => {
-  t.test('Find match', t => {
+test('Bad key', async t => {
+  await t.test('Find match', t => {
     t.plan(1)
     try {
       build({
@@ -1207,13 +1154,14 @@ test('Bad key', t => {
       })
       t.fail('Should throw')
     } catch (err) {
-      t.equal(err.message, 'Cannot find reference "#/definitions/porjectId"')
+      t.assert.equal(err.message, 'Cannot find reference "#/definitions/porjectId"')
     }
   })
 
-  t.test('No match', t => {
+  await t.test('No match', t => {
     t.plan(1)
-    try {
+
+    t.assert.throws(() => {
       build({
         definitions: {
           projectId: {
@@ -1230,15 +1178,12 @@ test('Bad key', t => {
           }
         }
       })
-      t.fail('Should throw')
-    } catch (err) {
-      t.equal(err.message, 'Cannot find reference "#/definitions/foobar"')
-    }
+    }, { message: 'Cannot find reference "#/definitions/foobar"' })
   })
 
-  t.test('Find match (external schema)', t => {
+  await t.test('Find match (external schema)', t => {
     t.plan(1)
-    try {
+    t.assert.throws(() => {
       build({
         type: 'object',
         properties: {
@@ -1261,14 +1206,12 @@ test('Bad key', t => {
         }
       })
       t.fail('Should throw')
-    } catch (err) {
-      t.equal(err.message, 'Cannot find reference "external#/definitions/porjectId"')
-    }
+    }, { message: 'Cannot find reference "external#/definitions/porjectId"' })
   })
 
-  t.test('No match (external schema)', t => {
+  await t.test('No match (external schema)', t => {
     t.plan(1)
-    try {
+    t.assert.throws(() => {
       build({
         type: 'object',
         properties: {
@@ -1290,15 +1233,12 @@ test('Bad key', t => {
           }
         }
       })
-      t.fail('Should throw')
-    } catch (err) {
-      t.equal(err.message, 'Cannot find reference "external#/definitions/foobar"')
-    }
+    }, { message: 'Cannot find reference "external#/definitions/foobar"' })
   })
 
-  t.test('Find match (external definitions typo)', t => {
+  await t.test('Find match (external definitions typo)', t => {
     t.plan(1)
-    try {
+    t.assert.throws(() => {
       build({
         type: 'object',
         properties: {
@@ -1320,15 +1260,12 @@ test('Bad key', t => {
           }
         }
       })
-      t.fail('Should throw')
-    } catch (err) {
-      t.equal(err.message, 'Cannot find reference "external#/deifnitions/projectId"')
-    }
+    }, { message: 'Cannot find reference "external#/deifnitions/projectId"' })
   })
 
-  t.test('Find match (definitions typo)', t => {
+  await t.test('Find match (definitions typo)', t => {
     t.plan(1)
-    try {
+    t.assert.throws(() => {
       build({
         definitions: {
           projectId: {
@@ -1345,15 +1282,12 @@ test('Bad key', t => {
           }
         }
       })
-      t.fail('Should throw')
-    } catch (err) {
-      t.equal(err.message, 'Cannot find reference "#/deifnitions/projectId"')
-    }
+    }, { message: 'Cannot find reference "#/deifnitions/projectId"' })
   })
 
-  t.test('Find match (external schema typo)', t => {
+  await t.test('Find match (external schema typo)', t => {
     t.plan(1)
-    try {
+    t.assert.throws(() => {
       build({
         type: 'object',
         properties: {
@@ -1375,16 +1309,8 @@ test('Bad key', t => {
           }
         }
       })
-      t.fail('Should throw')
-    } catch (err) {
-      t.equal(
-        err.message,
-        'Cannot resolve ref "extrenal#/definitions/projectId". Schema with id "extrenal" is not found.'
-      )
-    }
+    }, { message: 'Cannot resolve ref "extrenal#/definitions/projectId". Schema with id "extrenal" is not found.' })
   })
-
-  t.end()
 })
 
 test('Regression 2.5.2', t => {
@@ -1431,7 +1357,7 @@ test('Regression 2.5.2', t => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify([{ field: 'parent', sub: { field: 'joined' } }])
 
-  t.equal(output, '[{"field":"parent","sub":{"field":"joined"}}]')
+  t.assert.equal(output, '[{"field":"parent","sub":{"field":"joined"}}]')
 })
 
 test('Reference through multiple definitions', (t) => {
@@ -1466,10 +1392,8 @@ test('Reference through multiple definitions', (t) => {
   const stringify = build(schema)
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, JSON.stringify(object))
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, JSON.stringify(object))
 })
 
 test('issue #350', (t) => {
@@ -1509,10 +1433,8 @@ test('issue #350', (t) => {
   const stringify = build(schema)
   const output = stringify(object)
 
-  JSON.parse(output)
-  t.pass()
-
-  t.equal(output, JSON.stringify(object))
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, JSON.stringify(object))
 })
 
 test('deep union type', (t) => {
@@ -1759,10 +1681,10 @@ test('deep union type', (t) => {
       ]
     }
   ]
-  t.equal(JSON.stringify(obj), stringify(obj))
+  t.assert.equal(JSON.stringify(obj), stringify(obj))
 })
 
-test('ref with same id in properties', (t) => {
+test('ref with same id in properties', async (t) => {
   t.plan(2)
 
   const externalSchema = {
@@ -1781,7 +1703,7 @@ test('ref with same id in properties', (t) => {
     }
   }
 
-  t.test('anyOf', (t) => {
+  await t.test('anyOf', (t) => {
     t.plan(1)
 
     const schema = {
@@ -1801,10 +1723,10 @@ test('ref with same id in properties', (t) => {
     const stringify = build(schema, { schema: externalSchema })
     const output = stringify({ _id: 'foo', image: { _id: 'bar', name: 'hello', owner: 'baz' } })
 
-    t.equal(output, '{"_id":"foo","image":{"_id":"bar","name":"hello","owner":"baz"}}')
+    t.assert.equal(output, '{"_id":"foo","image":{"_id":"bar","name":"hello","owner":"baz"}}')
   })
 
-  t.test('oneOf', (t) => {
+  await t.test('oneOf', (t) => {
     t.plan(1)
 
     const schema = {
@@ -1824,7 +1746,7 @@ test('ref with same id in properties', (t) => {
     const stringify = build(schema, { schema: externalSchema })
     const output = stringify({ _id: 'foo', image: { _id: 'bar', name: 'hello', owner: 'baz' } })
 
-    t.equal(output, '{"_id":"foo","image":{"_id":"bar","name":"hello","owner":"baz"}}')
+    t.assert.equal(output, '{"_id":"foo","image":{"_id":"bar","name":"hello","owner":"baz"}}')
   })
 })
 
@@ -1855,8 +1777,8 @@ test('Should not modify external schemas', (t) => {
   const data = { id: 'a4e4c954-9f5f-443a-aa65-74d95732249a' }
   const output = stringify(data)
 
-  t.equal(output, JSON.stringify(data))
-  t.same(options, optionsClone)
+  t.assert.equal(output, JSON.stringify(data))
+  t.assert.deepStrictEqual(options, optionsClone)
 })
 
 test('input schema is not mutated', (t) => {
@@ -1884,15 +1806,9 @@ test('input schema is not mutated', (t) => {
   const stringify = build(schema)
   const output = stringify(object)
 
-  try {
-    JSON.parse(output)
-    t.pass()
-  } catch (e) {
-    t.fail()
-  }
-
-  t.equal(output, '{"obj":"test"}')
-  t.same(schema, clonedSchema)
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"obj":"test"}')
+  t.assert.deepStrictEqual(schema, clonedSchema)
 })
 
 test('anyOf inside allOf', (t) => {
@@ -1927,7 +1843,7 @@ test('anyOf inside allOf', (t) => {
   const stringify = build(schema)
   const output = stringify(object)
 
-  t.equal(output, JSON.stringify(object))
+  t.assert.equal(output, JSON.stringify(object))
 })
 
 test('should resolve absolute $refs', (t) => {
@@ -1954,7 +1870,7 @@ test('should resolve absolute $refs', (t) => {
   const stringify = build(schema, { schema: externalSchema })
   const output = stringify(object)
 
-  t.equal(output, JSON.stringify(object))
+  t.assert.equal(output, JSON.stringify(object))
 })
 
 test('nested schema should overwrite anchor scope', (t) => {
@@ -1981,8 +1897,8 @@ test('nested schema should overwrite anchor scope', (t) => {
   const stringify = build({ $ref: 'subschema#anchor' }, { schema: externalSchema })
   const output = stringify(data)
 
-  t.equal(output, JSON.stringify(data))
-  t.throws(() => build({ $ref: 'root#anchor' }, { schema: externalSchema }))
+  t.assert.equal(output, JSON.stringify(data))
+  t.assert.throws(() => build({ $ref: 'root#anchor' }, { schema: externalSchema }))
 })
 
 test('object property reference with default value', (t) => {
@@ -2006,7 +1922,7 @@ test('object property reference with default value', (t) => {
   const stringify = build(schema)
   const output = stringify({})
 
-  t.equal(output, '{"prop":"foo"}')
+  t.assert.equal(output, '{"prop":"foo"}')
 })
 
 test('should throw an Error if two non-identical schemas with same id are provided', (t) => {
@@ -2082,7 +1998,7 @@ test('should throw an Error if two non-identical schemas with same id are provid
   try {
     build(schema)
   } catch (err) {
-    t.equal(err.message, 'There is already another schema with id "inner_schema".')
+    t.assert.equal(err.message, 'There is already another schema with id "inner_schema".')
   }
 })
 
@@ -2125,6 +2041,6 @@ test('ref internal - throw if schema has definition twice with different shape',
   try {
     build(schema)
   } catch (err) {
-    t.equal(err.message, 'There is already another anchor "#uri" in a schema "test".')
+    t.assert.equal(err.message, 'There is already another anchor "#uri" in a schema "test".')
   }
 })

--- a/test/regex.test.js
+++ b/test/regex.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const validator = require('is-my-json-valid')
 const build = require('..')
 
@@ -25,9 +25,8 @@ test('object with RexExp', (t) => {
   const validate = validator(schema)
   const output = stringify(obj)
 
-  JSON.parse(output)
-  t.pass()
+  t.assert.doesNotThrow(() => JSON.parse(output))
 
-  t.equal(obj.reg.source, new RegExp(JSON.parse(output).reg).source)
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(obj.reg.source, new RegExp(JSON.parse(output).reg).source)
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })

--- a/test/regex.test.js
+++ b/test/regex.test.js
@@ -1,12 +1,11 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { equal, ok } = require('node:assert')
 const validator = require('is-my-json-valid')
 const build = require('..')
 
-test('object with RexExp', (t) => {
-  t.plan(3)
-
+describe('object with RexExp', (t) => {
   const schema = {
     title: 'object with RegExp',
     type: 'object',
@@ -26,8 +25,7 @@ test('object with RexExp', (t) => {
   const output = stringify(obj)
 
   JSON.parse(output)
-  t.pass()
 
-  t.equal(obj.reg.source, new RegExp(JSON.parse(output).reg).source)
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(obj.reg.source, new RegExp(JSON.parse(output).reg).source)
+  ok(validate(JSON.parse(output)), 'valid schema')
 })

--- a/test/required.test.js
+++ b/test/required.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('object with required field', (t) => {
-  t.plan(3)
+  t.plan(2)
 
   const schema = {
     title: 'object with required field',
@@ -21,24 +21,21 @@ test('object with required field', (t) => {
   }
   const stringify = build(schema)
 
-  stringify({
-    str: 'string'
+  t.assert.doesNotThrow(() => {
+    stringify({
+      str: 'string'
+    })
   })
-  t.pass()
 
-  try {
+  t.assert.throws(() => {
     stringify({
       num: 42
     })
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"str" is required!')
-    t.pass()
-  }
+  }, { message: '"str" is required!' })
 })
 
 test('object with required field not in properties schema', (t) => {
-  t.plan(4)
+  t.plan(2)
 
   const schema = {
     title: 'object with required field',
@@ -52,27 +49,19 @@ test('object with required field not in properties schema', (t) => {
   }
   const stringify = build(schema)
 
-  try {
+  t.assert.throws(() => {
     stringify({})
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"str" is required!')
-    t.pass()
-  }
+  }, { message: '"str" is required!' })
 
-  try {
+  t.assert.throws(() => {
     stringify({
       num: 42
     })
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"str" is required!')
-    t.pass()
-  }
+  }, { message: '"str" is required!' })
 })
 
 test('object with required field not in properties schema with additional properties true', (t) => {
-  t.plan(4)
+  t.plan(2)
 
   const schema = {
     title: 'object with required field',
@@ -87,27 +76,19 @@ test('object with required field not in properties schema with additional proper
   }
   const stringify = build(schema)
 
-  try {
+  t.assert.throws(() => {
     stringify({})
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"str" is required!')
-    t.pass()
-  }
+  }, { message: '"str" is required!' })
 
-  try {
+  t.assert.throws(() => {
     stringify({
       num: 42
     })
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"str" is required!')
-    t.pass()
-  }
+  }, { message: '"str" is required!' })
 })
 
 test('object with multiple required field not in properties schema', (t) => {
-  t.plan(6)
+  t.plan(3)
 
   const schema = {
     title: 'object with required field',
@@ -122,35 +103,23 @@ test('object with multiple required field not in properties schema', (t) => {
   }
   const stringify = build(schema)
 
-  try {
+  t.assert.throws(() => {
     stringify({})
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"key1" is required!')
-    t.pass()
-  }
+  }, { message: '"key1" is required!' })
 
-  try {
+  t.assert.throws(() => {
     stringify({
       key1: 42,
       key2: 42
     })
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"num" is required!')
-    t.pass()
-  }
+  }, { message: '"num" is required!' })
 
-  try {
+  t.assert.throws(() => {
     stringify({
       num: 42,
       key1: 'some'
     })
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"key2" is required!')
-    t.pass()
-  }
+  }, { message: '"key2" is required!' })
 })
 
 test('object with required bool', (t) => {
@@ -169,16 +138,14 @@ test('object with required bool', (t) => {
   }
   const stringify = build(schema)
 
-  try {
+  t.assert.throws(() => {
     stringify({})
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"bool" is required!')
-    t.pass()
-  }
+  }, { message: '"bool" is required!' })
 
-  stringify({
-    bool: false
+  t.assert.doesNotThrow(() => {
+    stringify({
+      bool: false
+    })
   })
 })
 
@@ -198,14 +165,15 @@ test('required nullable', (t) => {
   }
   const stringify = build(schema)
 
-  stringify({
-    null: null
+  t.assert.doesNotThrow(() => {
+    stringify({
+      null: null
+    })
   })
-  t.pass()
 })
 
 test('required numbers', (t) => {
-  t.plan(3)
+  t.plan(2)
 
   const schema = {
     title: 'object with required field',
@@ -222,18 +190,15 @@ test('required numbers', (t) => {
   }
   const stringify = build(schema)
 
-  stringify({
-    num: 42
+  t.assert.doesNotThrow(() => {
+    stringify({
+      num: 42
+    })
   })
-  t.pass()
 
-  try {
+  t.assert.throws(() => {
     stringify({
       num: 'aaa'
     })
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, 'The value "aaa" cannot be converted to an integer.')
-    t.pass()
-  }
+  }, { message: 'The value "aaa" cannot be converted to an integer.' })
 })

--- a/test/required.test.js
+++ b/test/required.test.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { throws } = require('node:assert')
 const build = require('..')
 
-test('object with required field', (t) => {
-  t.plan(3)
-
+describe('object with required field', (t) => {
   const schema = {
     title: 'object with required field',
     type: 'object',
@@ -24,22 +23,15 @@ test('object with required field', (t) => {
   stringify({
     str: 'string'
   })
-  t.pass()
 
-  try {
-    stringify({
-      num: 42
-    })
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"str" is required!')
-    t.pass()
-  }
+  throws(() => {
+    stringify({ num: 42 })
+  }, {
+    message: '"str" is required!'
+  })
 })
 
-test('object with required field not in properties schema', (t) => {
-  t.plan(4)
-
+describe('object with required field not in properties schema', (t) => {
   const schema = {
     title: 'object with required field',
     type: 'object',
@@ -52,28 +44,19 @@ test('object with required field not in properties schema', (t) => {
   }
   const stringify = build(schema)
 
-  try {
+  throws(() => {
     stringify({})
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"str" is required!')
-    t.pass()
-  }
-
-  try {
-    stringify({
-      num: 42
-    })
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"str" is required!')
-    t.pass()
-  }
+  }, {
+    message: '"str" is required!'
+  })
+  throws(() => {
+    stringify({ num: 42 })
+  }, {
+    message: '"str" is required!'
+  })
 })
 
-test('object with required field not in properties schema with additional properties true', (t) => {
-  t.plan(4)
-
+describe('object with required field not in properties schema with additional properties true', (t) => {
   const schema = {
     title: 'object with required field',
     type: 'object',
@@ -87,28 +70,20 @@ test('object with required field not in properties schema with additional proper
   }
   const stringify = build(schema)
 
-  try {
+  throws(() => {
     stringify({})
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"str" is required!')
-    t.pass()
-  }
+  }, {
+    message: '"str" is required!'
+  })
 
-  try {
-    stringify({
-      num: 42
-    })
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"str" is required!')
-    t.pass()
-  }
+  throws(() => {
+    stringify({ num: 42 })
+  }, {
+    message: '"str" is required!'
+  })
 })
 
-test('object with multiple required field not in properties schema', (t) => {
-  t.plan(6)
-
+describe('object with multiple required field not in properties schema', (t) => {
   const schema = {
     title: 'object with required field',
     type: 'object',
@@ -122,40 +97,32 @@ test('object with multiple required field not in properties schema', (t) => {
   }
   const stringify = build(schema)
 
-  try {
+  throws(() => {
     stringify({})
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"key1" is required!')
-    t.pass()
-  }
+  }, {
+    message: '"key1" is required!'
+  })
 
-  try {
+  throws(() => {
     stringify({
       key1: 42,
       key2: 42
     })
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"num" is required!')
-    t.pass()
-  }
+  }, {
+    message: '"num" is required!'
+  })
 
-  try {
+  throws(() => {
     stringify({
       num: 42,
       key1: 'some'
     })
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"key2" is required!')
-    t.pass()
-  }
+  }, {
+    message: '"key2" is required!'
+  })
 })
 
-test('object with required bool', (t) => {
-  t.plan(2)
-
+describe('object with required bool', (t) => {
   const schema = {
     title: 'object with required field',
     type: 'object',
@@ -169,22 +136,18 @@ test('object with required bool', (t) => {
   }
   const stringify = build(schema)
 
-  try {
+  throws(() => {
     stringify({})
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, '"bool" is required!')
-    t.pass()
-  }
+  }, {
+    message: '"bool" is required!'
+  })
 
   stringify({
     bool: false
   })
 })
 
-test('required nullable', (t) => {
-  t.plan(1)
-
+describe('required nullable', (t) => {
   const schema = {
     title: 'object with required field',
     type: 'object',
@@ -201,12 +164,9 @@ test('required nullable', (t) => {
   stringify({
     null: null
   })
-  t.pass()
 })
 
-test('required numbers', (t) => {
-  t.plan(3)
-
+describe('required numbers', (t) => {
   const schema = {
     title: 'object with required field',
     type: 'object',
@@ -225,15 +185,9 @@ test('required numbers', (t) => {
   stringify({
     num: 42
   })
-  t.pass()
-
-  try {
-    stringify({
-      num: 'aaa'
-    })
-    t.fail()
-  } catch (e) {
-    t.equal(e.message, 'The value "aaa" cannot be converted to an integer.')
-    t.pass()
-  }
+  throws(() => {
+    stringify({ num: 'aaa' })
+  }, {
+    message: 'The value "aaa" cannot be converted to an integer.'
+  })
 })

--- a/test/requiresAjv.test.js
+++ b/test/requiresAjv.test.js
@@ -1,48 +1,50 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
 const build = require('..')
 
-t.test('nested ref requires ajv', async t => {
-  const schemaA = {
-    $id: 'urn:schema:a',
-    definitions: {
-      foo: { anyOf: [{ type: 'string' }, { type: 'null' }] }
+test('nested ref requires ajv', async t => {
+  t.test('nested ref requires ajv', async t => {
+    const schemaA = {
+      $id: 'urn:schema:a',
+      definitions: {
+        foo: { anyOf: [{ type: 'string' }, { type: 'null' }] }
+      }
     }
-  }
 
-  const schemaB = {
-    $id: 'urn:schema:b',
-    type: 'object',
-    properties: {
-      results: {
-        type: 'object',
-        properties: {
-          items: {
-            type: 'object',
-            properties: {
-              bar: {
-                type: 'array',
-                items: { $ref: 'urn:schema:a#/definitions/foo' }
+    const schemaB = {
+      $id: 'urn:schema:b',
+      type: 'object',
+      properties: {
+        results: {
+          type: 'object',
+          properties: {
+            items: {
+              type: 'object',
+              properties: {
+                bar: {
+                  type: 'array',
+                  items: { $ref: 'urn:schema:a#/definitions/foo' }
+                }
               }
             }
           }
         }
       }
     }
-  }
 
-  const stringify = build(schemaB, {
-    schema: {
-      [schemaA.$id]: schemaA
-    }
-  })
-  const result = stringify({
-    results: {
-      items: {
-        bar: ['baz']
+    const stringify = build(schemaB, {
+      schema: {
+        [schemaA.$id]: schemaA
       }
-    }
+    })
+    const result = stringify({
+      results: {
+        items: {
+          bar: ['baz']
+        }
+      }
+    })
+    t.assert.equal(result, '{"results":{"items":{"bar":["baz"]}}}')
   })
-  t.same(result, '{"results":{"items":{"bar":["baz"]}}}')
 })

--- a/test/requiresAjv.test.js
+++ b/test/requiresAjv.test.js
@@ -1,9 +1,10 @@
 'use strict'
 
-const t = require('tap')
+const { describe } = require('node:test')
+const { equal } = require('node:assert')
 const build = require('..')
 
-t.test('nested ref requires ajv', async t => {
+describe('nested ref requires ajv', async t => {
   const schemaA = {
     $id: 'urn:schema:a',
     definitions: {
@@ -44,5 +45,5 @@ t.test('nested ref requires ajv', async t => {
       }
     }
   })
-  t.same(result, '{"results":{"items":{"bar":["baz"]}}}')
+  equal(result, '{"results":{"items":{"bar":["baz"]}}}')
 })

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
 const build = require('..')
 
 const stringify = build({
@@ -91,52 +91,51 @@ const obj = {
   notmatchnum: 42
 }
 
-// pass if it does not crash
-const json = stringify(obj)
-JSON.parse(json)
+test('sanitize', t => {
+  const json = stringify(obj)
+  t.assert.doesNotThrow(() => JSON.parse(json))
 
-const stringify2 = build({
-  title: 'Example Schema',
-  type: 'object',
-  patternProperties: {
-    '"\'w00t.*////': {
-      type: 'number'
+  const stringify2 = build({
+    title: 'Example Schema',
+    type: 'object',
+    patternProperties: {
+      '"\'w00t.*////': {
+        type: 'number'
+      }
     }
-  }
-})
+  })
 
-t.same(JSON.parse(stringify2({
-  '"\'phra////': 42,
-  asd: 42
-})), {
-})
+  t.assert.deepStrictEqual(JSON.parse(stringify2({
+    '"\'phra////': 42,
+    asd: 42
+  })), {
+  })
 
-const stringify3 = build({
-  title: 'Example Schema',
-  type: 'object',
-  properties: {
-    "\"phra\\'&&(console.log(42))//||'phra": {}
-  }
-})
-
-// this verifies the escaping
-JSON.parse(stringify3({
-  '"phra\'&&(console.log(42))//||\'phra': 42
-}))
-
-const stringify4 = build({
-  title: 'Example Schema',
-  type: 'object',
-  properties: {
-    '"\\\\\\\\\'w00t': {
-      type: 'string',
-      default: '"\'w00t'
+  const stringify3 = build({
+    title: 'Example Schema',
+    type: 'object',
+    properties: {
+      "\"phra\\'&&(console.log(42))//||'phra": {}
     }
-  }
-})
+  })
 
-t.same(JSON.parse(stringify4({})), {
-  '"\\\\\\\\\'w00t': '"\'w00t'
-})
+  // this verifies the escaping
+  JSON.parse(stringify3({
+    '"phra\'&&(console.log(42))//||\'phra': 42
+  }))
 
-t.pass('no crashes')
+  const stringify4 = build({
+    title: 'Example Schema',
+    type: 'object',
+    properties: {
+      '"\\\\\\\\\'w00t': {
+        type: 'string',
+        default: '"\'w00t'
+      }
+    }
+  })
+
+  t.assert.deepStrictEqual(JSON.parse(stringify4({})), {
+    '"\\\\\\\\\'w00t': '"\'w00t'
+  })
+})

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const t = require('tap')
+const { describe } = require('node:test')
+const { deepStrictEqual } = require('node:assert')
 const build = require('..')
 
 const stringify = build({
@@ -105,38 +106,38 @@ const stringify2 = build({
   }
 })
 
-t.same(JSON.parse(stringify2({
-  '"\'phra////': 42,
-  asd: 42
-})), {
-})
+describe('sanitize', () => {
+  deepStrictEqual(JSON.parse(stringify2({
+    '"\'phra////': 42,
+    asd: 42
+  })), {
+  })
 
-const stringify3 = build({
-  title: 'Example Schema',
-  type: 'object',
-  properties: {
-    "\"phra\\'&&(console.log(42))//||'phra": {}
-  }
-})
-
-// this verifies the escaping
-JSON.parse(stringify3({
-  '"phra\'&&(console.log(42))//||\'phra': 42
-}))
-
-const stringify4 = build({
-  title: 'Example Schema',
-  type: 'object',
-  properties: {
-    '"\\\\\\\\\'w00t': {
-      type: 'string',
-      default: '"\'w00t'
+  const stringify3 = build({
+    title: 'Example Schema',
+    type: 'object',
+    properties: {
+      "\"phra\\'&&(console.log(42))//||'phra": {}
     }
-  }
-})
+  })
 
-t.same(JSON.parse(stringify4({})), {
-  '"\\\\\\\\\'w00t': '"\'w00t'
-})
+  // this verifies the escaping
+  JSON.parse(stringify3({
+    '"phra\'&&(console.log(42))//||\'phra': 42
+  }))
 
-t.pass('no crashes')
+  const stringify4 = build({
+    title: 'Example Schema',
+    type: 'object',
+    properties: {
+      '"\\\\\\\\\'w00t': {
+        type: 'string',
+        default: '"\'w00t'
+      }
+    }
+  })
+
+  deepStrictEqual(JSON.parse(stringify4({})), {
+    '"\\\\\\\\\'w00t': '"\'w00t'
+  })
+})

--- a/test/sanitize2.test.js
+++ b/test/sanitize2.test.js
@@ -1,18 +1,18 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
 const build = require('..')
 
-const payload = '(throw "pwoned")'
+test('sanitize 2', t => {
+  const payload = '(throw "pwoned")'
 
-const stringify = build({
-  properties: {
-    [`*///\\\\\\']);${payload};{/*`]: {
-      type: 'number'
+  const stringify = build({
+    properties: {
+      [`*///\\\\\\']);${payload};{/*`]: {
+        type: 'number'
+      }
     }
-  }
+  })
+
+  t.assert.doesNotThrow(() => stringify({}))
 })
-
-stringify({})
-
-t.pass('no crashes')

--- a/test/sanitize2.test.js
+++ b/test/sanitize2.test.js
@@ -1,18 +1,18 @@
 'use strict'
 
-const t = require('tap')
+const { describe } = require('node:test')
 const build = require('..')
 
-const payload = '(throw "pwoned")'
+describe('sanitize 2', () => {
+  const payload = '(throw "pwoned")'
 
-const stringify = build({
-  properties: {
-    [`*///\\\\\\']);${payload};{/*`]: {
-      type: 'number'
+  const stringify = build({
+    properties: {
+      [`*///\\\\\\']);${payload};{/*`]: {
+        type: 'number'
+      }
     }
-  }
+  })
+
+  stringify({})
 })
-
-stringify({})
-
-t.pass('no crashes')

--- a/test/sanitize3.test.js
+++ b/test/sanitize3.test.js
@@ -1,15 +1,17 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
 const build = require('..')
 
-t.throws(() => {
-  build({
-    $defs: {
-      type: 'foooo"bar'
-    },
-    patternProperties: {
-      x: { $ref: '#/$defs' }
-    }
-  })
-}, 'foooo"bar unsupported')
+test('sanitize 3', t => {
+  t.assert.throws(() => {
+    build({
+      $defs: {
+        type: 'foooo"bar'
+      },
+      patternProperties: {
+        x: { $ref: '#/$defs' }
+      }
+    })
+  }, { message: 'foooo"bar unsupported' })
+})

--- a/test/sanitize3.test.js
+++ b/test/sanitize3.test.js
@@ -1,15 +1,18 @@
 'use strict'
 
-const t = require('tap')
+const { describe } = require('node:test')
+const { throws } = require('node:assert')
 const build = require('..')
 
-t.throws(() => {
-  build({
-    $defs: {
-      type: 'foooo"bar'
-    },
-    patternProperties: {
-      x: { $ref: '#/$defs' }
-    }
-  })
-}, 'foooo"bar unsupported')
+describe('sanitize 3', () => {
+  throws(() => {
+    build({
+      $defs: {
+        type: 'foooo"bar'
+      },
+      patternProperties: {
+        x: { $ref: '#/$defs' }
+      }
+    })
+  }, { message: 'foooo"bar unsupported' })
+})

--- a/test/sanitize4.test.js
+++ b/test/sanitize4.test.js
@@ -1,14 +1,16 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
 const build = require('..')
 
-const payload = '(throw "pwoned")'
+test('sanitize 4', t => {
+  const payload = '(throw "pwoned")'
 
-const stringify = build({
-  required: [`"];${payload}//`]
+  const stringify = build({
+    required: [`"];${payload}//`]
+  })
+
+  t.assert.throws(() => {
+    stringify({})
+  }, { message: '""];(throw "pwoned")//" is required!' })
 })
-
-t.throws(() => {
-  stringify({})
-}, 'Error: ""];(throw "pwoned")//" is required!')

--- a/test/sanitize4.test.js
+++ b/test/sanitize4.test.js
@@ -1,14 +1,17 @@
 'use strict'
 
-const t = require('tap')
+const { describe } = require('node:test')
+const { throws } = require('node:assert')
 const build = require('..')
 
-const payload = '(throw "pwoned")'
+describe('sanitize 4', () => {
+  const payload = '(throw "pwoned")'
 
-const stringify = build({
-  required: [`"];${payload}//`]
+  const stringify = build({
+    required: [`"];${payload}//`]
+  })
+
+  throws(() => {
+    stringify({})
+  }, { message: '""];(throw "pwoned")//" is required!' })
 })
-
-t.throws(() => {
-  stringify({})
-}, 'Error: ""];(throw "pwoned")//" is required!')

--- a/test/sanitize5.test.js
+++ b/test/sanitize5.test.js
@@ -1,16 +1,16 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
 const build = require('..')
 
-const payload = '(throw "pwoned")'
+test('sanitize 5', t => {
+  const payload = '(throw "pwoned")'
 
-const expected = 'Error: Invalid regular expression: /*/: Nothing to repeat. Found at * matching {"type":"*/(throw \\"pwoned\\")){//"}'
-
-t.throws(() => {
-  build({
-    patternProperties: {
-      '*': { type: `*/${payload}){//` }
-    }
-  })
-}, expected)
+  t.assert.throws(() => {
+    build({
+      patternProperties: {
+        '*': { type: `*/${payload}){//` }
+      }
+    })
+  }, { message: 'schema is invalid: data/patternProperties must match format "regex"' })
+})

--- a/test/sanitize5.test.js
+++ b/test/sanitize5.test.js
@@ -1,16 +1,17 @@
 'use strict'
 
-const t = require('tap')
+const { describe } = require('node:test')
+const { throws } = require('node:assert')
 const build = require('..')
 
-const payload = '(throw "pwoned")'
+describe('sanitize 5', () => {
+  const payload = '(throw "pwoned")'
 
-const expected = 'Error: Invalid regular expression: /*/: Nothing to repeat. Found at * matching {"type":"*/(throw \\"pwoned\\")){//"}'
-
-t.throws(() => {
-  build({
-    patternProperties: {
-      '*': { type: `*/${payload}){//` }
-    }
-  })
-}, expected)
+  throws(() => {
+    build({
+      patternProperties: {
+        '*': { type: `*/${payload}){//` }
+      }
+    })
+  }, { message: 'schema is invalid: data/patternProperties must match format "regex"' })
+})

--- a/test/sanitize6.test.js
+++ b/test/sanitize6.test.js
@@ -1,22 +1,22 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
 const build = require('..')
 
-const payload = '(throw "pwoned")'
+test('sanitize 6', t => {
+  const payload = '(throw "pwoned")'
 
-const stringify = build({
-  type: 'object',
-  properties: {
-    '/*': { type: 'object' },
-    x: {
-      type: 'object',
-      properties: {
-        a: { type: 'string', default: `*/}${payload};{//` }
+  const stringify = build({
+    type: 'object',
+    properties: {
+      '/*': { type: 'object' },
+      x: {
+        type: 'object',
+        properties: {
+          a: { type: 'string', default: `*/}${payload};{//` }
+        }
       }
     }
-  }
+  })
+  t.assert.doesNotThrow(() => { stringify({}) })
 })
-stringify({})
-
-t.pass('no crashes')

--- a/test/sanitize6.test.js
+++ b/test/sanitize6.test.js
@@ -1,22 +1,22 @@
 'use strict'
 
-const t = require('tap')
+const { describe } = require('node:test')
 const build = require('..')
 
-const payload = '(throw "pwoned")'
+describe('sanitize 6', () => {
+  const payload = '(throw "pwoned")'
 
-const stringify = build({
-  type: 'object',
-  properties: {
-    '/*': { type: 'object' },
-    x: {
-      type: 'object',
-      properties: {
-        a: { type: 'string', default: `*/}${payload};{//` }
+  const stringify = build({
+    type: 'object',
+    properties: {
+      '/*': { type: 'object' },
+      x: {
+        type: 'object',
+        properties: {
+          a: { type: 'string', default: `*/}${payload};{//` }
+        }
       }
     }
-  }
+  })
+  stringify({})
 })
-stringify({})
-
-t.pass('no crashes')

--- a/test/sanitize7.test.js
+++ b/test/sanitize7.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('required property containing single quote, contains property', (t) => {
@@ -16,7 +16,7 @@ test('required property containing single quote, contains property', (t) => {
     ]
   })
 
-  t.throws(() => stringify({}), new Error('"\'" is required!'))
+  t.assert.throws(() => stringify({}), new Error('"\'" is required!'))
 })
 
 test('required property containing double quote, contains property', (t) => {
@@ -32,7 +32,7 @@ test('required property containing double quote, contains property', (t) => {
     ]
   })
 
-  t.throws(() => stringify({}), new Error('""" is required!'))
+  t.assert.throws(() => stringify({}), new Error('""" is required!'))
 })
 
 test('required property containing single quote, does not contain property', (t) => {
@@ -48,7 +48,7 @@ test('required property containing single quote, does not contain property', (t)
     ]
   })
 
-  t.throws(() => stringify({}), new Error('"\'" is required!'))
+  t.assert.throws(() => stringify({}), new Error('"\'" is required!'))
 })
 
 test('required property containing double quote, does not contain property', (t) => {
@@ -64,5 +64,5 @@ test('required property containing double quote, does not contain property', (t)
     ]
   })
 
-  t.throws(() => stringify({}), new Error('""" is required!'))
+  t.assert.throws(() => stringify({}), new Error('""" is required!'))
 })

--- a/test/sanitize7.test.js
+++ b/test/sanitize7.test.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { throws } = require('node:assert')
 const build = require('..')
 
-test('required property containing single quote, contains property', (t) => {
-  t.plan(1)
-
+describe('required property containing single quote, contains property', (t) => {
   const stringify = build({
     type: 'object',
     properties: {
@@ -16,12 +15,10 @@ test('required property containing single quote, contains property', (t) => {
     ]
   })
 
-  t.throws(() => stringify({}), new Error('"\'" is required!'))
+  throws(() => stringify({}), new Error('"\'" is required!'))
 })
 
-test('required property containing double quote, contains property', (t) => {
-  t.plan(1)
-
+describe('required property containing double quote, contains property', (t) => {
   const stringify = build({
     type: 'object',
     properties: {
@@ -32,12 +29,10 @@ test('required property containing double quote, contains property', (t) => {
     ]
   })
 
-  t.throws(() => stringify({}), new Error('""" is required!'))
+  throws(() => stringify({}), new Error('""" is required!'))
 })
 
-test('required property containing single quote, does not contain property', (t) => {
-  t.plan(1)
-
+describe('required property containing single quote, does not contain property', (t) => {
   const stringify = build({
     type: 'object',
     properties: {
@@ -48,12 +43,10 @@ test('required property containing single quote, does not contain property', (t)
     ]
   })
 
-  t.throws(() => stringify({}), new Error('"\'" is required!'))
+  throws(() => stringify({}), new Error('"\'" is required!'))
 })
 
-test('required property containing double quote, does not contain property', (t) => {
-  t.plan(1)
-
+describe('required property containing double quote, does not contain property', (t) => {
   const stringify = build({
     type: 'object',
     properties: {
@@ -64,5 +57,5 @@ test('required property containing double quote, does not contain property', (t)
     ]
   })
 
-  t.throws(() => stringify({}), new Error('""" is required!'))
+  throws(() => stringify({}), new Error('""" is required!'))
 })

--- a/test/side-effect.test.js
+++ b/test/side-effect.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const clone = require('rfdc/default')
 const build = require('..')
 
@@ -32,8 +32,8 @@ test('oneOf with $ref should not change the input schema', t => {
   })
 
   const value = stringify({ people: { name: 'hello', foo: 'bar' } })
-  t.equal(value, '{"people":{"name":"hello"}}')
-  t.same(schema, clonedSchema)
+  t.assert.equal(value, '{"people":{"name":"hello"}}')
+  t.assert.deepStrictEqual(schema, clonedSchema)
 })
 
 test('oneOf and anyOf with $ref should not change the input schema', t => {
@@ -75,9 +75,9 @@ test('oneOf and anyOf with $ref should not change the input schema', t => {
   const valueAny1 = stringify({ people: { name: 'hello', foo: 'bar' }, love: 'music' })
   const valueAny2 = stringify({ people: { name: 'hello', foo: 'bar' }, love: true })
 
-  t.equal(valueAny1, '{"people":{"name":"hello"},"love":"music"}')
-  t.equal(valueAny2, '{"people":{"name":"hello"},"love":true}')
-  t.same(schema, clonedSchema)
+  t.assert.equal(valueAny1, '{"people":{"name":"hello"},"love":"music"}')
+  t.assert.equal(valueAny2, '{"people":{"name":"hello"},"love":true}')
+  t.assert.deepStrictEqual(schema, clonedSchema)
 })
 
 test('multiple $ref tree', t => {
@@ -118,8 +118,8 @@ test('multiple $ref tree', t => {
   })
 
   const value = stringify({ people: { name: 'hello', foo: 'bar', age: 42 } })
-  t.equal(value, '{"people":{"name":"hello","age":42}}')
-  t.same(schema, clonedSchema)
+  t.assert.equal(value, '{"people":{"name":"hello","age":42}}')
+  t.assert.deepStrictEqual(schema, clonedSchema)
 })
 
 test('must not mutate items $ref', t => {
@@ -152,8 +152,8 @@ test('must not mutate items $ref', t => {
   })
 
   const value = stringify([{ name: 'foo' }])
-  t.equal(value, '[{"name":"foo"}]')
-  t.same(schema, clonedSchema)
+  t.assert.equal(value, '[{"name":"foo"}]')
+  t.assert.deepStrictEqual(schema, clonedSchema)
 })
 
 test('must not mutate items referred by $ref', t => {
@@ -191,6 +191,6 @@ test('must not mutate items referred by $ref', t => {
   })
 
   const value = stringify({ name: { name: 'foo' } })
-  t.equal(value, '{"name":{"name":"foo"}}')
-  t.same(firstSchema, clonedSchema)
+  t.assert.equal(value, '{"name":{"name":"foo"}}')
+  t.assert.deepStrictEqual(firstSchema, clonedSchema)
 })

--- a/test/side-effect.test.js
+++ b/test/side-effect.test.js
@@ -1,12 +1,11 @@
 'use strict'
 
-const { test } = require('tap')
+const { describe } = require('node:test')
+const { equal, deepStrictEqual } = require('node:assert')
 const clone = require('rfdc/default')
 const build = require('..')
 
-test('oneOf with $ref should not change the input schema', t => {
-  t.plan(2)
-
+describe('oneOf with $ref should not change the input schema', t => {
   const referenceSchema = {
     $id: 'externalId',
     type: 'object',
@@ -32,13 +31,11 @@ test('oneOf with $ref should not change the input schema', t => {
   })
 
   const value = stringify({ people: { name: 'hello', foo: 'bar' } })
-  t.equal(value, '{"people":{"name":"hello"}}')
-  t.same(schema, clonedSchema)
+  equal(value, '{"people":{"name":"hello"}}')
+  deepStrictEqual(schema, clonedSchema)
 })
 
-test('oneOf and anyOf with $ref should not change the input schema', t => {
-  t.plan(3)
-
+describe('oneOf and anyOf with $ref should not change the input schema', t => {
   const referenceSchema = {
     $id: 'externalSchema',
     type: 'object',
@@ -75,14 +72,12 @@ test('oneOf and anyOf with $ref should not change the input schema', t => {
   const valueAny1 = stringify({ people: { name: 'hello', foo: 'bar' }, love: 'music' })
   const valueAny2 = stringify({ people: { name: 'hello', foo: 'bar' }, love: true })
 
-  t.equal(valueAny1, '{"people":{"name":"hello"},"love":"music"}')
-  t.equal(valueAny2, '{"people":{"name":"hello"},"love":true}')
-  t.same(schema, clonedSchema)
+  equal(valueAny1, '{"people":{"name":"hello"},"love":"music"}')
+  equal(valueAny2, '{"people":{"name":"hello"},"love":true}')
+  deepStrictEqual(schema, clonedSchema)
 })
 
-test('multiple $ref tree', t => {
-  t.plan(2)
-
+describe('multiple $ref tree', t => {
   const referenceDeepSchema = {
     $id: 'deepId',
     type: 'number'
@@ -118,13 +113,11 @@ test('multiple $ref tree', t => {
   })
 
   const value = stringify({ people: { name: 'hello', foo: 'bar', age: 42 } })
-  t.equal(value, '{"people":{"name":"hello","age":42}}')
-  t.same(schema, clonedSchema)
+  equal(value, '{"people":{"name":"hello","age":42}}')
+  deepStrictEqual(schema, clonedSchema)
 })
 
-test('must not mutate items $ref', t => {
-  t.plan(2)
-
+describe('must not mutate items $ref', t => {
   const referenceSchema = {
     $id: 'ShowSchema',
     $schema: 'http://json-schema.org/draft-07/schema#',
@@ -152,13 +145,11 @@ test('must not mutate items $ref', t => {
   })
 
   const value = stringify([{ name: 'foo' }])
-  t.equal(value, '[{"name":"foo"}]')
-  t.same(schema, clonedSchema)
+  equal(value, '[{"name":"foo"}]')
+  deepStrictEqual(schema, clonedSchema)
 })
 
-test('must not mutate items referred by $ref', t => {
-  t.plan(2)
-
+describe('must not mutate items referred by $ref', t => {
   const firstSchema = {
     $id: 'example1',
     type: 'object',
@@ -191,6 +182,6 @@ test('must not mutate items referred by $ref', t => {
   })
 
   const value = stringify({ name: { name: 'foo' } })
-  t.equal(value, '{"name":{"name":"foo"}}')
-  t.same(firstSchema, clonedSchema)
+  equal(value, '{"name":{"name":"foo"}}')
+  deepStrictEqual(firstSchema, clonedSchema)
 })

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
+
 const build = require('..')
 
 test('serialize short string', (t) => {
@@ -15,8 +15,8 @@ test('serialize short string', (t) => {
   const stringify = build(schema)
   const output = stringify(input)
 
-  t.equal(output, '"abcd"')
-  t.equal(JSON.parse(output), input)
+  t.assert.equal(output, '"abcd"')
+  t.assert.equal(JSON.parse(output), input)
 })
 
 test('serialize short string', (t) => {
@@ -30,8 +30,8 @@ test('serialize short string', (t) => {
   const stringify = build(schema)
   const output = stringify(input)
 
-  t.equal(output, '"\\u0000"')
-  t.equal(JSON.parse(output), input)
+  t.assert.equal(output, '"\\u0000"')
+  t.assert.equal(JSON.parse(output), input)
 })
 
 test('serialize long string', (t) => {
@@ -45,8 +45,8 @@ test('serialize long string', (t) => {
   const stringify = build(schema)
   const output = stringify(input)
 
-  t.equal(output, `"${new Array(2e4).fill('\\u0000').join('')}"`)
-  t.equal(JSON.parse(output), input)
+  t.assert.equal(output, `"${new Array(2e4).fill('\\u0000').join('')}"`)
+  t.assert.equal(JSON.parse(output), input)
 })
 
 test('unsafe string', (t) => {
@@ -61,8 +61,8 @@ test('unsafe string', (t) => {
   const stringify = build(schema)
   const output = stringify(input)
 
-  t.equal(output, `"${input}"`)
-  t.equal(JSON.parse(output), input)
+  t.assert.equal(output, `"${input}"`)
+  t.assert.equal(JSON.parse(output), input)
 })
 
 test('unsafe unescaped string', (t) => {
@@ -77,8 +77,8 @@ test('unsafe unescaped string', (t) => {
   const stringify = build(schema)
   const output = stringify(input)
 
-  t.equal(output, `"${input}"`)
-  t.throws(function () {
+  t.assert.equal(output, `"${input}"`)
+  t.assert.throws(function () {
     JSON.parse(output)
   })
 })

--- a/test/string.test.js
+++ b/test/string.test.js
@@ -1,12 +1,10 @@
 'use strict'
 
-const t = require('tap')
-const test = t.test
+const { describe } = require('node:test')
+const { deepStrictEqual, throws } = require('node:assert')
 const build = require('..')
 
-test('serialize short string', (t) => {
-  t.plan(2)
-
+describe('serialize short string', (t) => {
   const schema = {
     type: 'string'
   }
@@ -15,13 +13,11 @@ test('serialize short string', (t) => {
   const stringify = build(schema)
   const output = stringify(input)
 
-  t.equal(output, '"abcd"')
-  t.equal(JSON.parse(output), input)
+  deepStrictEqual(output, '"abcd"')
+  deepStrictEqual(JSON.parse(output), input)
 })
 
-test('serialize short string', (t) => {
-  t.plan(2)
-
+describe('serialize short string', (t) => {
   const schema = {
     type: 'string'
   }
@@ -30,13 +26,11 @@ test('serialize short string', (t) => {
   const stringify = build(schema)
   const output = stringify(input)
 
-  t.equal(output, '"\\u0000"')
-  t.equal(JSON.parse(output), input)
+  deepStrictEqual(output, '"\\u0000"')
+  deepStrictEqual(JSON.parse(output), input)
 })
 
-test('serialize long string', (t) => {
-  t.plan(2)
-
+describe('serialize long string', (t) => {
   const schema = {
     type: 'string'
   }
@@ -45,13 +39,11 @@ test('serialize long string', (t) => {
   const stringify = build(schema)
   const output = stringify(input)
 
-  t.equal(output, `"${new Array(2e4).fill('\\u0000').join('')}"`)
-  t.equal(JSON.parse(output), input)
+  deepStrictEqual(output, `"${new Array(2e4).fill('\\u0000').join('')}"`)
+  deepStrictEqual(JSON.parse(output), input)
 })
 
-test('unsafe string', (t) => {
-  t.plan(2)
-
+describe('unsafe string', (t) => {
   const schema = {
     type: 'string',
     format: 'unsafe'
@@ -61,13 +53,11 @@ test('unsafe string', (t) => {
   const stringify = build(schema)
   const output = stringify(input)
 
-  t.equal(output, `"${input}"`)
-  t.equal(JSON.parse(output), input)
+  deepStrictEqual(output, `"${input}"`)
+  deepStrictEqual(JSON.parse(output), input)
 })
 
-test('unsafe unescaped string', (t) => {
-  t.plan(2)
-
+describe('unsafe unescaped string', (t) => {
   const schema = {
     type: 'string',
     format: 'unsafe'
@@ -77,8 +67,8 @@ test('unsafe unescaped string', (t) => {
   const stringify = build(schema)
   const output = stringify(input)
 
-  t.equal(output, `"${input}"`)
-  t.throws(function () {
+  deepStrictEqual(output, `"${input}"`)
+  throws(() => {
     JSON.parse(output)
   })
 })

--- a/test/surrogate.test.js
+++ b/test/surrogate.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const validator = require('is-my-json-valid')
 const build = require('..')
 
@@ -16,8 +16,8 @@ test('render a string with surrogate pairs as JSON:test 1', (t) => {
   const stringify = build(schema)
   const output = stringify('𝌆')
 
-  t.equal(output, '"𝌆"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '"𝌆"')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('render a string with surrogate pairs as JSON: test 2', (t) => {
@@ -32,8 +32,8 @@ test('render a string with surrogate pairs as JSON: test 2', (t) => {
   const stringify = build(schema)
   const output = stringify('\uD834\uDF06')
 
-  t.equal(output, '"𝌆"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, '"𝌆"')
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('render a string with Unpaired surrogate code as JSON', (t) => {
@@ -47,8 +47,8 @@ test('render a string with Unpaired surrogate code as JSON', (t) => {
   const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify('\uDF06\uD834')
-  t.equal(output, JSON.stringify('\uDF06\uD834'))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, JSON.stringify('\uDF06\uD834'))
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
 test('render a string with lone surrogate code as JSON', (t) => {
@@ -62,6 +62,6 @@ test('render a string with lone surrogate code as JSON', (t) => {
   const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify('\uDEAD')
-  t.equal(output, JSON.stringify('\uDEAD'))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  t.assert.equal(output, JSON.stringify('\uDEAD'))
+  t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })

--- a/test/surrogate.test.js
+++ b/test/surrogate.test.js
@@ -1,12 +1,11 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { equal, ok } = require('node:assert')
 const validator = require('is-my-json-valid')
 const build = require('..')
 
-test('render a string with surrogate pairs as JSON:test 1', (t) => {
-  t.plan(2)
-
+describe('render a string with surrogate pairs as JSON:test 1', (t) => {
   const schema = {
     title: 'surrogate',
     type: 'string'
@@ -16,13 +15,11 @@ test('render a string with surrogate pairs as JSON:test 1', (t) => {
   const stringify = build(schema)
   const output = stringify('𝌆')
 
-  t.equal(output, '"𝌆"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '"𝌆"')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render a string with surrogate pairs as JSON: test 2', (t) => {
-  t.plan(2)
-
+describe('render a string with surrogate pairs as JSON: test 2', (t) => {
   const schema = {
     title: 'long',
     type: 'string'
@@ -32,13 +29,11 @@ test('render a string with surrogate pairs as JSON: test 2', (t) => {
   const stringify = build(schema)
   const output = stringify('\uD834\uDF06')
 
-  t.equal(output, '"𝌆"')
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, '"𝌆"')
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render a string with Unpaired surrogate code as JSON', (t) => {
-  t.plan(2)
-
+describe('render a string with Unpaired surrogate code as JSON', (t) => {
   const schema = {
     title: 'surrogate',
     type: 'string'
@@ -47,13 +42,11 @@ test('render a string with Unpaired surrogate code as JSON', (t) => {
   const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify('\uDF06\uD834')
-  t.equal(output, JSON.stringify('\uDF06\uD834'))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, JSON.stringify('\uDF06\uD834'))
+  ok(validate(JSON.parse(output)), 'valid schema')
 })
 
-test('render a string with lone surrogate code as JSON', (t) => {
-  t.plan(2)
-
+describe('render a string with lone surrogate code as JSON', (t) => {
   const schema = {
     title: 'surrogate',
     type: 'string'
@@ -62,6 +55,6 @@ test('render a string with lone surrogate code as JSON', (t) => {
   const validate = validator(schema)
   const stringify = build(schema)
   const output = stringify('\uDEAD')
-  t.equal(output, JSON.stringify('\uDEAD'))
-  t.ok(validate(JSON.parse(output)), 'valid schema')
+  equal(output, JSON.stringify('\uDEAD'))
+  ok(validate(JSON.parse(output)), 'valid schema')
 })

--- a/test/toJSON.test.js
+++ b/test/toJSON.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('use toJSON method on object types', (t) => {
@@ -22,7 +22,7 @@ test('use toJSON method on object types', (t) => {
     }
   }
 
-  t.equal('{"productName":"cola"}', stringify(object))
+  t.assert.equal('{"productName":"cola"}', stringify(object))
 })
 
 test('use toJSON method on nested object types', (t) => {
@@ -55,7 +55,7 @@ test('use toJSON method on nested object types', (t) => {
     }
   ]
 
-  t.equal('[{"productName":"cola"},{"productName":"sprite"}]', stringify(array))
+  t.assert.equal('[{"productName":"cola"},{"productName":"sprite"}]', stringify(array))
 })
 
 test('not use toJSON if does not exist', (t) => {
@@ -79,7 +79,7 @@ test('not use toJSON if does not exist', (t) => {
     product: { name: 'cola' }
   }
 
-  t.equal('{"product":{"name":"cola"}}', stringify(object))
+  t.assert.equal('{"product":{"name":"cola"}}', stringify(object))
 })
 
 test('not fail on null object declared nullable', (t) => {
@@ -100,7 +100,7 @@ test('not fail on null object declared nullable', (t) => {
       }
     }
   })
-  t.equal('null', stringify(null))
+  t.assert.equal('null', stringify(null))
 })
 
 test('not fail on null sub-object declared nullable', (t) => {
@@ -124,7 +124,7 @@ test('not fail on null sub-object declared nullable', (t) => {
   const object = {
     product: null
   }
-  t.equal('{"product":null}', stringify(object))
+  t.assert.equal('{"product":null}', stringify(object))
 })
 
 test('on non nullable null sub-object it should coerce to {}', (t) => {
@@ -150,7 +150,7 @@ test('on non nullable null sub-object it should coerce to {}', (t) => {
   }
 
   const result = stringify(object)
-  t.equal(result, JSON.stringify({ product: {} }))
+  t.assert.equal(result, JSON.stringify({ product: {} }))
 })
 
 test('on non nullable null object it should coerce to {}', (t) => {
@@ -174,7 +174,7 @@ test('on non nullable null object it should coerce to {}', (t) => {
   })
 
   const result = stringify(null)
-  t.equal(result, '{}')
+  t.assert.equal(result, '{}')
 })
 
 test('on non-nullable null object it should skip rendering, skipping required fields checks', (t) => {
@@ -199,5 +199,5 @@ test('on non-nullable null object it should skip rendering, skipping required fi
   })
 
   const result = stringify(null)
-  t.equal(result, '{}')
+  t.assert.equal(result, '{}')
 })

--- a/test/toJSON.test.js
+++ b/test/toJSON.test.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { equal } = require('node:assert')
 const build = require('..')
 
-test('use toJSON method on object types', (t) => {
-  t.plan(1)
-
+describe('use toJSON method on object types', (t) => {
   const stringify = build({
     title: 'simple object',
     type: 'object',
@@ -22,12 +21,10 @@ test('use toJSON method on object types', (t) => {
     }
   }
 
-  t.equal('{"productName":"cola"}', stringify(object))
+  equal('{"productName":"cola"}', stringify(object))
 })
 
-test('use toJSON method on nested object types', (t) => {
-  t.plan(1)
-
+describe('use toJSON method on nested object types', (t) => {
   const stringify = build({
     title: 'simple array',
     type: 'array',
@@ -55,12 +52,10 @@ test('use toJSON method on nested object types', (t) => {
     }
   ]
 
-  t.equal('[{"productName":"cola"},{"productName":"sprite"}]', stringify(array))
+  equal('[{"productName":"cola"},{"productName":"sprite"}]', stringify(array))
 })
 
-test('not use toJSON if does not exist', (t) => {
-  t.plan(1)
-
+describe('not use toJSON if does not exist', (t) => {
   const stringify = build({
     title: 'simple object',
     type: 'object',
@@ -79,12 +74,10 @@ test('not use toJSON if does not exist', (t) => {
     product: { name: 'cola' }
   }
 
-  t.equal('{"product":{"name":"cola"}}', stringify(object))
+  equal('{"product":{"name":"cola"}}', stringify(object))
 })
 
-test('not fail on null object declared nullable', (t) => {
-  t.plan(1)
-
+describe('not fail on null object declared nullable', (t) => {
   const stringify = build({
     title: 'simple object',
     type: 'object',
@@ -100,12 +93,10 @@ test('not fail on null object declared nullable', (t) => {
       }
     }
   })
-  t.equal('null', stringify(null))
+  equal('null', stringify(null))
 })
 
-test('not fail on null sub-object declared nullable', (t) => {
-  t.plan(1)
-
+describe('not fail on null sub-object declared nullable', (t) => {
   const stringify = build({
     title: 'simple object',
     type: 'object',
@@ -124,12 +115,10 @@ test('not fail on null sub-object declared nullable', (t) => {
   const object = {
     product: null
   }
-  t.equal('{"product":null}', stringify(object))
+  equal('{"product":null}', stringify(object))
 })
 
-test('on non nullable null sub-object it should coerce to {}', (t) => {
-  t.plan(1)
-
+describe('on non nullable null sub-object it should coerce to {}', (t) => {
   const stringify = build({
     title: 'simple object',
     type: 'object',
@@ -150,12 +139,10 @@ test('on non nullable null sub-object it should coerce to {}', (t) => {
   }
 
   const result = stringify(object)
-  t.equal(result, JSON.stringify({ product: {} }))
+  equal(result, JSON.stringify({ product: {} }))
 })
 
-test('on non nullable null object it should coerce to {}', (t) => {
-  t.plan(1)
-
+describe('on non nullable null object it should coerce to {}', (t) => {
   const stringify = build({
     title: 'simple object',
     nullable: false,
@@ -174,12 +161,10 @@ test('on non nullable null object it should coerce to {}', (t) => {
   })
 
   const result = stringify(null)
-  t.equal(result, '{}')
+  equal(result, '{}')
 })
 
-test('on non-nullable null object it should skip rendering, skipping required fields checks', (t) => {
-  t.plan(1)
-
+describe('on non-nullable null object it should skip rendering, skipping required fields checks', (t) => {
   const stringify = build({
     title: 'simple object',
     nullable: false,
@@ -199,5 +184,5 @@ test('on non-nullable null object it should skip rendering, skipping required fi
   })
 
   const result = stringify(null)
-  t.equal(result, '{}')
+  equal(result, '{}')
 })

--- a/test/typebox.test.js
+++ b/test/typebox.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('nested object in pattern properties for typebox', (t) => {
@@ -32,5 +32,5 @@ test('nested object in pattern properties for typebox', (t) => {
       }
     }
   })
-  t.equal(value, '{"key1":{"nestedKey":{"nestedKey1":"value1"}},"key2":{"nestedKey":{"nestedKey1":"value2"}}}')
+  t.assert.equal(value, '{"key1":{"nestedKey":{"nestedKey1":"value1"}},"key2":{"nestedKey":{"nestedKey1":"value2"}}}')
 })

--- a/test/typebox.test.js
+++ b/test/typebox.test.js
@@ -1,12 +1,11 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { equal } = require('node:assert')
 const build = require('..')
 
-test('nested object in pattern properties for typebox', (t) => {
+describe('nested object in pattern properties for typebox', (t) => {
   const { Type } = require('@sinclair/typebox')
-
-  t.plan(1)
 
   const nestedSchema = Type.Object({
     nestedKey1: Type.String()
@@ -32,5 +31,5 @@ test('nested object in pattern properties for typebox', (t) => {
       }
     }
   })
-  t.equal(value, '{"key1":{"nestedKey":{"nestedKey1":"value1"}},"key2":{"nestedKey":{"nestedKey1":"value2"}}}')
+  equal(value, '{"key1":{"nestedKey":{"nestedKey1":"value1"}},"key2":{"nestedKey":{"nestedKey1":"value2"}}}')
 })

--- a/test/typesArray.test.js
+++ b/test/typesArray.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('possibly nullable integer primitive alternative', (t) => {
@@ -21,7 +21,7 @@ test('possibly nullable integer primitive alternative', (t) => {
   const value = stringify({
     data: 4
   })
-  t.equal(value, '{"data":4}')
+  t.assert.equal(value, '{"data":4}')
 })
 
 test('possibly nullable number primitive alternative', (t) => {
@@ -42,7 +42,7 @@ test('possibly nullable number primitive alternative', (t) => {
   const value = stringify({
     data: 4
   })
-  t.equal(value, '{"data":4}')
+  t.assert.equal(value, '{"data":4}')
 })
 
 test('possibly nullable integer primitive alternative with null value', (t) => {
@@ -63,7 +63,7 @@ test('possibly nullable integer primitive alternative with null value', (t) => {
   const value = stringify({
     data: null
   })
-  t.equal(value, '{"data":0}')
+  t.assert.equal(value, '{"data":0}')
 })
 
 test('possibly nullable number primitive alternative with null value', (t) => {
@@ -84,7 +84,7 @@ test('possibly nullable number primitive alternative with null value', (t) => {
   const value = stringify({
     data: null
   })
-  t.equal(value, '{"data":0}')
+  t.assert.equal(value, '{"data":0}')
 })
 
 test('possibly nullable number primitive alternative with null value', (t) => {
@@ -105,7 +105,7 @@ test('possibly nullable number primitive alternative with null value', (t) => {
   const value = stringify({
     data: null
   })
-  t.equal(value, '{"data":false}')
+  t.assert.equal(value, '{"data":false}')
 })
 
 test('nullable integer primitive', (t) => {
@@ -126,7 +126,7 @@ test('nullable integer primitive', (t) => {
   const value = stringify({
     data: 4
   })
-  t.equal(value, '{"data":4}')
+  t.assert.equal(value, '{"data":4}')
 })
 
 test('nullable number primitive', (t) => {
@@ -147,7 +147,7 @@ test('nullable number primitive', (t) => {
   const value = stringify({
     data: 4
   })
-  t.equal(value, '{"data":4}')
+  t.assert.equal(value, '{"data":4}')
 })
 
 test('nullable primitive with null value', (t) => {
@@ -168,7 +168,7 @@ test('nullable primitive with null value', (t) => {
   const value = stringify({
     data: null
   })
-  t.equal(value, '{"data":null}')
+  t.assert.equal(value, '{"data":null}')
 })
 
 test('nullable number primitive with null value', (t) => {
@@ -189,7 +189,7 @@ test('nullable number primitive with null value', (t) => {
   const value = stringify({
     data: null
   })
-  t.equal(value, '{"data":null}')
+  t.assert.equal(value, '{"data":null}')
 })
 
 test('possibly null object with multi-type property', (t) => {
@@ -211,19 +211,19 @@ test('possibly null object with multi-type property', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     objectOrNull: {
       stringOrNumber: 'string'
     }
   }), '{"objectOrNull":{"stringOrNumber":"string"}}')
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     objectOrNull: {
       stringOrNumber: 42
     }
   }), '{"objectOrNull":{"stringOrNumber":42}}')
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     objectOrNull: null
   }), '{"objectOrNull":null}')
 })
@@ -249,7 +249,7 @@ test('object with possibly null array of multiple types', (t) => {
     const value = stringify({
       arrayOfStringsAndNumbers: null
     })
-    t.equal(value, '{"arrayOfStringsAndNumbers":null}')
+    t.assert.equal(value, '{"arrayOfStringsAndNumbers":null}')
   } catch (e) {
     console.log(e)
     t.fail()
@@ -259,21 +259,21 @@ test('object with possibly null array of multiple types', (t) => {
     const value = stringify({
       arrayOfStringsAndNumbers: ['string1', 'string2']
     })
-    t.equal(value, '{"arrayOfStringsAndNumbers":["string1","string2"]}')
+    t.assert.equal(value, '{"arrayOfStringsAndNumbers":["string1","string2"]}')
   } catch (e) {
     console.log(e)
     t.fail()
   }
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     arrayOfStringsAndNumbers: [42, 7]
   }), '{"arrayOfStringsAndNumbers":[42,7]}')
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     arrayOfStringsAndNumbers: ['string1', 42, 7, 'string2']
   }), '{"arrayOfStringsAndNumbers":["string1",42,7,"string2"]}')
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     arrayOfStringsAndNumbers: ['string1', null, 42, 7, 'string2', null]
   }), '{"arrayOfStringsAndNumbers":["string1",null,42,7,"string2",null]}')
 })
@@ -307,7 +307,7 @@ test('object with tuple of multiple types', (t) => {
     const value = stringify({
       fixedTupleOfStringsAndNumbers: ['string1', 42, 7]
     })
-    t.equal(value, '{"fixedTupleOfStringsAndNumbers":["string1",42,7]}')
+    t.assert.equal(value, '{"fixedTupleOfStringsAndNumbers":["string1",42,7]}')
   } catch (e) {
     console.log(e)
     t.fail()
@@ -317,7 +317,7 @@ test('object with tuple of multiple types', (t) => {
     const value = stringify({
       fixedTupleOfStringsAndNumbers: ['string1', 42, 'string2']
     })
-    t.equal(value, '{"fixedTupleOfStringsAndNumbers":["string1",42,"string2"]}')
+    t.assert.equal(value, '{"fixedTupleOfStringsAndNumbers":["string1",42,"string2"]}')
   } catch (e) {
     console.log(e)
     t.fail()
@@ -354,17 +354,17 @@ test('object with anyOf and multiple types', (t) => {
     const value = stringify({
       objectOrBoolean: { stringOrNumber: 'string' }
     })
-    t.equal(value, '{"objectOrBoolean":{"stringOrNumber":"string"}}')
+    t.assert.equal(value, '{"objectOrBoolean":{"stringOrNumber":"string"}}')
   } catch (e) {
     console.log(e)
     t.fail()
   }
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     objectOrBoolean: { stringOrNumber: 42 }
   }), '{"objectOrBoolean":{"stringOrNumber":42}}')
 
-  t.equal(stringify({
+  t.assert.equal(stringify({
     objectOrBoolean: true
   }), '{"objectOrBoolean":true}')
 })
@@ -383,7 +383,7 @@ test('string type array can handle dates', (t) => {
     date: new Date('2018-04-20T07:52:31.017Z'),
     dateObject: new Date('2018-04-21T07:52:31.017Z')
   })
-  t.equal(value, '{"date":"2018-04-20T07:52:31.017Z","dateObject":"2018-04-21T07:52:31.017Z"}')
+  t.assert.equal(value, '{"date":"2018-04-20T07:52:31.017Z","dateObject":"2018-04-21T07:52:31.017Z"}')
 })
 
 test('object that is simultaneously a string and a json', (t) => {
@@ -406,10 +406,10 @@ test('object that is simultaneously a string and a json', (t) => {
 
   const stringify = build(schema)
   const valueStr = stringify({ simultaneously: likeObjectId })
-  t.equal(valueStr, '{"simultaneously":"hello"}')
+  t.assert.equal(valueStr, '{"simultaneously":"hello"}')
 
   const valueObj = stringify({ simultaneously: { foo: likeObjectId } })
-  t.equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
+  t.assert.equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
 })
 
 test('object that is simultaneously a string and a json switched', (t) => {
@@ -432,10 +432,10 @@ test('object that is simultaneously a string and a json switched', (t) => {
 
   const stringify = build(schema)
   const valueStr = stringify({ simultaneously: likeObjectId })
-  t.equal(valueStr, '{"simultaneously":{}}')
+  t.assert.equal(valueStr, '{"simultaneously":{}}')
 
   const valueObj = stringify({ simultaneously: { foo: likeObjectId } })
-  t.equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
+  t.assert.equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
 })
 
 test('class instance that is simultaneously a string and a json', (t) => {
@@ -461,10 +461,10 @@ test('class instance that is simultaneously a string and a json', (t) => {
 
   const stringify = build(schema)
   const valueStr = stringify({ simultaneously: likeObjectId })
-  t.equal(valueStr, '{"simultaneously":"hello"}')
+  t.assert.equal(valueStr, '{"simultaneously":"hello"}')
 
   const valueObj = stringify({ simultaneously: { foo: likeObjectId } })
-  t.equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
+  t.assert.equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
 })
 
 test('should not throw an error when type is array and object is null, it should instead coerce to []', (t) => {
@@ -483,7 +483,7 @@ test('should not throw an error when type is array and object is null, it should
 
   const stringify = build(schema)
   const result = stringify({ arr: null })
-  t.equal(result, JSON.stringify({ arr: [] }))
+  t.assert.equal(result, JSON.stringify({ arr: [] }))
 })
 
 test('should throw an error when type is array and object is not an array', (t) => {
@@ -501,7 +501,7 @@ test('should throw an error when type is array and object is not an array', (t) 
   }
 
   const stringify = build(schema)
-  t.throws(() => stringify({ arr: { foo: 'hello' } }), new TypeError('The value of \'#/properties/arr\' does not match schema definition.'))
+  t.assert.throws(() => stringify({ arr: { foo: 'hello' } }), new TypeError('The value of \'#/properties/arr\' does not match schema definition.'))
 })
 
 test('should throw an error when type is array and object is not an array with external schema', (t) => {
@@ -529,7 +529,7 @@ test('should throw an error when type is array and object is not an array with e
   }
 
   const stringify = build(schema, { schema: externalSchema })
-  t.throws(() => stringify({ arr: { foo: 'hello' } }), new TypeError('The value of \'arrayOfNumbers#/definitions/arr\' does not match schema definition.'))
+  t.assert.throws(() => stringify({ arr: { foo: 'hello' } }), new TypeError('The value of \'arrayOfNumbers#/definitions/arr\' does not match schema definition.'))
 })
 
 test('throw an error if none of types matches', (t) => {
@@ -546,5 +546,5 @@ test('throw an error if none of types matches', (t) => {
   }
 
   const stringify = build(schema)
-  t.throws(() => stringify({ data: 'string' }), 'The value "string" does not match schema definition.')
+  t.assert.throws(() => stringify({ data: 'string' }), 'The value "string" does not match schema definition.')
 })

--- a/test/typesArray.test.js
+++ b/test/typesArray.test.js
@@ -1,11 +1,10 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { equal, throws } = require('node:assert')
 const build = require('..')
 
-test('possibly nullable integer primitive alternative', (t) => {
-  t.plan(1)
-
+describe('possibly nullable integer primitive alternative', (t) => {
   const schema = {
     title: 'simple object with multi-type nullable primitive',
     type: 'object',
@@ -21,12 +20,10 @@ test('possibly nullable integer primitive alternative', (t) => {
   const value = stringify({
     data: 4
   })
-  t.equal(value, '{"data":4}')
+  equal(value, '{"data":4}')
 })
 
-test('possibly nullable number primitive alternative', (t) => {
-  t.plan(1)
-
+describe('possibly nullable number primitive alternative', (t) => {
   const schema = {
     title: 'simple object with multi-type nullable primitive',
     type: 'object',
@@ -42,12 +39,10 @@ test('possibly nullable number primitive alternative', (t) => {
   const value = stringify({
     data: 4
   })
-  t.equal(value, '{"data":4}')
+  equal(value, '{"data":4}')
 })
 
-test('possibly nullable integer primitive alternative with null value', (t) => {
-  t.plan(1)
-
+describe('possibly nullable integer primitive alternative with null value', (t) => {
   const schema = {
     title: 'simple object with multi-type nullable primitive',
     type: 'object',
@@ -63,12 +58,10 @@ test('possibly nullable integer primitive alternative with null value', (t) => {
   const value = stringify({
     data: null
   })
-  t.equal(value, '{"data":0}')
+  equal(value, '{"data":0}')
 })
 
-test('possibly nullable number primitive alternative with null value', (t) => {
-  t.plan(1)
-
+describe('possibly nullable number primitive alternative with null value', (t) => {
   const schema = {
     title: 'simple object with multi-type nullable primitive',
     type: 'object',
@@ -84,12 +77,10 @@ test('possibly nullable number primitive alternative with null value', (t) => {
   const value = stringify({
     data: null
   })
-  t.equal(value, '{"data":0}')
+  equal(value, '{"data":0}')
 })
 
-test('possibly nullable number primitive alternative with null value', (t) => {
-  t.plan(1)
-
+describe('possibly nullable number primitive alternative with null value', (t) => {
   const schema = {
     title: 'simple object with multi-type nullable primitive',
     type: 'object',
@@ -105,12 +96,10 @@ test('possibly nullable number primitive alternative with null value', (t) => {
   const value = stringify({
     data: null
   })
-  t.equal(value, '{"data":false}')
+  equal(value, '{"data":false}')
 })
 
-test('nullable integer primitive', (t) => {
-  t.plan(1)
-
+describe('nullable integer primitive', (t) => {
   const schema = {
     title: 'simple object with nullable primitive',
     type: 'object',
@@ -126,12 +115,10 @@ test('nullable integer primitive', (t) => {
   const value = stringify({
     data: 4
   })
-  t.equal(value, '{"data":4}')
+  equal(value, '{"data":4}')
 })
 
-test('nullable number primitive', (t) => {
-  t.plan(1)
-
+describe('nullable number primitive', (t) => {
   const schema = {
     title: 'simple object with nullable primitive',
     type: 'object',
@@ -147,12 +134,10 @@ test('nullable number primitive', (t) => {
   const value = stringify({
     data: 4
   })
-  t.equal(value, '{"data":4}')
+  equal(value, '{"data":4}')
 })
 
-test('nullable primitive with null value', (t) => {
-  t.plan(1)
-
+describe('nullable primitive with null value', (t) => {
   const schema = {
     title: 'simple object with nullable primitive',
     type: 'object',
@@ -168,12 +153,10 @@ test('nullable primitive with null value', (t) => {
   const value = stringify({
     data: null
   })
-  t.equal(value, '{"data":null}')
+  equal(value, '{"data":null}')
 })
 
-test('nullable number primitive with null value', (t) => {
-  t.plan(1)
-
+describe('nullable number primitive with null value', (t) => {
   const schema = {
     title: 'simple object with nullable primitive',
     type: 'object',
@@ -189,12 +172,10 @@ test('nullable number primitive with null value', (t) => {
   const value = stringify({
     data: null
   })
-  t.equal(value, '{"data":null}')
+  equal(value, '{"data":null}')
 })
 
-test('possibly null object with multi-type property', (t) => {
-  t.plan(3)
-
+describe('possibly null object with multi-type property', (t) => {
   const schema = {
     title: 'simple object with multi-type property',
     type: 'object',
@@ -211,26 +192,24 @@ test('possibly null object with multi-type property', (t) => {
   }
   const stringify = build(schema)
 
-  t.equal(stringify({
+  equal(stringify({
     objectOrNull: {
       stringOrNumber: 'string'
     }
   }), '{"objectOrNull":{"stringOrNumber":"string"}}')
 
-  t.equal(stringify({
+  equal(stringify({
     objectOrNull: {
       stringOrNumber: 42
     }
   }), '{"objectOrNull":{"stringOrNumber":42}}')
 
-  t.equal(stringify({
+  equal(stringify({
     objectOrNull: null
   }), '{"objectOrNull":null}')
 })
 
-test('object with possibly null array of multiple types', (t) => {
-  t.plan(5)
-
+describe('object with possibly null array of multiple types', (t) => {
   const schema = {
     title: 'object with array of multiple types',
     type: 'object',
@@ -249,7 +228,7 @@ test('object with possibly null array of multiple types', (t) => {
     const value = stringify({
       arrayOfStringsAndNumbers: null
     })
-    t.equal(value, '{"arrayOfStringsAndNumbers":null}')
+    equal(value, '{"arrayOfStringsAndNumbers":null}')
   } catch (e) {
     console.log(e)
     t.fail()
@@ -259,28 +238,26 @@ test('object with possibly null array of multiple types', (t) => {
     const value = stringify({
       arrayOfStringsAndNumbers: ['string1', 'string2']
     })
-    t.equal(value, '{"arrayOfStringsAndNumbers":["string1","string2"]}')
+    equal(value, '{"arrayOfStringsAndNumbers":["string1","string2"]}')
   } catch (e) {
     console.log(e)
     t.fail()
   }
 
-  t.equal(stringify({
+  equal(stringify({
     arrayOfStringsAndNumbers: [42, 7]
   }), '{"arrayOfStringsAndNumbers":[42,7]}')
 
-  t.equal(stringify({
+  equal(stringify({
     arrayOfStringsAndNumbers: ['string1', 42, 7, 'string2']
   }), '{"arrayOfStringsAndNumbers":["string1",42,7,"string2"]}')
 
-  t.equal(stringify({
+  equal(stringify({
     arrayOfStringsAndNumbers: ['string1', null, 42, 7, 'string2', null]
   }), '{"arrayOfStringsAndNumbers":["string1",null,42,7,"string2",null]}')
 })
 
-test('object with tuple of multiple types', (t) => {
-  t.plan(2)
-
+describe('object with tuple of multiple types', (t) => {
   const schema = {
     title: 'object with array of multiple types',
     type: 'object',
@@ -307,7 +284,7 @@ test('object with tuple of multiple types', (t) => {
     const value = stringify({
       fixedTupleOfStringsAndNumbers: ['string1', 42, 7]
     })
-    t.equal(value, '{"fixedTupleOfStringsAndNumbers":["string1",42,7]}')
+    equal(value, '{"fixedTupleOfStringsAndNumbers":["string1",42,7]}')
   } catch (e) {
     console.log(e)
     t.fail()
@@ -317,16 +294,14 @@ test('object with tuple of multiple types', (t) => {
     const value = stringify({
       fixedTupleOfStringsAndNumbers: ['string1', 42, 'string2']
     })
-    t.equal(value, '{"fixedTupleOfStringsAndNumbers":["string1",42,"string2"]}')
+    equal(value, '{"fixedTupleOfStringsAndNumbers":["string1",42,"string2"]}')
   } catch (e) {
     console.log(e)
     t.fail()
   }
 })
 
-test('object with anyOf and multiple types', (t) => {
-  t.plan(3)
-
+describe('object with anyOf and multiple types', (t) => {
   const schema = {
     title: 'object with anyOf and multiple types',
     type: 'object',
@@ -354,23 +329,22 @@ test('object with anyOf and multiple types', (t) => {
     const value = stringify({
       objectOrBoolean: { stringOrNumber: 'string' }
     })
-    t.equal(value, '{"objectOrBoolean":{"stringOrNumber":"string"}}')
+    equal(value, '{"objectOrBoolean":{"stringOrNumber":"string"}}')
   } catch (e) {
     console.log(e)
     t.fail()
   }
 
-  t.equal(stringify({
+  equal(stringify({
     objectOrBoolean: { stringOrNumber: 42 }
   }), '{"objectOrBoolean":{"stringOrNumber":42}}')
 
-  t.equal(stringify({
+  equal(stringify({
     objectOrBoolean: true
   }), '{"objectOrBoolean":true}')
 })
 
-test('string type array can handle dates', (t) => {
-  t.plan(1)
+describe('string type array can handle dates', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -383,11 +357,10 @@ test('string type array can handle dates', (t) => {
     date: new Date('2018-04-20T07:52:31.017Z'),
     dateObject: new Date('2018-04-21T07:52:31.017Z')
   })
-  t.equal(value, '{"date":"2018-04-20T07:52:31.017Z","dateObject":"2018-04-21T07:52:31.017Z"}')
+  equal(value, '{"date":"2018-04-20T07:52:31.017Z","dateObject":"2018-04-21T07:52:31.017Z"}')
 })
 
-test('object that is simultaneously a string and a json', (t) => {
-  t.plan(2)
+describe('object that is simultaneously a string and a json', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -406,14 +379,13 @@ test('object that is simultaneously a string and a json', (t) => {
 
   const stringify = build(schema)
   const valueStr = stringify({ simultaneously: likeObjectId })
-  t.equal(valueStr, '{"simultaneously":"hello"}')
+  equal(valueStr, '{"simultaneously":"hello"}')
 
   const valueObj = stringify({ simultaneously: { foo: likeObjectId } })
-  t.equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
+  equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
 })
 
-test('object that is simultaneously a string and a json switched', (t) => {
-  t.plan(2)
+describe('object that is simultaneously a string and a json switched', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -432,15 +404,13 @@ test('object that is simultaneously a string and a json switched', (t) => {
 
   const stringify = build(schema)
   const valueStr = stringify({ simultaneously: likeObjectId })
-  t.equal(valueStr, '{"simultaneously":{}}')
+  equal(valueStr, '{"simultaneously":{}}')
 
   const valueObj = stringify({ simultaneously: { foo: likeObjectId } })
-  t.equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
+  equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
 })
 
-test('class instance that is simultaneously a string and a json', (t) => {
-  t.plan(2)
-
+describe('class instance that is simultaneously a string and a json', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -461,14 +431,13 @@ test('class instance that is simultaneously a string and a json', (t) => {
 
   const stringify = build(schema)
   const valueStr = stringify({ simultaneously: likeObjectId })
-  t.equal(valueStr, '{"simultaneously":"hello"}')
+  equal(valueStr, '{"simultaneously":"hello"}')
 
   const valueObj = stringify({ simultaneously: { foo: likeObjectId } })
-  t.equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
+  equal(valueObj, '{"simultaneously":{"foo":"hello"}}')
 })
 
-test('should not throw an error when type is array and object is null, it should instead coerce to []', (t) => {
-  t.plan(1)
+describe('should not throw an error when type is array and object is null, it should instead coerce to []', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -483,11 +452,10 @@ test('should not throw an error when type is array and object is null, it should
 
   const stringify = build(schema)
   const result = stringify({ arr: null })
-  t.equal(result, JSON.stringify({ arr: [] }))
+  equal(result, JSON.stringify({ arr: [] }))
 })
 
-test('should throw an error when type is array and object is not an array', (t) => {
-  t.plan(1)
+describe('should throw an error when type is array and object is not an array', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -501,11 +469,10 @@ test('should throw an error when type is array and object is not an array', (t) 
   }
 
   const stringify = build(schema)
-  t.throws(() => stringify({ arr: { foo: 'hello' } }), new TypeError('The value of \'#/properties/arr\' does not match schema definition.'))
+  throws(() => stringify({ arr: { foo: 'hello' } }), new TypeError('The value of \'#/properties/arr\' does not match schema definition.'))
 })
 
-test('should throw an error when type is array and object is not an array with external schema', (t) => {
-  t.plan(1)
+describe('should throw an error when type is array and object is not an array with external schema', (t) => {
   const schema = {
     type: 'object',
     properties: {
@@ -529,12 +496,10 @@ test('should throw an error when type is array and object is not an array with e
   }
 
   const stringify = build(schema, { schema: externalSchema })
-  t.throws(() => stringify({ arr: { foo: 'hello' } }), new TypeError('The value of \'arrayOfNumbers#/definitions/arr\' does not match schema definition.'))
+  throws(() => stringify({ arr: { foo: 'hello' } }), new TypeError('The value of \'arrayOfNumbers#/definitions/arr\' does not match schema definition.'))
 })
 
-test('throw an error if none of types matches', (t) => {
-  t.plan(1)
-
+describe('throw an error if none of types matches', (t) => {
   const schema = {
     title: 'simple object with multi-type nullable primitive',
     type: 'object',
@@ -546,5 +511,5 @@ test('throw an error if none of types matches', (t) => {
   }
 
   const stringify = build(schema)
-  t.throws(() => stringify({ data: 'string' }), 'The value "string" does not match schema definition.')
+  throws(() => stringify({ data: 'string' }), 'The value "string" does not match schema definition.')
 })

--- a/test/unknownFormats.test.js
+++ b/test/unknownFormats.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const build = require('..')
 
 test('object with custom format field', (t) => {
@@ -19,9 +19,9 @@ test('object with custom format field', (t) => {
 
   const stringify = build(schema)
 
-  stringify({
-    str: 'string'
+  t.assert.doesNotThrow(() => {
+    stringify({
+      str: 'string'
+    })
   })
-
-  t.pass()
 })

--- a/test/unknownFormats.test.js
+++ b/test/unknownFormats.test.js
@@ -1,11 +1,9 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
 const build = require('..')
 
-test('object with custom format field', (t) => {
-  t.plan(1)
-
+describe('object with custom format field', (t) => {
   const schema = {
     title: 'object with custom format field',
     type: 'object',
@@ -22,6 +20,4 @@ test('object with custom format field', (t) => {
   stringify({
     str: 'string'
   })
-
-  t.pass()
 })

--- a/test/webpack.test.js
+++ b/test/webpack.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const webpack = require('webpack')
 const path = require('path')
 
@@ -46,5 +46,5 @@ test('the library should work with webpack', async (t) => {
   })
 
   const obj = { foo: '42', bar: true }
-  t.equal(stringify(obj), '{"foo":"42","bar":true}')
+  t.assert.equal(stringify(obj), '{"foo":"42","bar":true}')
 })

--- a/test/webpack.test.js
+++ b/test/webpack.test.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const test = require('tap').test
+const { describe } = require('node:test')
+const { equal } = require('node:assert')
 const webpack = require('webpack')
 const path = require('path')
 
-test('the library should work with webpack', async (t) => {
-  t.plan(1)
+describe('the library should work with webpack', async (t) => {
   const targetdir = path.resolve(__dirname, '..', '.cache')
   const targetname = path.join(targetdir, 'webpacktest.js')
   const wopts = {
@@ -46,5 +46,5 @@ test('the library should work with webpack', async (t) => {
   })
 
   const obj = { foo: '42', bar: true }
-  t.equal(stringify(obj), '{"foo":"42","bar":true}')
+  equal(stringify(obj), '{"foo":"42","bar":true}')
 })


### PR DESCRIPTION
1. Converted all the tests in the repo from `tap` to `node:test` and `node:assert`
2. Removed the `tap` dependency and related configuration files

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
