### PR TITLE
perf: better large string limit (2000)

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -4,7 +4,7 @@
 const STR_ESCAPE = /[\u0000-\u001f\u0022\u005c\ud800-\udfff]/
 
 module.exports = class Serializer {
-  constructor (options) {
+  constructor(options) {
     switch (options && options.rounding) {
       case 'floor':
         this.parseInteger = Math.floor
@@ -23,7 +23,7 @@ module.exports = class Serializer {
     this._options = options
   }
 
-  asInteger (i) {
+  asInteger(i) {
     if (Number.isInteger(i)) {
       return '' + i
     } else if (typeof i === 'bigint') {
@@ -39,7 +39,7 @@ module.exports = class Serializer {
     return '' + integer
   }
 
-  asNumber (i) {
+  asNumber(i) {
     // fast cast to number
     const num = Number(i)
     // check if number is NaN
@@ -53,11 +53,11 @@ module.exports = class Serializer {
     }
   }
 
-  asBoolean (bool) {
+  asBoolean(bool) {
     return bool && 'true' || 'false' // eslint-disable-line
   }
 
-  asDateTime (date) {
+  asDateTime(date) {
     if (date === null) return '""'
     if (date instanceof Date) {
       return '"' + date.toISOString() + '"'
@@ -68,7 +68,7 @@ module.exports = class Serializer {
     throw new Error(`The value "${date}" cannot be converted to a date-time.`)
   }
 
-  asDate (date) {
+  asDate(date) {
     if (date === null) return '""'
     if (date instanceof Date) {
       return '"' + new Date(date.getTime() - (date.getTimezoneOffset() * 60000)).toISOString().slice(0, 10) + '"'
@@ -79,7 +79,7 @@ module.exports = class Serializer {
     throw new Error(`The value "${date}" cannot be converted to a date.`)
   }
 
-  asTime (date) {
+  asTime(date) {
     if (date === null) return '""'
     if (date instanceof Date) {
       return '"' + new Date(date.getTime() - (date.getTimezoneOffset() * 60000)).toISOString().slice(11, 19) + '"'
@@ -90,7 +90,7 @@ module.exports = class Serializer {
     throw new Error(`The value "${date}" cannot be converted to a time.`)
   }
 
-  asString (str) {
+  asString(str) {
     const len = str.length
     if (len === 0) {
       return '""'
@@ -119,7 +119,7 @@ module.exports = class Serializer {
         }
       }
       return (last === -1 && ('"' + str + '"')) || ('"' + result + str.slice(last) + '"')
-    } else if (len < 5000 && STR_ESCAPE.test(str) === false) {
+    } else if (len < 2000 && STR_ESCAPE.test(str) === false) {
       // Only use the regular expression for shorter input. The overhead is otherwise too much.
       return '"' + str + '"'
     } else {
@@ -127,15 +127,15 @@ module.exports = class Serializer {
     }
   }
 
-  asUnsafeString (str) {
+  asUnsafeString(str) {
     return '"' + str + '"'
   }
 
-  getState () {
+  getState() {
     return this._options
   }
 
-  static restoreFromState (state) {
+  static restoreFromState(state) {
     return new Serializer(state)
   }
 }


### PR DESCRIPTION
```
long string..............................................+29.19%
```


```
> fast-json-stringify@6.2.0 bench:cmp
> node ./benchmark/bench-cmp-branch.js

Select the branch you want to compare (feature branch):
(x) bench-improve
( ) cache-str
( ) fast-escape
( ) fjs-vs-json.stringify
( ) format-dirty
per-str-limit
Select the branch you want to compare with (main branch):
main
Checking out "per-str-limit"
Execute "npm run bench"

> fast-json-stringify@6.2.0 bench
> node --expose-gc ./benchmark/bench.js

short string............................................. x 11,411,281 ops/sec ±2.16% (14069059 runs sampled)
unsafe short string...................................... x 14,226,216 ops/sec ±0.26% (18650764 runs sampled)
short string with double quote........................... x 10,080,920 ops/sec ±0.25% (11182471 runs sampled)
long string without double quotes........................ x 47,216 ops/sec ±0.48% (43776 runs sampled)
unsafe long string without double quotes................. x 14,308,723 ops/sec ±0.26% (18669384 runs sampled)
long string.............................................. x 42,260 ops/sec ±0.48% (39282 runs sampled)
unsafe long string....................................... x 15,153,143 ops/sec ±0.26% (19776921 runs sampled)
number................................................... x 15,087,027 ops/sec ±0.27% (19741324 runs sampled)
integer.................................................. x 15,757,289 ops/sec ±0.24% (20625540 runs sampled)
formatted date-time...................................... x 1,205,424 ops/sec ±0.30% (1116208 runs sampled)
formatted date........................................... x 935,828 ops/sec ±0.34% (868305 runs sampled)
formatted time........................................... x 916,080 ops/sec ±0.26% (864021 runs sampled)
short array of numbers................................... x 65,738 ops/sec ±0.52% (61398 runs sampled)
short array of integers.................................. x 81,740 ops/sec ±0.51% (75380 runs sampled)
short array of short strings............................. x 20,554 ops/sec ±0.53% (19406 runs sampled)
short array of long strings.............................. x 20,585 ops/sec ±0.53% (19361 runs sampled)
short array of objects with properties of different types x 10,796 ops/sec ±0.70% (10220 runs sampled)
object with number property.............................. x 15,375,924 ops/sec ±0.26% (20110033 runs sampled)
object with integer property............................. x 15,427,002 ops/sec ±0.26% (20150569 runs sampled)
object with short string property........................ x 11,326,029 ops/sec ±1.42% (13982415 runs sampled)
object with long string property......................... x 41,206 ops/sec ±0.47% (38387 runs sampled)
object with properties of different types................ x 1,991,384 ops/sec ±0.25% (1872826 runs sampled)
simple object............................................ x 8,099,915 ops/sec ±1.33% (6800245 runs sampled)
simple object with required fields....................... x 8,294,438 ops/sec ±1.05% (7181533 runs sampled)
object with const string property........................ x 16,177,910 ops/sec ±0.24% (21218046 runs sampled)
object with const number property........................ x 15,212,718 ops/sec ±0.26% (19919168 runs sampled)
object with const bool property.......................... x 14,853,819 ops/sec ±0.24% (19449592 runs sampled)
object with const object property........................ x 15,636,283 ops/sec ±0.29% (20413387 runs sampled)
object with const null property.......................... x 15,963,435 ops/sec ±0.22% (20925422 runs sampled)

Checking out "main"
Execute "npm run bench"

> fast-json-stringify@6.2.0 bench
> node --expose-gc ./benchmark/bench.js

short string............................................. x 11,255,413 ops/sec ±0.11% (14143764 runs sampled)
unsafe short string...................................... x 13,324,410 ops/sec ±0.16% (17472040 runs sampled)
short string with double quote........................... x 10,166,809 ops/sec ±1.43% (11347347 runs sampled)
long string without double quotes........................ x 47,070 ops/sec ±0.48% (43738 runs sampled)
unsafe long string without double quotes................. x 9,300,564 ops/sec ±1.05% (9393785 runs sampled)
long string.............................................. x 32,711 ops/sec ±0.61% (29526 runs sampled)
unsafe long string....................................... x 11,793,069 ops/sec ±0.14% (15104071 runs sampled)
number................................................... x 14,293,924 ops/sec ±0.23% (18688123 runs sampled)
integer.................................................. x 13,009,629 ops/sec ±0.23% (16897461 runs sampled)
formatted date-time...................................... x 1,062,248 ops/sec ±0.29% (916516 runs sampled)
formatted date........................................... x 819,513 ops/sec ±0.84% (681867 runs sampled)
formatted time........................................... x 880,487 ops/sec ±0.30% (782822 runs sampled)
short array of numbers................................... x 76,972 ops/sec ±0.53% (70727 runs sampled)
short array of integers.................................. x 74,656 ops/sec ±0.49% (69874 runs sampled)
short array of short strings............................. x 20,236 ops/sec ±0.57% (18984 runs sampled)
short array of long strings.............................. x 20,539 ops/sec ±0.53% (19431 runs sampled)
short array of objects with properties of different types x 10,727 ops/sec ±0.73% (10117 runs sampled)
object with number property.............................. x 15,400,165 ops/sec ±0.22% (20240322 runs sampled)
object with integer property............................. x 14,800,457 ops/sec ±0.28% (19400734 runs sampled)
object with short string property........................ x 10,815,441 ops/sec ±0.23% (13129554 runs sampled)
object with long string property......................... x 41,398 ops/sec ±0.50% (38318 runs sampled)
object with properties of different types................ x 1,917,087 ops/sec ±0.25% (1777209 runs sampled)
simple object............................................ x 8,144,484 ops/sec ±0.30% (6924877 runs sampled)
simple object with required fields....................... x 8,216,688 ops/sec ±1.10% (7152252 runs sampled)
object with const string property........................ x 15,383,625 ops/sec ±0.24% (20220957 runs sampled)
object with const number property........................ x 15,090,857 ops/sec ±0.28% (19781972 runs sampled)
object with const bool property.......................... x 14,967,374 ops/sec ±0.22% (19645066 runs sampled)
object with const object property........................ x 14,295,000 ops/sec ±0.23% (18679639 runs sampled)
object with const null property.......................... x 14,044,963 ops/sec ±0.25% (18312171 runs sampled)

short string..............................................+1.38%
unsafe short string.......................................+6.77%
short string with double quote............................-0.84%
long string without double quotes.........................+0.31%
unsafe long string without double quotes.................+53.85%
long string..............................................+29.19%
unsafe long string.......................................+28.49%
number....................................................+5.55%
integer..................................................+21.12%
formatted date-time......................................+13.48%
formatted date...........................................+14.19%
formatted time............................................+4.04%
short array of numbers...................................-14.59%
short array of integers...................................+9.49%
short array of short strings..............................+1.57%
short array of long strings...............................+0.22%
short array of objects with properties of different types.+0.64%
object with number property...............................-0.16%
object with integer property..............................+4.23%
object with short string property.........................+4.72%
object with long string property..........................-0.46%
object with properties of different types.................+3.88%
simple object.............................................-0.55%
simple object with required fields........................+0.95%
object with const string property.........................+5.16%
object with const number property.........................+0.81%
object with const bool property...........................-0.76%
object with const object property.........................+9.38%
object with const null property..........................+13.66%
Back to per-str-limit 17a7fba
```