### PR TITLE
fix: resolve percent-encoded $ref definition keys

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -5,6 +5,18 @@ const fastUri = require('fast-uri')
 const ajvFormats = require('ajv-formats')
 const clone = require('rfdc')({ proto: true })
 
+// Ajv resolves a $ref's JSON pointer by url-decoding each segment, so a
+// definition whose key is itself percent-encoded (e.g. `Some%3Cloremipsum%3E`)
+// can no longer be found: the pointer `#/definitions/Some%3Cloremipsum%3E`
+// decodes to `Some<loremipsum>`, which does not match the literal key.
+// Re-encoding the `%` in the fragment makes Ajv's single decode round-trip
+// back to the original key. See https://github.com/fastify/fast-json-stringify/issues/740
+function escapeRefForAjv (ref) {
+  const hashIndex = ref.indexOf('#')
+  if (hashIndex === -1) return ref
+  return ref.slice(0, hashIndex) + ref.slice(hashIndex).replace(/%/g, '%25')
+}
+
 class Validator {
   constructor (ajvOptions) {
     this.ajv = new Ajv({
@@ -48,7 +60,7 @@ class Validator {
   }
 
   validate (schemaRef, data) {
-    return this.ajv.validate(schemaRef, data)
+    return this.ajv.validate(escapeRefForAjv(schemaRef), data)
   }
 
   // Ajv does not natively support JavaScript objects like Date or other types
@@ -58,6 +70,10 @@ class Validator {
   // (see https://github.com/fastify/fast-json-stringify/pull/441)
   convertSchemaToAjvFormat (schema) {
     if (schema === null) return
+
+    if (typeof schema.$ref === 'string') {
+      schema.$ref = escapeRefForAjv(schema.$ref)
+    }
 
     if (schema.type === 'string') {
       schema.fjs_type = 'string'

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -2075,3 +2075,45 @@ test('ref nested', (t) => {
   t.assert.doesNotThrow(() => JSON.parse(output))
   t.assert.equal(output, '{"str":"test"}')
 })
+
+test('ref internal - percent-encoded definition key with oneOf', (t) => {
+  t.plan(2)
+
+  // See https://github.com/fastify/fast-json-stringify/issues/740
+  // A definition key that is itself percent-encoded (e.g. `Some%3Cloremipsum%3E`)
+  // must still resolve when the referenced schema contains oneOf/anyOf/allOf.
+  const schema = {
+    title: 'object with $ref',
+    definitions: {
+      'Some%3Cloremipsum%3E': {
+        type: 'object',
+        additionalProperties: {
+          oneOf: [
+            { type: 'string' },
+            { type: 'number' },
+            { type: 'object' },
+            { type: 'null' }
+          ]
+        }
+      }
+    },
+    type: 'object',
+    properties: {
+      obj: {
+        $ref: '#/definitions/Some%3Cloremipsum%3E'
+      }
+    }
+  }
+
+  const object = {
+    obj: {
+      str: 'test'
+    }
+  }
+
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"obj":{"str":"test"}}')
+})


### PR DESCRIPTION
Fixes #740

### Problem

When a definition key is itself percent-encoded (e.g. `Some%3Cloremipsum%3E`) and the referenced subschema contains `oneOf`/`anyOf`/`allOf`, building a serializer throws:

```
Error: can't resolve reference #/definitions/Some%3Cloremipsum%3E from id __fjs_root_0
```

Such schemas need Ajv to compile a sub-validator for the `oneOf`/`anyOf`/`allOf` branch. Ajv resolves a `$ref` JSON pointer by url-decoding each segment, so `#/definitions/Some%3Cloremipsum%3E` decodes to `Some<loremipsum>`, which does not match the literal definition key `Some%3Cloremipsum%3E` — hence `MissingRefError`. Plain refs (no `oneOf`/`anyOf`/`allOf`) avoided this only because they were resolved by the internal literal-lookup resolver instead of Ajv.

### Fix

In `lib/validator.js`, re-encode the `%` in the ref fragment before handing it to Ajv (in `validate()` and when converting a schema's `$ref` in `convertSchemaToAjvFormat`). Ajv's single decode then round-trips back to the original literal key. The internal `json-schema-ref-resolver` used by the serializer (which performs a literal lookup) is untouched, so both resolvers stay correct.

The fix is ~12 lines and adds a small `escapeRefForAjv` helper.

### Test

Added a unit test in `test/ref.test.js` (node:test, matching the existing file style) that ports the repro from the issue: a schema with a percent-encoded `$ref` definition key whose subschema uses `oneOf` now serializes correctly.

Full suite is green: `npm test` → 473 unit tests + tstyche type tests pass, lint clean.

### Note

Standalone mode (`mode: 'standalone'`) carries the same escaped refs through `restoreFromState`, so it benefits from this fix as well; any remaining standalone-specific edge cases are pre-existing and out of scope for this change.