### PR TITLE
ci: use tags for immutable github actions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,13 +17,13 @@ jobs:
       PR-BENCH: ${{ steps.benchmark-pr.outputs.BENCH_RESULT }}
       MAIN-BENCH: ${{ steps.benchmark-main.outputs.BENCH_RESULT }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: ${{github.event.pull_request.head.sha}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@v4
         with:
           check-latest: true
           node-version: 20
@@ -43,7 +43,7 @@ jobs:
           echo "::set-output name=BENCH_RESULT::$content"
 
       # main benchmark
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v4
         with:
           ref: 'main'
           persist-credentials: false


### PR DESCRIPTION
Most first party actions now use https://github.com/actions/publish-immutable-action, which negates the need for commit hashes