### PR TITLE
chore(types): remove deprecated debugMode option

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,10 +222,6 @@ function build (schema, options) {
     }
   }
 
-  if (options.debugMode) {
-    options.mode = 'debug'
-  }
-
   if (options.mode === 'debug') {
     return {
       validator,

--- a/test/debug-mode.test.js
+++ b/test/debug-mode.test.js
@@ -22,30 +22,18 @@ function build (opts) {
 
 test('activate debug mode', t => {
   t.plan(5)
-  const debugMode = build({ debugMode: true })
+  const debugMode = build({ mode: 'debug' })
 
   t.assert.ok(typeof debugMode === 'object')
   t.assert.ok(debugMode.ajv instanceof Ajv)
   t.assert.ok(debugMode.validator instanceof Validator)
   t.assert.ok(debugMode.serializer instanceof Serializer)
   t.assert.ok(typeof debugMode.code === 'string')
-})
-
-test('activate debug mode truthy', t => {
-  t.plan(5)
-
-  const debugMode = build({ debugMode: 'yes' })
-
-  t.assert.ok(typeof debugMode === 'object')
-  t.assert.ok(typeof debugMode.code === 'string')
-  t.assert.ok(debugMode.ajv instanceof Ajv)
-  t.assert.ok(debugMode.validator instanceof Validator)
-  t.assert.ok(debugMode.serializer instanceof Serializer)
 })
 
 test('to string auto-consistent', t => {
   t.plan(6)
-  const debugMode = build({ debugMode: 1 })
+  const debugMode = build({ mode: 'debug' })
 
   t.assert.ok(typeof debugMode === 'object')
   t.assert.ok(typeof debugMode.code === 'string')
@@ -73,7 +61,7 @@ test('to string auto-consistent with ajv', t => {
         }]
       }
     }
-  }, { debugMode: 1 })
+  }, { mode: 'debug' })
 
   t.assert.ok(typeof debugMode === 'object')
   t.assert.ok(typeof debugMode.code === 'string')
@@ -102,7 +90,7 @@ test('to string auto-consistent with ajv-formats', t => {
         }]
       }
     }
-  }, { debugMode: 1 })
+  }, { mode: 'debug' })
 
   t.assert.ok(typeof debugMode === 'object')
 
@@ -115,7 +103,7 @@ test('to string auto-consistent with ajv-formats', t => {
 test('debug should restore the same serializer instance', t => {
   t.plan(1)
 
-  const debugMode = fjs({ type: 'integer' }, { debugMode: 1, rounding: 'ceil' })
+  const debugMode = fjs({ type: 'integer' }, { mode: 'debug', rounding: 'ceil' })
   const compiled = fjs.restore(debugMode)
   t.assert.equal(compiled(3.95), 4)
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -193,10 +193,6 @@ interface DebugOption extends build.Options {
   mode: 'debug'
 }
 
-interface DeprecateDebugOption extends build.Options {
-  debugMode: true
-}
-
 interface StandaloneOption extends build.Options {
   mode: 'standalone'
 }
@@ -210,7 +206,6 @@ type IntegerCoercible = number | BigInt
  * @param options The options to use (optional)
  */
 declare function build (schema: build.AnySchema, options: DebugOption): { code: string, ajv: Ajv }
-declare function build (schema: build.AnySchema, options: DeprecateDebugOption): { code: string, ajv: Ajv }
 declare function build (schema: build.AnySchema, options: StandaloneOption): string
 declare function build (schema: build.AnySchema, options?: build.Options): <TDoc = any>(doc: TDoc) => any
 declare function build (schema: build.StringSchema, options?: build.Options): <TDoc extends StringCoercible = StringCoercible>(doc: TDoc) => string

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -163,15 +163,9 @@ declare namespace build {
      */
     rounding?: 'ceil' | 'floor' | 'round' | 'trunc'
     /**
-     * @deprecated
-     * Enable debug mode. Please use `mode: "debug"` instead
-     */
-    debugMode?: boolean
-    /**
      * Running mode of fast-json-stringify
      */
     mode?: 'debug' | 'standalone'
-
     /**
      * Large arrays are defined as arrays containing, by default, `20000`
      * elements or more. That value can be adjusted via the option parameter
@@ -180,7 +174,6 @@ declare namespace build {
      * @default 20000
      */
     largeArraySize?: number | string | BigInt
-
     /**
      * Specify the function on how large Arrays should be stringified.
      *


### PR DESCRIPTION
Proposal:

Remove the deprecated `debugMode` boolean option in `types/index.d.ts`.

Changes:

- Removed `debugMode?: boolean` from `types/index.d.ts`
- Update `index.js`
- Update `debug-mode.test.js`

Note:

- Release a major version of the library after this pull request has been merged
- PR reference:
   - https://github.com/fastify/fastify-swagger-ui/pull/274