### PR TITLE
perf: Cache obj[key] access into (missed property from PR 707)

### DIFF
--- a/index.js
+++ b/index.js
@@ -580,16 +580,18 @@ function buildArray (context, location) {
     if (schema.additionalItems) {
       functionCode += `
         for (let i = ${itemsSchema.length}; i < arrayLength; i++) {
-          json += JSON.stringify(obj[i])
+          value = obj[i]
+          json += JSON.stringify(value)
           if (i < arrayEnd) {
             json += JSON_STR_COMMA
           }
         }`
     }
   } else {
-    const code = buildValue(context, itemsLocation, 'obj[i]')
+    const code = buildValue(context, itemsLocation, 'value')
     functionCode += `
       for (let i = 0; i < arrayLength; i++) {
+        value = obj[i]
         ${code}
         if (i < arrayEnd) {
           json += JSON_STR_COMMA


### PR DESCRIPTION
This PR complete the https://github.com/fastify/fast-json-stringify/pull/707

> Caching the value of obj[key] into a variable instead of continue access to object

