### PR TITLE
chore: upgrade to typescript v6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "tinybench": "^6.0.0",
     "tsd": "^0.33.0",
     "typebox": "^1.0.81",
-    "typescript": "^5.9.3",
+    "typescript": "~6.0.2",
     "webpack": "^5.104.1"
   },
   "dependencies": {


### PR DESCRIPTION
Proposal:

- Upgrade `typescript` dependency to v6.0.2 🔥


see reference PR: https://github.com/fastify/fastify/pull/6605