### PR TITLE
chore: use default time value (100 ms is too low)

### DIFF
--- a/benchmark/bench-cmp-lib.js
+++ b/benchmark/bench-cmp-lib.js
@@ -3,7 +3,6 @@
 const { Bench } = require('tinybench')
 const suite = new Bench({
   name: 'Library Comparison Benchmarks',
-  time: 100,
   setup: (_task, mode) => {
     // Run the garbage collector before warmup at each cycle
     if (mode === 'warmup' && typeof globalThis.gc === 'function') {

--- a/benchmark/bench-thread.js
+++ b/benchmark/bench-thread.js
@@ -6,7 +6,6 @@ const { Bench } = require('tinybench')
 
 const bench = new Bench({
   name: benchmark.name,
-  time: 100,
   setup: (_task, mode) => {
     // Run the garbage collector before warmup at each cycle
     if (mode === 'warmup' && typeof globalThis.gc === 'function') {


### PR DESCRIPTION
With https://github.com/fastify/fast-json-stringify/pull/803 I have misunderstanding the settings of `time` into tinybench. `time: 100` is 100 ms and is too low for a benchmark, the default time is `1000 ms`. This PR use the deafult value