### PR TITLE
fix: Updates fast-uri to fix vulns CVE-2026-6321 and CVE-2026-6322

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@fastify/merge-json-schemas": "^0.2.0",
     "ajv": "^8.12.0",
     "ajv-formats": "^3.0.1",
-    "fast-uri": "^3.0.0",
+    "fast-uri": "^3.1.2",
     "json-schema-ref-resolver": "^3.0.0",
     "rfdc": "^1.2.0"
   },


### PR DESCRIPTION
Updates fast-uri to fix vulns CVE-2026-6321 and CVE-2026-6322
## Testing and benchmark
```bash

uses TypeScript 6.0.3 with baseline TSConfig

pass ./types/index.tst.ts

Targets:    1 passed, 1 total
Test files: 1 passed, 1 total
Assertions: 12 passed, 12 total
Duration:   0.4s

> fast-json-stringify@6.4.0 benchmark
> node --expose-gc ./benchmark/bench-cmp-lib.js


--- creation ---
🏆 AJV                                      x      26,319,859 ops/sec ±0.02% (32733906 runs sampled)
   json-accelerator                         x         848,163 ops/sec ±0.26% (840699 runs sampled)
   compile-json-stringify                   x         235,323 ops/sec ±0.12% (233835 runs sampled)
   fast-json-stringify                      x          18,170 ops/sec ±0.27% (17993 runs sampled)

--- array ---
🏆 JSON.stringify                           x          14,117 ops/sec ±0.15% (14093 runs sampled)
   fast-json-stringify [default]            x          10,908 ops/sec ±0.45% (10752 runs sampled)
   fast-json-stringify [json-stringify]     x          10,847 ops/sec ±0.45% (10690 runs sampled)
   AJV                                      x           9,511 ops/sec ±0.46% (9380 runs sampled)
   compile-json-stringify                   x           9,136 ops/sec ±0.49% (9009 runs sampled)
   json-accelerator                         x           7,855 ops/sec ±0.39% (7774 runs sampled)

--- large array ---
🏆 fast-json-stringify [json-stringify]     x             649 ops/sec ±1.19% (645 runs sampled)
   fast-json-stringify [default]            x             491 ops/sec ±3.74% (449 runs sampled)
   AJV                                      x             452 ops/sec ±1.62% (442 runs sampled)
   compile-json-stringify                   x             432 ops/sec ±1.99% (420 runs sampled)
   JSON.stringify                           x             221 ops/sec ±0.54% (221 runs sampled)

--- long string ---
🏆 fast-json-stringify                      x          55,891 ops/sec ±0.22% (55676 runs sampled)
   JSON.stringify                           x          55,858 ops/sec ±0.11% (55670 runs sampled)
   compile-json-stringify                   x          55,753 ops/sec ±0.09% (55584 runs sampled)
   json-accelerator                         x          55,575 ops/sec ±0.09% (55409 runs sampled)
   AJV                                      x          25,238 ops/sec ±0.25% (25098 runs sampled)

--- short string ---
🏆 fast-json-stringify                      x      29,234,085 ops/sec ±0.03% (38086584 runs sampled)
   json-accelerator                         x      29,068,063 ops/sec ±0.03% (37804992 runs sampled)
   compile-json-stringify                   x      22,385,670 ops/sec ±0.02% (21151646 runs sampled)
   AJV                                      x      22,306,839 ops/sec ±0.02% (21080613 runs sampled)
   JSON.stringify                           x      15,424,548 ops/sec ±0.02% (13900530 runs sampled)

--- obj ---
🏆 compile-json-stringify                   x      16,102,431 ops/sec ±0.02% (14414191 runs sampled)
   AJV                                      x      15,240,235 ops/sec ±0.02% (13781231 runs sampled)
   fast-json-stringify                      x       9,377,154 ops/sec ±0.01% (8989844 runs sampled)
   json-accelerator                         x       8,299,031 ops/sec ±0.30% (7996159 runs sampled)
   JSON.stringify                           x       7,097,722 ops/sec ±0.32% (6837397 runs sampled)

--- date ---
🏆 fast-json-stringify                      x       2,241,036 ops/sec ±0.02% (2229685 runs sampled)
   json-accelerate                          x       2,237,844 ops/sec ±3.34% (2188538 runs sampled)
   compile-json-stringify                   x       1,479,599 ops/sec ±0.04% (1472675 runs sampled)
   JSON.stringify                           x       1,472,373 ops/sec ±0.03% (1465672 runs sampled)
```
#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
