### PR TITLE
perf: direct access to serialize method

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ let largeArraySize = 2e4
 let largeArrayMechanism = 'default'
 
 const serializerFns = `
-let {
+const {
   asString,
   asInteger,
   asNumber,
@@ -27,7 +27,7 @@ let {
   asUnsafeString
 } = serializer
 
-asInteger = asInteger.bind(serializer)
+const asInteger = serializer.asInteger.bind(serializer)
 
 `
 

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ let {
   asDateTime,
   asDate,
   asTime,
+  asUnsafeString
 } = serializer
 
 asInteger = asInteger.bind(serializer)

--- a/index.js
+++ b/index.js
@@ -15,6 +15,21 @@ const SINGLE_TICK = /'/g
 let largeArraySize = 2e4
 let largeArrayMechanism = 'default'
 
+const serializerFns = `
+let {
+  asString,
+  asInteger,
+  asNumber,
+  asBoolean,
+  asDateTime,
+  asDate,
+  asTime,
+} = serializer
+
+asNumber = asNumber.bind(serializer)
+
+`
+
 const validRoundingMethods = [
   'floor',
   'ceil',
@@ -141,6 +156,7 @@ function build (schema, options) {
   const code = buildValue(context, location, 'input')
 
   let contextFunctionCode = `
+    ${serializerFns}
     const JSON_STR_BEGIN_OBJECT = '{'
     const JSON_STR_END_OBJECT = '}'
     const JSON_STR_BEGIN_ARRAY = '['
@@ -292,7 +308,7 @@ function buildExtraObjectPropertiesSerializer (context, location, addComma) {
       code += `
         if (/${propertyKey.replace(/\\*\//g, '\\/')}/.test(key)) {
           ${addComma}
-          json += serializer.asString(key) + JSON_STR_COLONS
+          json += asString(key) + JSON_STR_COLONS
           ${buildValue(context, propertyLocation, 'value')}
           continue
         }
@@ -307,13 +323,13 @@ function buildExtraObjectPropertiesSerializer (context, location, addComma) {
     if (additionalPropertiesSchema === true) {
       code += `
         ${addComma}
-        json += serializer.asString(key) + JSON_STR_COLONS + JSON.stringify(value)
+        json += asString(key) + JSON_STR_COLONS + JSON.stringify(value)
       `
     } else {
       const propertyLocation = location.getPropertyLocation('additionalProperties')
       code += `
         ${addComma}
-        json += serializer.asString(key) + JSON_STR_COLONS
+        json += asString(key) + JSON_STR_COLONS
         ${buildValue(context, propertyLocation, 'value')}
       `
     }
@@ -729,13 +745,13 @@ function buildSingleTypeSerializer (context, location, input) {
       return 'json += JSON_STR_NULL'
     case 'string': {
       if (schema.format === 'date-time') {
-        return `json += serializer.asDateTime(${input})`
+        return `json += asDateTime(${input})`
       } else if (schema.format === 'date') {
-        return `json += serializer.asDate(${input})`
+        return `json += asDate(${input})`
       } else if (schema.format === 'time') {
-        return `json += serializer.asTime(${input})`
+        return `json += asTime(${input})`
       } else if (schema.format === 'unsafe') {
-        return `json += serializer.asUnsafeString(${input})`
+        return `json += asUnsafeString(${input})`
       } else {
         return `
         if (typeof ${input} !== 'string') {
@@ -744,22 +760,22 @@ function buildSingleTypeSerializer (context, location, input) {
           } else if (${input} instanceof Date) {
             json += JSON_STR_QUOTE + ${input}.toISOString() + JSON_STR_QUOTE
           } else if (${input} instanceof RegExp) {
-            json += serializer.asString(${input}.source)
+            json += asString(${input}.source)
           } else {
-            json += serializer.asString(${input}.toString())
+            json += asString(${input}.toString())
           }
         } else {
-          json += serializer.asString(${input})
+          json += asString(${input})
         }
         `
       }
     }
     case 'integer':
-      return `json += serializer.asInteger(${input})`
+      return `json += asInteger(${input})`
     case 'number':
-      return `json += serializer.asNumber(${input})`
+      return `json += asNumber(${input})`
     case 'boolean':
-      return `json += serializer.asBoolean(${input})`
+      return `json += asBoolean(${input})`
     case 'object': {
       const funcName = buildObject(context, location)
       return `json += ${funcName}(${input})`

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ let largeArrayMechanism = 'default'
 const serializerFns = `
 const {
   asString,
-  asInteger,
   asNumber,
   asBoolean,
   asDateTime,

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ let {
   asTime,
 } = serializer
 
-asNumber = asNumber.bind(serializer)
+asInteger = asInteger.bind(serializer)
 
 `
 


### PR DESCRIPTION
Direct access to serialize method (eg.: `asString(key)`) instead of access to object/method (eg.: `serializer.asString(key)`)

**PR**
```
short string............................................. x 26,715,109 ops/sec ±1.66% (186 runs sampled)
unsafe short string...................................... x 144,926,182 ops/sec ±2.70% (178 runs sampled)
short string with double quote........................... x 14,302,995 ops/sec ±0.71% (187 runs sampled)
long string without double quotes........................ x 13,117 ops/sec ±0.44% (192 runs sampled)
unsafe long string without double quotes................. x 136,037,346 ops/sec ±3.21% (174 runs sampled)
long string.............................................. x 12,649 ops/sec ±0.53% (189 runs sampled)
unsafe long string....................................... x 140,424,165 ops/sec ±3.30% (173 runs sampled)
number................................................... x 141,936,485 ops/sec ±2.62% (176 runs sampled)
integer.................................................. x 116,027,589 ops/sec ±2.30% (181 runs sampled)
formatted date-time...................................... x 1,208,504 ops/sec ±0.54% (189 runs sampled)
formatted date........................................... x 1,004,965 ops/sec ±0.44% (190 runs sampled)
formatted time........................................... x 1,011,317 ops/sec ±0.49% (192 runs sampled)
short array of numbers................................... x 64,741 ops/sec ±0.73% (183 runs sampled)
short array of integers.................................. x 59,744 ops/sec ±0.64% (185 runs sampled)
short array of long strings.............................. x 19,351 ops/sec ±0.46% (190 runs sampled)
```

**MASTER**
```
short string............................................. x 26,372,524 ops/sec ±1.51% (187 runs sampled)
unsafe short string...................................... x 135,783,091 ops/sec ±3.67% (176 runs sampled)
short string with double quote........................... x 14,744,744 ops/sec ±0.61% (190 runs sampled)
long string without double quotes........................ x 13,022 ops/sec ±0.52% (191 runs sampled)
unsafe long string without double quotes................. x 141,731,330 ops/sec ±3.09% (173 runs sampled)
long string.............................................. x 13,091 ops/sec ±0.43% (192 runs sampled)
unsafe long string....................................... x 140,741,175 ops/sec ±3.24% (175 runs sampled)
number................................................... x 139,034,507 ops/sec ±3.69% (172 runs sampled)
integer.................................................. x 129,740,924 ops/sec ±3.11% (179 runs sampled)
formatted date-time...................................... x 1,226,870 ops/sec ±0.51% (192 runs sampled)
formatted date........................................... x 1,009,991 ops/sec ±0.50% (190 runs sampled)
formatted time........................................... x 1,023,148 ops/sec ±0.41% (191 runs sampled)
short array of numbers................................... x 71,547 ops/sec ±0.53% (189 runs sampled)
short array of integers.................................. x 69,933 ops/sec ±0.57% (191 runs sampled)
short array of short strings............................. x 19,665 ops/sec ±0.43% (190 runs sampled)
short array of long strings.............................. x 19,480 ops/sec ±0.52% (190 runs sampled)
```