### PR TITLE
fix: avoid stray comma when required is set but properties is empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -386,23 +386,9 @@ function buildInnerObject (context, location, objVar) {
   const localUid = context.uid++
   let addComma = ''
 
-  // The skip-leading-comma optimization is only safe when at least one
-  // declared property is also required: that guarantees the first emitted
-  // entry has no preceding separator. `propertiesKeys` is sorted with
-  // required keys first, so `requiredProperties.includes(propertiesKeys[0])`
-  // is the cheapest way to express the condition.
-  //
-  // Falls through to the generic runtime-`addComma` branch when:
-  //   * `requiredProperties` is empty (no anchor needed), or
-  //   * `propertiesKeys` is empty (record-style schema with only
-  //     `additionalProperties`), or
-  //   * `required` only names keys that are not in `properties` (so no
-  //     declared property is guaranteed to emit first).
-  // Otherwise the additionalProperties / patternProperties serializer
-  // would write a separator with no preceding property, producing
-  // `{ ,"k":v,... }`.
+  // propertiesKeys is sorted required-first; the guard checks [0] is required because
+  // otherwise additionalProperties/patternProperties would emit a stray `{ ,"k":v }`.
   if (propertiesKeys.length > 0 && requiredProperties.includes(propertiesKeys[0])) {
-
     // The first property is required, so we don't need a comma.
     // For the subsequent properties, we can blindly add a comma.
 

--- a/index.js
+++ b/index.js
@@ -386,16 +386,22 @@ function buildInnerObject (context, location, objVar) {
   const localUid = context.uid++
   let addComma = ''
 
-  if (requiredProperties.length > 0 && propertiesKeys.length > 0) {
-    // If we have required properties AND declared properties, we know that
-    // at least one declared property will be serialized first, so we can
-    // avoid the runtime check for the comma.
-    //
-    // When `required` is set but `properties` is empty (e.g. a record-style
-    // schema with `additionalProperties` only), we fall through to the
-    // generic branch below which uses a runtime `addComma` flag — otherwise
-    // the additionalProperties serializer would write a separator with no
-    // preceding property, producing `{ ,"k":v,... }`.
+  // The skip-leading-comma optimization is only safe when at least one
+  // declared property is also required: that guarantees the first emitted
+  // entry has no preceding separator. `propertiesKeys` is sorted with
+  // required keys first, so `requiredProperties.includes(propertiesKeys[0])`
+  // is the cheapest way to express the condition.
+  //
+  // Falls through to the generic runtime-`addComma` branch when:
+  //   * `requiredProperties` is empty (no anchor needed), or
+  //   * `propertiesKeys` is empty (record-style schema with only
+  //     `additionalProperties`), or
+  //   * `required` only names keys that are not in `properties` (so no
+  //     declared property is guaranteed to emit first).
+  // Otherwise the additionalProperties / patternProperties serializer
+  // would write a separator with no preceding property, producing
+  // `{ ,"k":v,... }`.
+  if (propertiesKeys.length > 0 && requiredProperties.includes(propertiesKeys[0])) {
 
     // The first property is required, so we don't need a comma.
     // For the subsequent properties, we can blindly add a comma.

--- a/index.js
+++ b/index.js
@@ -386,9 +386,16 @@ function buildInnerObject (context, location, objVar) {
   const localUid = context.uid++
   let addComma = ''
 
-  if (requiredProperties.length > 0) {
-    // If we have required properties, we know that at least one property will be serialized.
-    // We can avoid the runtime check for the comma.
+  if (requiredProperties.length > 0 && propertiesKeys.length > 0) {
+    // If we have required properties AND declared properties, we know that
+    // at least one declared property will be serialized first, so we can
+    // avoid the runtime check for the comma.
+    //
+    // When `required` is set but `properties` is empty (e.g. a record-style
+    // schema with `additionalProperties` only), we fall through to the
+    // generic branch below which uses a runtime `addComma` flag — otherwise
+    // the additionalProperties serializer would write a separator with no
+    // preceding property, producing `{ ,"k":v,... }`.
 
     // The first property is required, so we don't need a comma.
     // For the subsequent properties, we can blindly add a comma.

--- a/test/additionalProperties.test.js
+++ b/test/additionalProperties.test.js
@@ -356,3 +356,24 @@ test('required + additionalProperties without declared properties produces valid
   t.assert.equal(out, '{"obj":{"a":1,"b":2}}')
   t.assert.deepStrictEqual(JSON.parse(out), { obj: { a: 1, b: 2 } })
 })
+
+test('required key not in properties + additionalProperties produces valid JSON', (t) => {
+  // Regression: declared `properties` is non-empty but `required` only lists
+  // keys that are not in `properties`. After sorting, propertiesKeys[0] is
+  // not required, so the "first declared property anchors the comma" premise
+  // does not hold. The serializer used to emit '{,"str":"x"}' for input
+  // missing the (non-required) declared `num`.
+  t.plan(2)
+  const stringify = build({
+    type: 'object',
+    properties: {
+      num: { type: 'number' }
+    },
+    additionalProperties: true,
+    required: ['str']
+  })
+
+  const out = stringify({ str: 'x' })
+  t.assert.equal(out, '{"str":"x"}')
+  t.assert.deepStrictEqual(JSON.parse(out), { str: 'x' })
+})

--- a/test/additionalProperties.test.js
+++ b/test/additionalProperties.test.js
@@ -330,3 +330,29 @@ test('function and symbol references are not serialized as undefined', (t) => {
   const obj = { str: 'x', test: 'test', meth: () => 'x', sym: Symbol('x') }
   t.assert.equal(stringify(obj), '{"str":"x","test":"test"}')
 })
+
+test('required + additionalProperties without declared properties produces valid JSON', (t) => {
+  // Regression: when `required` is non-empty but `properties` is absent
+  // (e.g. a record-style schema with only `additionalProperties`), the
+  // serializer used to emit a stray leading comma:
+  //   {"obj":{,"a":1,"b":2}}
+  // because the "skip first comma" optimization assumed a declared
+  // property would anchor it. With no `properties`, the additionalProperties
+  // branch would write the separator before its first entry.
+  t.plan(2)
+  const stringify = build({
+    type: 'object',
+    properties: {
+      obj: {
+        type: 'object',
+        propertyNames: { type: 'string', enum: ['a', 'b'] },
+        additionalProperties: { type: 'number' },
+        required: ['a', 'b']
+      }
+    }
+  })
+
+  const out = stringify({ obj: { a: 1, b: 2 } })
+  t.assert.equal(out, '{"obj":{"a":1,"b":2}}')
+  t.assert.deepStrictEqual(JSON.parse(out), { obj: { a: 1, b: 2 } })
+})

--- a/test/patternProperties.test.js
+++ b/test/patternProperties.test.js
@@ -166,3 +166,27 @@ test('patternProperties - fail on invalid regex, handled by ajv', (t) => {
     }
   }), new Error('schema is invalid: data/patternProperties must match format "regex"'))
 })
+
+test('required key not in properties + patternProperties produces valid JSON', (t) => {
+  // Regression: symmetric case to the additionalProperties variant. `required`
+  // names a key not in `properties`, so after sorting propertiesKeys[0] is not
+  // required and the "first declared property anchors the comma" premise does
+  // not hold. The patternProperties branch shares the same code path, so the
+  // same stray-leading-comma bug would surface here without the tightened
+  // guard in `index.js`.
+  t.plan(2)
+  const stringify = build({
+    type: 'object',
+    properties: {
+      num: { type: 'number' }
+    },
+    patternProperties: {
+      '^s_': { type: 'string' }
+    },
+    required: ['s_x']
+  })
+
+  const out = stringify({ s_x: 'x' })
+  t.assert.equal(out, '{"s_x":"x"}')
+  t.assert.deepStrictEqual(JSON.parse(out), { s_x: 'x' })
+})


### PR DESCRIPTION
## Problem

A response schema with `required` set but no `properties` map (e.g. what `z.toJSONSchema` produces for `z.record(enum, V)`) serializes with a stray leading comma:

```js
const schema = {
  type: 'object',
  properties: {
    obj: {
      type: 'object',
      propertyNames: { type: 'string', enum: ['a', 'b'] },
      additionalProperties: { type: 'number' },
      required: ['a', 'b']
    }
  }
}
build(schema)({ obj: { a: 1, b: 2 } })
// {"obj":{,"a":1,"b":2}}
```

HTTP 200 from Fastify, but `JSON.parse` fails client-side.

## Root cause

The optimization at `index.js:389` skips the runtime comma check when `requiredProperties.length > 0`, on the assumption that the first declared property will anchor the comma logic. When `properties` is empty (or absent), the loop body never runs and `addComma` is set to unconditional immediately after, so the `additionalProperties` branch at `index.js:484` emits a separator before its first entry.

## Fix

Tighten the condition to `propertiesKeys.length > 0 && requiredProperties.includes(propertiesKeys[0])`. The sort just above (`index.js:367-373`) moves required-and-declared keys to the front, so this captures exactly when the "first declared property anchors the comma" premise actually holds. It falls through to the existing runtime `addComma` flag path in three cases that the old condition handled incorrectly:

1. `properties` is empty (record-style schema, only `additionalProperties`)
2. `required` only names keys that are not in `properties`
3. (Trivially) `requiredProperties` is empty — already handled before

No behaviour change for any schema where at least one declared property is required.

## Tests

Three regression tests covering the canonical bug shapes:

- `test/additionalProperties.test.js`: `required + additionalProperties` with no `properties` map (the original z.record-style trigger).
- `test/additionalProperties.test.js`: `required` key not in `properties`, with `additionalProperties: true`.
- `test/patternProperties.test.js`: same shape with `patternProperties` (symmetric branch at `index.js:484`).

Each test fails on the respective baseline (`main` for #1, the first proposed fix for #2 and #3) and passes after this patch. Full suite: 476/476 green.

## Benchmark

Ran `npm run benchmark` 3 times on `main` and 3 times on the fix branch. All scenario ranges overlap; absolute mean deltas ≤ 1.1%, within natural inter-run variance (±0.7% to ±2.0%). The modified branch is not exercised by any standard scenario, so no runtime perf change is expected by construction.

After tightening the guard further (to also handle `required` keys not in `properties`), re-ran 3 vs 3 between the first fix and the tightened version. Absolute mean deltas ≤ 1.7%, still within inter-run variance. By transitivity, the tightened fix is also performance-neutral vs `main`.

## Related

- #642 / #651: same class of bug (extra-comma in object serialization), different branch.
- #530: proposed dropping `required` support entirely. This fix is a smaller targeted patch in the same area while that broader change is on hold.

---

## Checklist 

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
