### PR TITLE
fix: serialize const string values to valid JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,6 @@ const Location = require('./lib/location')
 const validate = require('./lib/schema-validator')
 const mergeSchemas = require('./lib/merge-schemas')
 
-const SINGLE_TICK = /'/g
-
 let largeArraySize = 2e4
 let largeArrayMechanism = 'default'
 
@@ -1074,7 +1072,7 @@ function buildConstSerializer (location, input) {
     `
   }
 
-  code += `json += '${JSON.stringify(schema.const).replace(SINGLE_TICK, "\\'")}'`
+  code += `json += ${JSON.stringify(JSON.stringify(schema.const))}`
 
   if (hasNullType) {
     code += `

--- a/test/const.test.js
+++ b/test/const.test.js
@@ -24,6 +24,26 @@ test('schema with const string', (t) => {
   t.assert.ok(validate(JSON.parse(output)), 'valid schema')
 })
 
+test('schema with const string containing characters that need escaping', (t) => {
+  const values = ['back\\slash', 'tab\there', 'quote"here', 'new\nline', "tick's"]
+  t.plan(values.length * 2)
+
+  for (const value of values) {
+    const schema = {
+      type: 'object',
+      properties: {
+        foo: { const: value }
+      }
+    }
+
+    const stringify = build(schema)
+    const output = stringify({ foo: value })
+
+    t.assert.equal(output, JSON.stringify({ foo: value }))
+    t.assert.deepStrictEqual(JSON.parse(output), { foo: value })
+  }
+})
+
 test('schema with const string and different input', (t) => {
   t.plan(2)
 


### PR DESCRIPTION
### Problem

A `const` string containing a backslash, control character, or double quote is serialized into corrupted or invalid JSON, even when the input matches the schema:

```js
const build = require('fast-json-stringify')

build({ type: 'object', properties: { v: { const: 'a\\b' } } })({ v: 'a\\b' })
// -> {"v":"a\b"}            JSON.parse -> "a\b" (the value becomes a backspace)

build({ type: 'object', properties: { v: { const: 'a\tb' } } })({ v: 'a\tb' })
// -> {"v":"a<RAW TAB>b"}    JSON.parse -> SyntaxError: Bad control character

build({ type: 'object', properties: { v: { const: 'q"q' } } })({ v: 'q"q' })
// -> {"v":"q"q"}            JSON.parse -> SyntaxError
```

This reproduces for `const` at the top level, in properties, in array `items`, with `type` set, and as a nullable. `enum` and `default` with the same values serialize correctly — only `const` is affected.

### Cause

`JSON.stringify(schema.const)` produces correct JSON text, but it is then embedded into a **single-quoted JS string literal** in the generated function source, escaping only single quotes (`SINGLE_TICK`):

```js
code += `json += '${JSON.stringify(schema.const).replace(SINGLE_TICK, "\\'")}'`
```

When the `Function` constructor evaluates that source, `\\` collapses back to `\`, a `\t` becomes a raw tab, and an embedded `"` breaks the JSON string. (Introduced by #658, which handled only the single-quote case.)

### Fix

`JSON.stringify` the JSON text a second time to produce a properly escaped JS string literal — the same approach already used for default values:

```js
code += `json += ${JSON.stringify(JSON.stringify(schema.const))}`
```

`SINGLE_TICK` is now unused and removed. This also still covers the original single-quote case from #658.

### Tests

Added a case to `test/const.test.js` over `['back\\slash', 'tab\there', 'quote"here', 'new\nline', "tick's"]` asserting the output equals `JSON.stringify({ foo: value })` and round-trips (red before, green after).

Full unit suite green (473/473). Note: I ran it via `node --test` directly, because `c8`'s bundled `yargs` cannot load under Node 26 (`require is not defined in ES module scope`) — unrelated to this change. `npm run test:typescript` passes.