### PR TITLE
feat: enhance benchmarking output structure

### DIFF
--- a/benchmark/bench-cmp-lib.js
+++ b/benchmark/bench-cmp-lib.js
@@ -321,7 +321,7 @@ suite.run().then(() => {
     let scenario = 'Other'
     let library = result.name
 
-    if (result.name.startsWith('creation')) {
+    if (result.name.includes('creation')) {
       scenario = 'Schema Creation'
       library = result.name.replace(' creation', '')
     } else if (result.name.includes('large array')) {

--- a/benchmark/bench-cmp-lib.js
+++ b/benchmark/bench-cmp-lib.js
@@ -321,9 +321,9 @@ suite.run().then(() => {
     let scenario = 'Other'
     let library = result.name
 
-    if (result.name.startsWith('creation:')) {
+    if (result.name.startsWith('creation')) {
       scenario = 'Schema Creation'
-      library = result.name.replace('creation: ', '')
+      library = result.name.replace(' creation', '')
     } else if (result.name.includes('large array')) {
       scenario = 'Large Array'
       library = result.name.replace(' large array', '').replace('JSON.stringify', 'Native JSON')

--- a/benchmark/bench-cmp-lib.js
+++ b/benchmark/bench-cmp-lib.js
@@ -169,142 +169,140 @@ for (let i = STR_LEN; i < LARGE_ARRAY_SIZE; ++i) {
   }
 }
 
-Number(str)
-
 for (let i = 0; i < MULTI_ARRAY_LENGTH; i++) {
   multiArray[i] = obj
 }
 
-suite.add('fast-json-stringify creation', function () {
+suite.add('fast-json-stringify: creation', function () {
   FJS(schema)
 })
-suite.add('compile-json-stringify creation', function () {
+suite.add('compile-json-stringify: creation', function () {
   CJS(schemaCJS)
 })
-suite.add('AJV Serialize creation', function () {
+suite.add('AJV: creation', function () {
   ajv.compileSerializer(schemaAJVJTD)
 })
-suite.add('json-accelerator creation', function () {
+suite.add('json-accelerator: creation', function () {
   createAccelerator(schema)
 })
 
-suite.add('JSON.stringify array', function () {
+suite.add('JSON.stringify: array', function () {
   JSON.stringify(multiArray)
 })
 
-suite.add('fast-json-stringify array default', function () {
+suite.add('fast-json-stringify [default]: array', function () {
   stringifyArrayDefault(multiArray)
 })
 
-suite.add('json-accelerator array', function () {
+suite.add('json-accelerator: array', function () {
   accelArray(multiArray)
 })
 
-suite.add('fast-json-stringify array json-stringify', function () {
+suite.add('fast-json-stringify [json-stringify]: array', function () {
   stringifyArrayJSONStringify(multiArray)
 })
 
-suite.add('compile-json-stringify array', function () {
+suite.add('compile-json-stringify: array', function () {
   CJSStringifyArray(multiArray)
 })
 
-suite.add('AJV Serialize array', function () {
+suite.add('AJV: array', function () {
   ajvSerializeArray(multiArray)
 })
 
-suite.add('JSON.stringify large array', function () {
+suite.add('JSON.stringify: large array', function () {
   JSON.stringify(largeArray)
 })
 
-suite.add('fast-json-stringify large array default', function () {
+suite.add('fast-json-stringify [default]: large array', function () {
   stringifyArrayDefault(largeArray)
 })
 
-suite.add('fast-json-stringify large array json-stringify', function () {
+suite.add('fast-json-stringify [json-stringify]: large array', function () {
   stringifyArrayJSONStringify(largeArray)
 })
 
-suite.add('compile-json-stringify large array', function () {
+suite.add('compile-json-stringify: large array', function () {
   CJSStringifyArray(largeArray)
 })
 
-suite.add('AJV Serialize large array', function () {
+suite.add('AJV: large array', function () {
   ajvSerializeArray(largeArray)
 })
 
-suite.add('JSON.stringify long string', function () {
+suite.add('JSON.stringify: long string', function () {
   JSON.stringify(str)
 })
 
-suite.add('fast-json-stringify long string', function () {
+suite.add('fast-json-stringify: long string', function () {
   stringifyString(str)
 })
 
-suite.add('json-accelerator long string', function () {
+suite.add('json-accelerator: long string', function () {
   stringifyString(str)
 })
 
-suite.add('compile-json-stringify long string', function () {
+suite.add('compile-json-stringify: long string', function () {
   CJSStringifyString(str)
 })
 
-suite.add('AJV Serialize long string', function () {
+suite.add('AJV: long string', function () {
   ajvSerializeString(str)
 })
 
-suite.add('JSON.stringify short string', function () {
+suite.add('JSON.stringify: short string', function () {
   JSON.stringify('hello world')
 })
 
-suite.add('fast-json-stringify short string', function () {
+suite.add('fast-json-stringify: short string', function () {
   stringifyString('hello world')
 })
 
-suite.add('json-accelerator short string', function () {
+suite.add('json-accelerator: short string', function () {
   accelString('hello world')
 })
 
-suite.add('compile-json-stringify short string', function () {
+suite.add('compile-json-stringify: short string', function () {
   CJSStringifyString('hello world')
 })
 
-suite.add('AJV Serialize short string', function () {
+suite.add('AJV: short string', function () {
   ajvSerializeString('hello world')
 })
 
-suite.add('JSON.stringify obj', function () {
+suite.add('JSON.stringify: obj', function () {
   JSON.stringify(obj)
 })
 
-suite.add('fast-json-stringify obj', function () {
+suite.add('fast-json-stringify: obj', function () {
   stringify(obj)
 })
 
-suite.add('json-accelerator obj', function () {
+suite.add('json-accelerator: obj', function () {
   accelStringify(obj)
 })
 
-suite.add('compile-json-stringify obj', function () {
+suite.add('compile-json-stringify: obj', function () {
   CJSStringify(obj)
 })
 
-suite.add('AJV Serialize obj', function () {
+suite.add('AJV: obj', function () {
   ajvSerialize(obj)
 })
 
-suite.add('JSON stringify date', function () {
+suite.add('JSON.stringify: date', function () {
   JSON.stringify(date)
 })
 
-suite.add('fast-json-stringify date format', function () {
+suite.add('fast-json-stringify: date', function () {
   stringifyDate(date)
 })
 
-suite.add('json-accelerate date format', function () {
+suite.add('json-accelerate: date', function () {
   accelDate(date)
 })
 
-suite.add('compile-json-stringify date format', function () {
+suite.add('compile-json-stringify: date', function () {
   CJSStringifyDate(date)
 })
 
@@ -318,31 +316,7 @@ suite.run().then(() => {
 
   const scenarios = {}
   for (const result of results) {
-    let scenario = 'Other'
-    let library = result.name
-
-    if (result.name.includes('creation')) {
-      scenario = 'Schema Creation'
-      library = result.name.replace(' creation', '')
-    } else if (result.name.includes('large array')) {
-      scenario = 'Large Array'
-      library = result.name.replace(' large array', '').replace('JSON.stringify', 'Native JSON')
-    } else if (result.name.includes('array')) {
-      scenario = 'Small Array'
-      library = result.name.replace(' array', '').replace('JSON.stringify', 'Native JSON')
-    } else if (result.name.includes('long string')) {
-      scenario = 'Long String'
-      library = result.name.replace(' long string', '').replace('JSON.stringify', 'Native JSON')
-    } else if (result.name.includes('short string')) {
-      scenario = 'Short String'
-      library = result.name.replace(' short string', '').replace('JSON.stringify', 'Native JSON')
-    } else if (result.name.includes('obj')) {
-      scenario = 'Object'
-      library = result.name.replace(' obj', '').replace('JSON.stringify', 'Native JSON')
-    } else if (result.name.includes('date')) {
-      scenario = 'Date'
-      library = result.name.replace(' date format', '').replace('JSON stringify date', 'Native JSON')
-    }
+    const [library, scenario] = result.name.split(':').map(s => s.trim())
 
     if (!scenarios[scenario]) scenarios[scenario] = []
     scenarios[scenario].push({ ...result, library })
@@ -358,9 +332,8 @@ suite.run().then(() => {
       const formattedRme = task.rme.toFixed(2)
       const isWinner = task === winner
       const prefix = isWinner ? '🏆 ' : '   '
-      const suffix = isWinner ? ' (WINNER)' : ''
 
-      console.log(`${prefix}${task.library.padEnd(40)} x ${formattedHz.padStart(15)} ops/sec ±${formattedRme}% (${task.samples} runs sampled)${suffix}`)
+      console.log(`${prefix}${task.library.padEnd(40)} x ${formattedHz.padStart(15)} ops/sec ±${formattedRme}% (${task.samples} runs sampled)`)
     }
   }
 }).catch(err => console.error(`Error: ${err.message}`))


### PR DESCRIPTION
This is the new output of the[ benchmark lib compare](https://github.com/fastify/fast-json-stringify?tab=readme-ov-file#benchmarks)
```
npm run benchmark

> fast-json-stringify@6.2.0 benchmark
> node --expose-gc ./benchmark/bench-cmp-lib.js


--- creation ---
🏆 AJV                                      x      13,095,886 ops/sec ±0.13% (17095476 runs sampled)
   json-accelerator                         x         752,551 ops/sec ±1.50% (722124 runs sampled)
   compile-json-stringify                   x         338,564 ops/sec ±0.32% (328564 runs sampled)
   fast-json-stringify                      x           8,304 ops/sec ±0.57% (8142 runs sampled)

--- array ---
🏆 fast-json-stringify [json-stringify]     x           8,707 ops/sec ±0.60% (8526 runs sampled)
   JSON.stringify                           x           8,627 ops/sec ±0.41% (8545 runs sampled)
   fast-json-stringify [default]            x           8,315 ops/sec ±0.93% (8008 runs sampled)
   compile-json-stringify                   x           7,376 ops/sec ±0.64% (7236 runs sampled)
   AJV                                      x           7,263 ops/sec ±0.72% (7098 runs sampled)
   json-accelerator                         x           5,995 ops/sec ±0.73% (5878 runs sampled)

--- large array ---
🏆 fast-json-stringify [default]            x             368 ops/sec ±3.44% (348 runs sampled)
   compile-json-stringify                   x             324 ops/sec ±3.88% (305 runs sampled)
   JSON.stringify                           x             306 ops/sec ±2.25% (303 runs sampled)
   fast-json-stringify [json-stringify]     x             293 ops/sec ±2.64% (290 runs sampled)
   AJV                                      x             250 ops/sec ±5.24% (219 runs sampled)

--- long string ---
🏆 json-accelerator                         x          37,545 ops/sec ±0.69% (35549 runs sampled)
   fast-json-stringify                      x          36,084 ops/sec ±0.64% (34278 runs sampled)
   compile-json-stringify                   x          35,678 ops/sec ±0.65% (34237 runs sampled)
   JSON.stringify                           x          34,595 ops/sec ±0.61% (33262 runs sampled)
   AJV                                      x           9,879 ops/sec ±0.67% (9679 runs sampled)

--- short string ---
🏆 json-accelerator                         x      11,877,685 ops/sec ±0.09% (15198314 runs sampled)
   fast-json-stringify                      x      11,840,083 ops/sec ±0.15% (15109116 runs sampled)
   compile-json-stringify                   x      10,855,159 ops/sec ±0.19% (13231473 runs sampled)
   AJV                                      x      10,465,767 ops/sec ±0.22% (12311031 runs sampled)
   JSON.stringify                           x       6,387,540 ops/sec ±0.08% (5669101 runs sampled)

--- obj ---
🏆 compile-json-stringify                   x       9,925,158 ops/sec ±0.14% (10336623 runs sampled)
   AJV                                      x       9,358,225 ops/sec ±12.40% (8023148 runs sampled)
   fast-json-stringify                      x       6,823,055 ops/sec ±0.15% (5748096 runs sampled)
   json-accelerator                         x       5,730,326 ops/sec ±0.54% (5168567 runs sampled)
   JSON.stringify                           x       4,142,449 ops/sec ±0.36% (3858776 runs sampled)

--- date ---
🏆 json-accelerate                          x         786,927 ops/sec ±0.35% (712618 runs sampled)
   fast-json-stringify                      x         644,667 ops/sec ±0.28% (616435 runs sampled)
   JSON.stringify                           x         530,199 ops/sec ±23.34% (419698 runs sampled)
   compile-json-stringify                   x         492,356 ops/sec ±0.17% (446835 runs sampled)
```