### PR TITLE
perf(serializer): avoid addComma when not necessary

### DIFF
--- a/test/json-add-comma.test.js
+++ b/test/json-add-comma.test.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const { test } = require('node:test')
+const build = require('..')
+
+test('additionalProperties: false', (t) => {
+  t.plan(1)
+  const stringify = build({
+    title: 'additionalProperties',
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'string'
+      }
+    },
+    additionalProperties: false
+  })
+
+  const obj = { foo: 'a', bar: 'b', baz: 'c' }
+  t.assert.equal(stringify(obj), '{"foo":"a"}')
+})
+
+test('additionalProperties: {}', (t) => {
+  t.plan(1)
+  const stringify = build({
+    title: 'additionalProperties',
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'string'
+      }
+    },
+    additionalProperties: {}
+  })
+
+  const obj = { foo: 'a', bar: 'b', baz: 'c' }
+  t.assert.equal(stringify(obj), '{"foo":"a","bar":"b","baz":"c"}')
+})
+
+test('additionalProperties: {type: string}', (t) => {
+  t.plan(1)
+  const stringify = build({
+    title: 'additionalProperties',
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'string'
+      }
+    },
+    additionalProperties: {
+      type: 'string'
+    }
+  })
+
+  const obj = { foo: 'a', bar: 'b', baz: 'c' }
+  t.assert.equal(stringify(obj), '{"foo":"a","bar":"b","baz":"c"}')
+})


### PR DESCRIPTION
Just a small performance improvements when an object contains only one key or an array only one item, the fjs code avoid to check to `addComma` 

Currently this schema
```js
fjs({
    title: 'additionalProperties',
    type: 'object',
    properties: {
      foo: {
        type: 'string'
      }
    },
    additionalProperties: false
})
```

produce this fjs code
```js
function anonymous0 (input) {
      const obj = (input && typeof input.toJSON === 'function')
    ? input.toJSON()
    : input

      if (obj === null) return JSON_STR_EMPTY_OBJECT

      let json = JSON_STR_BEGIN_OBJECT
let addComma = false

      const value_foo_0 = obj["foo"]
      if (value_foo_0 !== undefined) {
        !addComma && (addComma = true) || (json += JSON_STR_COMMA)
        json += "\"foo\":"

        if (typeof value_foo_0 !== 'string') {
          if (value_foo_0 === null) {
            json += JSON_STR_EMPTY_STRING
          } else if (value_foo_0 instanceof Date) {
            json += JSON_STR_QUOTE + value_foo_0.toISOString() + JSON_STR_QUOTE
          } else if (value_foo_0 instanceof RegExp) {
            json += asString(value_foo_0.source)
          } else {
            json += asString(value_foo_0.toString())
          }
        } else {
          json += asString(value_foo_0)
        }

      }

    return json + JSON_STR_END_OBJECT

    }
```
whith this PR
```JS
function anonymous0 (input) {
      const obj = (input && typeof input.toJSON === 'function')
    ? input.toJSON()
    : input

      if (obj === null) return JSON_STR_EMPTY_OBJECT

      let json = JSON_STR_BEGIN_OBJECT

      const value_foo_0 = obj["foo"]
      if (value_foo_0 !== undefined) {

        json += "\"foo\":"

        if (typeof value_foo_0 !== 'string') {
          if (value_foo_0 === null) {
            json += JSON_STR_EMPTY_STRING
          } else if (value_foo_0 instanceof Date) {
            json += JSON_STR_QUOTE + value_foo_0.toISOString() + JSON_STR_QUOTE
          } else if (value_foo_0 instanceof RegExp) {
            json += asString(value_foo_0.source)
          } else {
            json += asString(value_foo_0.toString())
          }
        } else {
          json += asString(value_foo_0)
        }

      }

    return json + JSON_STR_END_OBJECT

    }
```

Diff
<img width="1668" height="629" alt="image" src="https://github.com/user-attachments/assets/26be1f5a-c278-4657-a9a9-6215b1ba07f4" />

Side note: the benchmark don't cover this case

