### PR TITLE
chore: rename @sinclair/typebox to typebox

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     }
   ],
   "devDependencies": {
-    "@sinclair/typebox": "^0.34.48",
     "c8": "^10.1.3",
     "cli-select": "^1.1.2",
     "compile-json-stringify": "^0.1.2",
@@ -74,6 +73,7 @@
     "simple-git": "^3.30.0",
     "tinybench": "^6.0.0",
     "tsd": "^0.33.0",
+    "typebox": "^1.0.81",
     "typescript": "^5.9.3",
     "webpack": "^5.104.1"
   },

--- a/test/typebox.test.js
+++ b/test/typebox.test.js
@@ -4,7 +4,7 @@ const { test } = require('node:test')
 const build = require('..')
 
 test('nested object in pattern properties for typebox', (t) => {
-  const { Type } = require('@sinclair/typebox')
+  const { Type } = require('typebox')
 
   t.plan(1)
 


### PR DESCRIPTION
Proposals:

- Replaced `@sinclair/typebox` with `typebox` in `package.json` (dependency reference and version bump to `^1.0.81`)
- Updated test files (`test/typebox.test.js`)


`@sinclair/typebox` is the legacy package for TypeBox versions pre-1.0 (`0.34.x`). TypeBox versions 1.0 and above are published under the `typebox` package name ( see screenshot ). This PR migrates to the current package to use TypeBox 1.x. 

<img width="805" height="113" alt="screenshot" src="https://github.com/user-attachments/assets/d8ec1023-fee7-4a99-a7c3-9401dac8b3bd" />

