### PR TITLE
fix: serialize array input when object precedes array in multi-type schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -901,6 +901,17 @@ function buildMultiTypeSerializer (context, location, input) {
         `
         break
       }
+      case 'object': {
+        // An array is `typeof === 'object'`, so it would otherwise be captured
+        // by this branch and serialized as an object (dropping its items). Exclude
+        // arrays here so a sibling `array` type in the same `type` list can match.
+        code += `
+          ${statement}((typeof ${input} === "object" && !Array.isArray(${input})) || ${input} === null) {
+            ${nestedResult}
+          }
+        `
+        break
+      }
       default: {
         code += `
           ${statement}(typeof ${input} === "${type}" || ${input} === null) {

--- a/test/typesArray.test.js
+++ b/test/typesArray.test.js
@@ -548,3 +548,62 @@ test('throw an error if none of types matches', (t) => {
   const stringify = build(schema)
   t.assert.throws(() => stringify({ data: 'string' }), 'The value "string" does not match schema definition.')
 })
+
+test('multi-type object listed before array serializes array input as an array', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: ['object', 'array'],
+    properties: {
+      a: { type: 'integer' }
+    },
+    items: { type: 'integer' }
+  }
+
+  const stringify = build(schema, { ajv: { allowUnionTypes: true } })
+
+  // Array input must match the `array` member, not be captured by `object`.
+  t.assert.equal(stringify([1, 2, 3]), '[1,2,3]')
+
+  // Object input for the same schema still serializes as an object.
+  t.assert.equal(stringify({ a: 4 }), '{"a":4}')
+})
+
+test('multi-type [object, array] round-trips an array of objects (JSON:API data)', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    properties: {
+      data: {
+        type: ['object', 'array'],
+        properties: {
+          id: { type: 'string' },
+          type: { type: 'string' }
+        },
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            type: { type: 'string' }
+          }
+        }
+      }
+    }
+  }
+
+  const stringify = build(schema, { ajv: { allowUnionTypes: true } })
+
+  const arrayInput = {
+    data: [
+      { id: '1', type: 'article' },
+      { id: '2', type: 'article' }
+    ]
+  }
+  t.assert.deepEqual(JSON.parse(stringify(arrayInput)), arrayInput)
+
+  const objectInput = {
+    data: { id: '1', type: 'article' }
+  }
+  t.assert.deepEqual(JSON.parse(stringify(objectInput)), objectInput)
+})


### PR DESCRIPTION
When a schema lists `object` before `array` in its `type` array, array input serializes to `{}` and every element is lost.

## Steps to reproduce

```js
const build = require('fast-json-stringify')

const stringify = build({
  type: ['object', 'array'],
  properties: { a: { type: 'integer' } },
  items: { type: 'integer' }
}, { ajv: { allowUnionTypes: true } })

console.log(stringify([1, 2, 3]))
// ACTUAL:   {}
// EXPECTED: [1,2,3]
```

Swapping the order to `type: ['array', 'object']` produces the correct `[1,2,3]`, so the bug is order dependent.

## Root cause

`buildMultiTypeSerializer` emits one branch per listed type in list order. The object branch is generated by the `default` case as `if (typeof input === "object" || input === null)`. Because `typeof [] === 'object'`, that guard captures array input first, which makes the later `else if (Array.isArray(input))` branch unreachable. The array is then run through the object serializer, which emits only declared `properties` and returns `{}`.

## Fix

Add an explicit `object` case that excludes arrays from the object branch, mirroring the object guard already used in `buildArrayTypeCondition`:

```js
if ((typeof input === "object" && !Array.isArray(input)) || input === null) { ... }
```

A sibling `array` type in the same `type` list can now match array input. Plain objects, `toString` objects for `['object', 'string']`, and `['object', 'null']` null handling are unchanged, since none of those are arrays.

## Authority

Round-trip invariant: `JSON.parse(serialize(x))` must equal a schema-valid `x`. `[1,2,3]` is valid for the `array` member yet serialized to `{}`, breaking the invariant.

## Tests

Added to `test/typesArray.test.js`: array input under `type: ['object', 'array']` serializes to `[1,2,3]` (object input still serializes as an object), and a JSON:API-style `data` field with `type: ['object', 'array']` round-trips an array of objects. Both fail on the current base (array serialized as `{}`) and pass with the fix.

Full suite: 475/475 passing.
