### PR TITLE
refactor: replace `var` statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,20 +252,16 @@ const numberKeywords = [
  * https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-01#section-6
  */
 function inferTypeByKeyword (schema) {
-  // eslint-disable-next-line
-  for (var keyword of objectKeywords) {
+  for (let keyword of objectKeywords) {
     if (keyword in schema) return 'object'
   }
-  // eslint-disable-next-line
-  for (var keyword of arrayKeywords) {
+  for (let keyword of arrayKeywords) {
     if (keyword in schema) return 'array'
   }
-  // eslint-disable-next-line
-  for (var keyword of stringKeywords) {
+  for (let keyword of stringKeywords) {
     if (keyword in schema) return 'string'
   }
-  // eslint-disable-next-line
-  for (var keyword of numberKeywords) {
+  for (let keyword of numberKeywords) {
     if (keyword in schema) return 'number'
   }
   return schema.type

--- a/index.js
+++ b/index.js
@@ -252,16 +252,16 @@ const numberKeywords = [
  * https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-01#section-6
  */
 function inferTypeByKeyword (schema) {
-  for (let keyword of objectKeywords) {
+  for (const keyword of objectKeywords) {
     if (keyword in schema) return 'object'
   }
-  for (let keyword of arrayKeywords) {
+  for (const keyword of arrayKeywords) {
     if (keyword in schema) return 'array'
   }
-  for (let keyword of stringKeywords) {
+  for (const keyword of stringKeywords) {
     if (keyword in schema) return 'string'
   }
-  for (let keyword of numberKeywords) {
+  for (const keyword of numberKeywords) {
     if (keyword in schema) return 'number'
   }
   return schema.type

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -102,8 +102,7 @@ module.exports = class Serializer {
       let result = ''
       let last = -1
       let point = 255
-      // eslint-disable-next-line
-      for (var i = 0; i < len; i++) {
+      for (let i = 0; i < len; i++) {
         point = str.charCodeAt(i)
         if (
           point === 0x22 || // '"'


### PR DESCRIPTION
See https://github.com/fastify/fastify/issues/5756

Benchmarks:

```
> fast-json-stringify@6.0.0 bench
> node ./benchmark/bench.js

short string............................................. x 31,349,530 ops/sec ±0.31% (193 runs sampled)
unsafe short string...................................... x 1,802,803,481 ops/sec ±0.10% (194 runs sampled)
short string with double quote........................... x 19,272,037 ops/sec ±0.24% (193 runs sampled)
long string without double quotes........................ x 15,877 ops/sec ±0.15% (196 runs sampled)
unsafe long string without double quotes................. x 1,805,311,324 ops/sec ±0.09% (196 runs sampled)
long string.............................................. x 14,947 ops/sec ±0.25% (195 runs sampled)
unsafe long string....................................... x 1,806,650,421 ops/sec ±0.10% (196 runs sampled)
number................................................... x 1,804,422,038 ops/sec ±0.14% (196 runs sampled)
integer.................................................. x 267,442,465 ops/sec ±0.13% (195 runs sampled)
formatted date-time...................................... x 1,418,094 ops/sec ±0.20% (195 runs sampled)
formatted date........................................... x 1,184,518 ops/sec ±0.24% (194 runs sampled)
formatted time........................................... x 1,164,235 ops/sec ±1.76% (191 runs sampled)
short array of numbers................................... x 76,988 ops/sec ±3.13% (176 runs sampled)
short array of integers.................................. x 107,147 ops/sec ±0.46% (192 runs sampled)
short array of short strings............................. x 27,265 ops/sec ±0.24% (193 runs sampled)
short array of long strings.............................. x 27,155 ops/sec ±0.20% (189 runs sampled)
short array of objects with properties of different types x 14,711 ops/sec ±0.29% (193 runs sampled)
object with number property.............................. x 1,801,200,799 ops/sec ±0.09% (196 runs sampled)
object with integer property............................. x 269,369,444 ops/sec ±0.11% (196 runs sampled)
object with short string property........................ x 31,059,097 ops/sec ±0.26% (193 runs sampled)
object with long string property......................... x 15,142 ops/sec ±0.14% (196 runs sampled)
object with properties of different types................ x 3,061,414 ops/sec ±0.26% (194 runs sampled)
simple object............................................ x 14,934,076 ops/sec ±0.30% (191 runs sampled)
simple object with required fields....................... x 15,324,092 ops/sec ±0.23% (194 runs sampled)
object with const string property........................ x 1,789,865,450 ops/sec ±0.18% (195 runs sampled)
object with const number property........................ x 1,796,809,786 ops/sec ±0.14% (196 runs sampled)
object with const bool property.......................... x 1,763,976,530 ops/sec ±0.46% (194 runs sampled)
object with const object property........................ x 1,759,086,849 ops/sec ±0.21% (193 runs sampled)
object with const null property.......................... x 1,768,421,296 ops/sec ±0.16% (192 runs sampled)

Checking out "master"
Execute "npm run bench"

> fast-json-stringify@6.0.0 bench
> node ./benchmark/bench.js

short string............................................. x 23,912,633 ops/sec ±3.26% (189 runs sampled)
unsafe short string...................................... x 1,774,499,751 ops/sec ±0.18% (195 runs sampled)
short string with double quote........................... x 18,989,670 ops/sec ±0.24% (193 runs sampled)
long string without double quotes........................ x 15,537 ops/sec ±0.21% (194 runs sampled)
unsafe long string without double quotes................. x 1,778,937,405 ops/sec ±0.17% (194 runs sampled)
long string.............................................. x 14,970 ops/sec ±0.18% (193 runs sampled)
unsafe long string....................................... x 1,780,989,200 ops/sec ±0.29% (194 runs sampled)
number................................................... x 1,800,349,688 ops/sec ±0.24% (195 runs sampled)
integer.................................................. x 268,647,172 ops/sec ±0.22% (194 runs sampled)
formatted date-time...................................... x 1,415,994 ops/sec ±0.26% (196 runs sampled)
formatted date........................................... x 1,194,071 ops/sec ±0.21% (195 runs sampled)
formatted time........................................... x 1,191,121 ops/sec ±0.24% (195 runs sampled)
short array of numbers................................... x 118,071 ops/sec ±0.65% (191 runs sampled)
short array of integers.................................. x 117,691 ops/sec ±0.39% (193 runs sampled)
short array of short strings............................. x 27,034 ops/sec ±0.25% (186 runs sampled)
short array of long strings.............................. x 27,887 ops/sec ±0.24% (192 runs sampled)
short array of objects with properties of different types x 14,225 ops/sec ±1.26% (186 runs sampled)
object with number property.............................. x 1,386,347,717 ops/sec ±2.64% (177 runs sampled)
object with integer property............................. x 268,999,488 ops/sec ±0.18% (196 runs sampled)
object with short string property........................ x 31,696,967 ops/sec ±0.22% (193 runs sampled)
object with long string property......................... x 14,956 ops/sec ±0.17% (195 runs sampled)
object with properties of different types................ x 3,339,428 ops/sec ±0.25% (194 runs sampled)
simple object............................................ x 15,121,786 ops/sec ±0.24% (194 runs sampled)
simple object with required fields....................... x 15,377,960 ops/sec ±0.27% (194 runs sampled)
object with const string property........................ x 1,805,443,865 ops/sec ±0.08% (195 runs sampled)
object with const number property........................ x 1,797,637,123 ops/sec ±0.16% (192 runs sampled)
object with const bool property.......................... x 1,799,121,125 ops/sec ±0.13% (193 runs sampled)
object with const object property........................ x 1,806,433,745 ops/sec ±0.10% (195 runs sampled)
object with const null property.......................... x 1,793,772,787 ops/sec ±0.21% (195 runs sampled)

short string..............................................+31.1%
unsafe short string........................................+1.6%
short string with double quote............................+1.49%
long string without double quotes.........................+2.19%
unsafe long string without double quotes..................+1.48%
long string...............................................-0.15%
unsafe long string........................................+1.44%
number....................................................+0.23%
integer...................................................-0.45%
formatted date-time.......................................+0.15%
formatted date.............................................-0.8%
formatted time............................................-2.26%
short array of numbers....................................-34.8%
short array of integers...................................-8.96%
short array of short strings..............................+0.85%
short array of long strings...............................-2.62%
short array of objects with properties of different types.+3.42%
object with number property..............................+29.92%
object with integer property..............................+0.14%
object with short string property.........................-2.01%
object with long string property..........................+1.24%
object with properties of different types.................-8.33%
simple object.............................................-1.24%
simple object with required fields........................-0.35%
object with const string property.........................-0.86%
object with const number property.........................-0.05%
object with const bool property...........................-1.95%
object with const object property.........................-2.62%
object with const null property...........................-1.41%
Back to ref/var 3979ddd
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
