### PR TITLE
benchmark: change date format from 'date' to 'datetime'

### DIFF
--- a/benchmark/bench-cmp-lib.js
+++ b/benchmark/bench-cmp-lib.js
@@ -84,13 +84,13 @@ const arraySchemaAJVJTD = {
 const dateFormatSchema = {
   description: 'Date of birth',
   type: 'string',
-  format: 'date'
+  format: 'datetime'
 }
 
 const dateFormatSchemaCJS = {
   description: 'Date of birth',
   type: 'string',
-  format: 'date'
+  format: 'datetime'
 }
 
 const obj = {


### PR DESCRIPTION
Ohter libs serialize in "datetime" format. 
Also, the "dat"e format is slower in fjs