### PR TITLE
test: isWellFormed (PR 774) break the lib

### DIFF
--- a/test/string.test.js
+++ b/test/string.test.js
@@ -34,6 +34,21 @@ test('serialize short string', (t) => {
   t.assert.equal(JSON.parse(output), input)
 })
 
+test('serialize medium string', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'string'
+  }
+
+  const input = new Array(2e4).fill('\x00').join('')
+  const stringify = build(schema)
+  const output = stringify(input)
+
+  t.assert.equal(output, `"${new Array(150).fill('\\u0000').join('')}"`)
+  t.assert.equal(JSON.parse(output), input)
+})
+
 test('serialize long string', (t) => {
   t.plan(2)
 


### PR DESCRIPTION
`isWellFormed` don't works like the regex `/[\u0000-\u001f\u0022\u005c\ud800-\udfff]/`

This commit must be reverted
https://github.com/fastify/fast-json-stringify/commit/7f48cb6b21e41ccc37fbad09338d6c7e5f107ab3

This PR https://github.com/fastify/fast-json-stringify/pull/774 just pass the test, because no test match the condition >40 chars <5000

I have added a test (serialize medium string) that enter in this condition
```
# Subtest: serialize short string
ok 362 - serialize short string

# Subtest: serialize medium string
not ok 363 - serialize medium string

# Subtest: serialize long string
ok 364 - serialize long string
```

The regex `[\u0000-\u001f\u0022\u005c\ud800-\udfff]/` check for:
1. ASCII (U+0000–U+001F)
3. Char `"`
5. Char `\`
4. UTF-16 (\uD800–\uDFFF)

`isWellFormed()` only check case 4

These are case need escape but isWellFormed says are good!
```js
'"'.isWellFormed()
true

'\\'.isWellFormed()
true

'\n'.isWellFormed()
true
```