### PR TITLE
ci(.github): use latest node version

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,6 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
+          check-latest: true
           node-version: 18
 
       - name: Install


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5577. This is a batch PR, so may have some issues. Please review changes.