### PR TITLE
chore: upgrade c8 to v11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     }
   ],
   "devDependencies": {
-    "c8": "^10.1.3",
+    "c8": "^11.0.0",
     "cli-select": "^1.1.2",
     "compile-json-stringify": "^0.1.2",
     "eslint": "^9.39.2",


### PR DESCRIPTION
Proposal:

- Upgrade `c8` dependency from `^10.1.3` to `^11.0.0` ( see here: https://github.com/bcoe/c8/releases/tag/v11.0.0 )