### PR TITLE
perf: improve-perfs

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,11 +142,9 @@ function build (schema, options) {
 
   if (options.largeArraySize) {
     const largeArraySizeType = typeof options.largeArraySize
-    if (largeArraySizeType === 'string') {
-      const newLargeArraySize = Number.parseInt(options.largeArraySize, 10)
-      if (Number.isFinite(newLargeArraySize)) {
-        largeArraySize = newLargeArraySize
-      }
+
+    if (largeArraySizeType === 'string' && Number.isFinite(Number.parseInt(options.largeArraySize, 10))) {
+      largeArraySize = Number.parseInt(options.largeArraySize, 10)
     } else if (largeArraySizeType === 'number' && Number.isInteger(options.largeArraySize)) {
       largeArraySize = options.largeArraySize
     } else if (largeArraySizeType === 'bigint') {

--- a/index.js
+++ b/index.js
@@ -142,9 +142,10 @@ function build (schema, options) {
 
   if (options.largeArraySize) {
     const largeArraySizeType = typeof options.largeArraySize
+    let parsedNumber
 
-    if (largeArraySizeType === 'string' && Number.isFinite(Number.parseInt(options.largeArraySize, 10))) {
-      largeArraySize = Number.parseInt(options.largeArraySize, 10)
+    if (largeArraySizeType === 'string' && Number.isFinite((parsedNumber = Number.parseInt(options.largeArraySize, 10)))) {
+      largeArraySize = parsedNumber
     } else if (largeArraySizeType === 'number' && Number.isInteger(options.largeArraySize)) {
       largeArraySize = options.largeArraySize
     } else if (largeArraySizeType === 'bigint') {

--- a/index.js
+++ b/index.js
@@ -30,17 +30,17 @@ const asInteger = serializer.asInteger.bind(serializer)
 
 `
 
-const validRoundingMethods = [
+const validRoundingMethods = new Set([
   'floor',
   'ceil',
   'round',
   'trunc'
-]
+])
 
-const validLargeArrayMechanisms = [
+const validLargeArrayMechanisms = new Set([
   'default',
   'json-stringify'
-]
+])
 
 let schemaIdCounter = 0
 
@@ -127,13 +127,13 @@ function build (schema, options) {
   }
 
   if (options.rounding) {
-    if (!validRoundingMethods.includes(options.rounding)) {
+    if (!validRoundingMethods.has(options.rounding)) {
       throw new Error(`Unsupported integer rounding method ${options.rounding}`)
     }
   }
 
   if (options.largeArrayMechanism) {
-    if (validLargeArrayMechanisms.includes(options.largeArrayMechanism)) {
+    if (validLargeArrayMechanisms.has(options.largeArrayMechanism)) {
       largeArrayMechanism = options.largeArrayMechanism
     } else {
       throw new Error(`Unsupported large array mechanism ${options.largeArrayMechanism}`)
@@ -141,11 +141,15 @@ function build (schema, options) {
   }
 
   if (options.largeArraySize) {
-    if (typeof options.largeArraySize === 'string' && Number.isFinite(Number.parseInt(options.largeArraySize, 10))) {
-      largeArraySize = Number.parseInt(options.largeArraySize, 10)
-    } else if (typeof options.largeArraySize === 'number' && Number.isInteger(options.largeArraySize)) {
+    const largeArraySizeType = typeof options.largeArraySize
+    if (largeArraySizeType === 'string') {
+      const newLargeArraySize = Number.parseInt(options.largeArraySize, 10)
+      if (Number.isFinite(newLargeArraySize)) {
+        largeArraySize = newLargeArraySize
+      }
+    } else if (largeArraySizeType === 'number' && Number.isInteger(options.largeArraySize)) {
       largeArraySize = options.largeArraySize
-    } else if (typeof options.largeArraySize === 'bigint') {
+    } else if (largeArraySizeType === 'bigint') {
       largeArraySize = Number(options.largeArraySize)
     } else {
       throw new Error(`Unsupported large array size. Expected integer-like, got ${typeof options.largeArraySize} with value ${options.largeArraySize}`)
@@ -423,7 +427,7 @@ function buildInnerObject (context, location) {
 }
 
 function mergeLocations (context, mergedSchemaId, mergedLocations) {
-  for (let i = 0; i < mergedLocations.length; i++) {
+  for (let i = 0, mergedLocationsLength = mergedLocations.length; i < mergedLocationsLength; i++) {
     const location = mergedLocations[i]
     const schema = location.schema
     if (schema.$ref) {
@@ -575,7 +579,7 @@ function buildArray (context, location) {
   `
 
   if (Array.isArray(itemsSchema)) {
-    for (let i = 0; i < itemsSchema.length; i++) {
+    for (let i = 0, itemsSchemaLength = itemsSchema.length; i < itemsSchemaLength; i++) {
       const item = itemsSchema[i]
       functionCode += `value = obj[${i}]`
       const tmpRes = buildValue(context, itemsLocation.getPropertyLocation(i), 'value')
@@ -842,7 +846,7 @@ function buildAllOf (context, location, input) {
   ]
 
   const allOfsLocation = location.getPropertyLocation('allOf')
-  for (let i = 0; i < allOf.length; i++) {
+  for (let i = 0, allOfsLength = allOfsLocation.length; i < allOfsLength; i++) {
     locations.push(allOfsLocation.getPropertyLocation(i))
   }
 
@@ -867,7 +871,7 @@ function buildOneOf (context, location, input) {
 
   let code = ''
 
-  for (let index = 0; index < oneOfs.length; index++) {
+  for (let index = 0, oneOfsLength = oneOfs.length; index < oneOfsLength; index++) {
     const optionLocation = oneOfsLocation.getPropertyLocation(index)
     const optionSchema = optionLocation.schema
 

--- a/index.js
+++ b/index.js
@@ -352,19 +352,19 @@ function buildInnerObject (context, location) {
   const requiredProperties = schema.required || []
 
   // Should serialize required properties first
-  const propertiesKeys = Object.keys(schema.properties || {}).sort(
+  const propertiesKeys = new Set(Object.keys(schema.properties || {}).sort(
     (key1, key2) => {
       const required1 = requiredProperties.includes(key1)
       const required2 = requiredProperties.includes(key2)
       return required1 === required2 ? 0 : required1 ? -1 : 1
     }
-  )
+  ))
   const hasRequiredProperties = requiredProperties.includes(propertiesKeys[0])
 
   let code = 'let value\n'
 
   for (const key of requiredProperties) {
-    if (!propertiesKeys.includes(key)) {
+    if (!propertiesKeys.has(key)) {
       const sanitizedKey = JSON.stringify(key)
       code += `if (obj[${sanitizedKey}] === undefined) throw new Error('${sanitizedKey.replace(/'/g, '\\\'')} is required!')\n`
     }
@@ -846,7 +846,7 @@ function buildAllOf (context, location, input) {
   ]
 
   const allOfsLocation = location.getPropertyLocation('allOf')
-  for (let i = 0, allOfsLength = allOfsLocation.length; i < allOfsLength; i++) {
+  for (let i = 0, allOfLength = allOf.length; i < allOfLength; i++) {
     locations.push(allOfsLocation.getPropertyLocation(i))
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

### Benchmarks

Main:
```
FJS creation x 22,718 ops/sec ±0.78% (97 runs sampled)
CJS creation x 274,085 ops/sec ±1.31% (91 runs sampled)
AJV Serialize creation x 96,969,652 ops/sec ±2.25% (87 runs sampled)
json-accelerator creation x 1,462,630 ops/sec ±0.45% (97 runs sampled)
JSON.stringify array x 16,035 ops/sec ±0.45% (97 runs sampled)
fast-json-stringify array default x 14,639 ops/sec ±0.48% (100 runs sampled)
json-accelerator array x 11,567 ops/sec ±0.60% (97 runs sampled)
fast-json-stringify array json-stringify x 14,630 ops/sec ±0.32% (96 runs sampled)
compile-json-stringify array x 12,554 ops/sec ±0.84% (94 runs sampled)
AJV Serialize array x 13,289 ops/sec ±0.53% (98 runs sampled)
JSON.stringify large array x 668 ops/sec ±0.50% (92 runs sampled)
fast-json-stringify large array default x 584 ops/sec ±0.43% (83 runs sampled)
fast-json-stringify large array json-stringify x 673 ops/sec ±1.11% (93 runs sampled)
compile-json-stringify large array x 568 ops/sec ±0.40% (92 runs sampled)
AJV Serialize large array x 623 ops/sec ±0.38% (95 runs sampled)
JSON.stringify long string x 63,565 ops/sec ±0.51% (95 runs sampled)
fast-json-stringify long string x 63,195 ops/sec ±0.69% (98 runs sampled)
json-accelerator long string x 63,824 ops/sec ±0.48% (96 runs sampled)
compile-json-stringify long string x 63,838 ops/sec ±0.52% (95 runs sampled)
AJV Serialize long string x 29,409 ops/sec ±0.64% (96 runs sampled)
JSON.stringify short string x 25,843,438 ops/sec ±0.64% (98 runs sampled)
fast-json-stringify short string x 75,164,429 ops/sec ±1.97% (90 runs sampled)
json-accelerator short string x 76,927,958 ops/sec ±1.50% (91 runs sampled)
compile-json-stringify short string x 45,149,640 ops/sec ±1.82% (92 runs sampled)
AJV Serialize short string x 49,126,961 ops/sec ±1.36% (88 runs sampled)
JSON.stringify obj x 9,218,881 ops/sec ±0.35% (98 runs sampled)
fast-json-stringify obj x 14,708,149 ops/sec ±0.32% (97 runs sampled)
json-accelerator obj x 12,972,310 ops/sec ±0.59% (96 runs sampled)
compile-json-stringify obj x 30,034,675 ops/sec ±1.09% (96 runs sampled)
AJV Serialize obj x 25,647,842 ops/sec ±0.57% (97 runs sampled)
JSON stringify date x 1,736,113 ops/sec ±0.24% (98 runs sampled)
fast-json-stringify date format x 2,473,266 ops/sec ±0.27% (98 runs sampled)
json-accelerate date format x 2,466,332 ops/sec ±0.28% (98 runs sampled)
compile-json-stringify date format x 1,736,477 ops/sec ±0.40% (100 runs sampled)
```

PR:
```
FJS creation x 23,365 ops/sec ±0.78% (96 runs sampled)
CJS creation x 283,284 ops/sec ±0.31% (99 runs sampled)
AJV Serialize creation x 112,666,375 ops/sec ±1.63% (95 runs sampled)
json-accelerator creation x 1,528,582 ops/sec ±0.54% (99 runs sampled)
JSON.stringify array x 16,436 ops/sec ±0.32% (100 runs sampled)
fast-json-stringify array default x 15,325 ops/sec ±0.48% (98 runs sampled)
json-accelerator array x 12,012 ops/sec ±0.28% (99 runs sampled)
fast-json-stringify array json-stringify x 15,151 ops/sec ±0.39% (97 runs sampled)
compile-json-stringify array x 13,226 ops/sec ±0.39% (98 runs sampled)
AJV Serialize array x 13,864 ops/sec ±0.34% (99 runs sampled)
JSON.stringify large array x 685 ops/sec ±1.31% (94 runs sampled)
fast-json-stringify large array default x 598 ops/sec ±0.43% (84 runs sampled)
fast-json-stringify large array json-stringify x 689 ops/sec ±0.45% (94 runs sampled)
compile-json-stringify large array x 583 ops/sec ±0.43% (95 runs sampled)
AJV Serialize large array x 632 ops/sec ±0.34% (91 runs sampled)
JSON.stringify long string x 64,483 ops/sec ±0.50% (98 runs sampled)
fast-json-stringify long string x 64,886 ops/sec ±0.56% (97 runs sampled)
json-accelerator long string x 64,525 ops/sec ±0.45% (95 runs sampled)
compile-json-stringify long string x 64,946 ops/sec ±0.48% (92 runs sampled)
AJV Serialize long string x 30,062 ops/sec ±0.31% (96 runs sampled)
JSON.stringify short string x 25,635,151 ops/sec ±0.96% (98 runs sampled)
fast-json-stringify short string x 77,976,957 ops/sec ±1.52% (92 runs sampled)
json-accelerator short string x 76,716,105 ops/sec ±1.34% (95 runs sampled)
compile-json-stringify short string x 48,370,586 ops/sec ±1.09% (97 runs sampled)
AJV Serialize short string x 51,103,059 ops/sec ±1.10% (94 runs sampled)
JSON.stringify obj x 9,210,479 ops/sec ±0.50% (95 runs sampled)
fast-json-stringify obj x 14,952,465 ops/sec ±0.31% (99 runs sampled)
json-accelerator obj x 13,375,692 ops/sec ±0.36% (96 runs sampled)
compile-json-stringify obj x 30,524,819 ops/sec ±0.63% (96 runs sampled)
AJV Serialize obj x 25,625,599 ops/sec ±0.59% (92 runs sampled)
JSON stringify date x 1,733,028 ops/sec ±0.25% (100 runs sampled)
fast-json-stringify date format x 2,507,194 ops/sec ±0.27% (97 runs sampled)
json-accelerate date format x 2,508,081 ops/sec ±0.27% (101 runs sampled)
compile-json-stringify date format x 1,739,833 ops/sec ±0.21% (101 runs sampled)
```

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
