### PR TITLE
test: improve test coverage (~1%)

### DIFF
--- a/test/anyof.test.js
+++ b/test/anyof.test.js
@@ -790,3 +790,23 @@ test('should build merged schemas twice', (t) => {
     t.assert.equal(stringify({ enums: 'BAR' }), '{"enums":"BAR"}')
   }
 })
+
+test('invalid anyOf schema', (t) => {
+  t.plan(1)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      prop: {
+        anyOf: 'not array'  // invalid, anyOf must be array
+      }
+    }
+  }
+
+  try {
+    build(schema)
+    t.assert.fail('Should throw')
+  } catch (err) {
+    t.assert.ok(err.message.includes('schema is invalid'))
+  }
+})

--- a/test/array.test.js
+++ b/test/array.test.js
@@ -358,6 +358,28 @@ test('array items is a schema and additionalItems is false', (t) => {
   t.assert.equal(validate({ foo: ['foo', 'bar'] }), true)
 })
 
+test('array items is a list of schema and additionalItems is a schema', (t) => {
+  t.plan(1)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      foo: {
+        type: 'array',
+        items: [
+          { type: 'string' }
+        ],
+        additionalItems: { type: 'number' }
+      }
+    }
+  }
+
+  const stringify = build(schema)
+  const result = stringify({ foo: ['foo', 42] })
+
+  t.assert.equal(result, '{"foo":["foo",42]}')
+})
+
 // https://github.com/fastify/fast-json-stringify/issues/279
 test('object array with anyOf and symbol', (t) => {
   t.plan(1)

--- a/test/debug-mode.test.js
+++ b/test/debug-mode.test.js
@@ -119,3 +119,24 @@ test('debug should restore the same serializer instance', t => {
   const compiled = fjs.restore(debugMode)
   t.assert.equal(compiled(3.95), 4)
 })
+
+test('Serializer restoreFromState', t => {
+  t.plan(1)
+
+  const Serializer = require('../lib/serializer')
+  const serializer = new Serializer()
+  const state = serializer.getState()
+  const restored = Serializer.restoreFromState(state)
+  t.assert.ok(restored instanceof Serializer)
+})
+
+test('Validator restoreFromState', t => {
+  t.plan(1)
+
+  const Validator = require('../lib/validator')
+  const validator = new Validator()
+  validator.addSchema({ type: 'string' }, 'test')
+  const state = validator.getState()
+  const restored = Validator.restoreFromState(state)
+  t.assert.ok(restored instanceof Validator)
+})

--- a/test/invalidSchema.test.js
+++ b/test/invalidSchema.test.js
@@ -16,3 +16,23 @@ test('Should throw on invalid schema', t => {
     })
   }, { message: /^"invalid" schema is invalid:.*/ })
 })
+
+test('invalid not schema', (t) => {
+  t.plan(1)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      prop: {
+        not: 'not object'  // invalid, not must be object
+      }
+    }
+  }
+
+  try {
+    build(schema)
+    t.assert.fail('Should throw')
+  } catch (err) {
+    t.assert.ok(err.message.includes('schema is invalid'))
+  }
+})

--- a/test/oneof.test.js
+++ b/test/oneof.test.js
@@ -488,3 +488,23 @@ test('all array items does not match oneOf types', (t) => {
 
   t.assert.throws(() => stringify({ data: [null, false, true, undefined, [], {}] }))
 })
+
+test('invalid oneOf schema', (t) => {
+  t.plan(1)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      prop: {
+        oneOf: 'not array'  // invalid, oneOf must be array
+      }
+    }
+  }
+
+  try {
+    build(schema)
+    t.assert.fail('Should throw')
+  } catch (err) {
+    t.assert.ok(err.message.includes('schema is invalid'))
+  }
+})

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -2044,3 +2044,34 @@ test('ref internal - throw if schema has definition twice with different shape',
     t.assert.equal(err.message, 'There is already another anchor "#uri" in schema "test".')
   }
 })
+
+test('ref nested', (t) => {
+  t.plan(2)
+
+  const schema = {
+    definitions: {
+      def1: {
+        $ref: '#/definitions/def2'
+      },
+      def2: {
+        type: 'string'
+      }
+    },
+    type: 'object',
+    properties: {
+      str: {
+        $ref: '#/definitions/def1'
+      }
+    }
+  }
+
+  const object = {
+    str: 'test'
+  }
+
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"str":"test"}')
+})


### PR DESCRIPTION
I attempted an optimization and all tests are passing, but only because some cases are currently missing. This PR improves test coverage to prevent similar issues in the future.

This PR adds only tests (no benchmark needed)

MASTER
```
----------------------------|---------|----------|---------|---------|----------------------------
File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------------------|---------|----------|---------|---------|----------------------------
All files                   |   81.48 |    69.12 |   31.12 |   81.48 |                            
 fast-json-stringify        |    96.7 |    95.16 |     100 |    96.7 |                            
  index.js                  |    96.7 |    95.16 |     100 |    96.7 | ...605-606,613-640,968-969 
 fast-json-stringify/.cache |   42.85 |    50.77 |   25.85 |   42.85 |                            
  webpacktest.js            |   42.85 |    50.77 |   25.85 |   42.85 | 2-3,5-6                    
 fast-json-stringify/lib    |   68.49 |    73.59 |    92.3 |   68.49 |                            
  location.js               |     100 |      100 |     100 |     100 |                            
  merge-schemas.js          |     100 |      100 |     100 |     100 |                            
  schema-validator.js       |   61.02 |    61.88 |     100 |   61.02 | ...058,1068-1070,1078-1084 
  serializer.js             |   97.87 |    98.59 |    90.9 |   97.87 | 96,139-140                 
  standalone.js             |     100 |      100 |     100 |     100 |                            
  validator.js              |   91.66 |    90.47 |   85.71 |   91.66 | 36-37,88-93                
----------------------------|---------|----------|---------|---------|----------------------------
```

PR
```
----------------------------|---------|----------|---------|---------|----------------------------
File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------------------|---------|----------|---------|---------|----------------------------
All files                   |   82.74 |    69.81 |   31.41 |   82.74 |                            
 fast-json-stringify        |   96.86 |    95.49 |     100 |   96.86 |                            
  index.js                  |   96.86 |    95.49 |     100 |   96.86 | ...597-602,605-606,613-640 
 fast-json-stringify/.cache |   42.85 |    50.77 |   25.85 |   42.85 |                            
  webpacktest.js            |   42.85 |    50.77 |   25.85 |   42.85 | 2-3,5-6                    
 fast-json-stringify/lib    |   70.72 |    75.47 |     100 |   70.72 |                            
  location.js               |     100 |      100 |     100 |     100 |                            
  merge-schemas.js          |     100 |      100 |     100 |     100 |                            
  schema-validator.js       |   63.13 |    65.11 |     100 |   63.13 | ...000,1008-1010,1020-1022 
  serializer.js             |   99.29 |    98.61 |     100 |   99.29 | 96                         
  standalone.js             |     100 |      100 |     100 |     100 |                            
  validator.js              |   97.91 |     90.9 |     100 |   97.91 | 36-37                      
----------------------------|---------|----------|---------|---------|----------------------------
```
