### PR TITLE
perf: avoid unnecessary access to array item

### DIFF
--- a/index.js
+++ b/index.js
@@ -581,7 +581,7 @@ function buildArray (context, location) {
       const tmpRes = buildValue(context, itemsLocation.getPropertyLocation(i), 'value')
       functionCode += `
         if (${i} < arrayLength) {
-          if (${buildArrayTypeCondition(item.type, `[${i}]`)}) {
+          if (${buildArrayTypeCondition(item.type, 'value')}) {
             ${tmpRes}
             if (${i} < arrayEnd) {
               json += JSON_STR_COMMA


### PR DESCRIPTION
I have missed a property from my previous PR: https://github.com/fastify/fast-json-stringify/pull/707