### PR TITLE
fix: update fjs_type validation to check for toJSON method

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -21,8 +21,8 @@ class Validator {
       keyword: 'fjs_type',
       type: 'object',
       errors: false,
-      validate: (_type, date) => {
-        return date instanceof Date
+      validate: (_type, data) => {
+        return data && typeof data.toJSON === 'function'
       }
     })
 
@@ -51,8 +51,10 @@ class Validator {
     return this.ajv.validate(schemaRef, data)
   }
 
-  // Ajv does not support js date format. In order to properly validate objects containing a date,
-  // it needs to replace all occurrences of the string date format with a custom keyword fjs_type.
+  // Ajv does not natively support JavaScript objects like Date or other types
+  // that rely on a custom .toJSON() representation. To properly validate schemas
+  // that may contain such objects (e.g. Date, ObjectId, etc.), we replace all
+  // occurrences of the string type with a custom keyword fjs_type
   // (see https://github.com/fastify/fast-json-stringify/pull/441)
   convertSchemaToAjvFormat (schema) {
     if (schema === null) return


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

This PR fixes an issue where **custom object formats failed during serialization when nested inside a `Union` type** (check https://github.com/fastify/fast-json-stringify/issues/779).

Previously, the `fjs_type` keyword was used to support JavaScript `Date` objects, since Ajv does not natively validate them. This PR **extends that logic to all objects implementing a `.toJSON()` method**, ensuring they are serialized correctly (for example, MongoDB `ObjectId`).

### Key Points

✅ Extends `fjs_type` handling beyond Date to any `.toJSON()`-capable object.
✅ Ensures correct serialization for custom formats like `ObjectId`.
✅ Backward compatibility is preserved since `Date` objects already implement `.toJSON()` (returning an ISO string).
