### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "c8": "^10.1.2",
     "cli-select": "^1.1.2",
     "compile-json-stringify": "^0.1.2",
+    "eslint": "^9.17.0",
     "fast-json-stringify": ".",
     "is-my-json-valid": "^2.20.6",
     "neostandard": "^0.12.0",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.