### PR TITLE
perf: optimize Ajv refs for external schema branches

### DIFF
--- a/benchmark/bench-thread.js
+++ b/benchmark/bench-thread.js
@@ -15,10 +15,14 @@ const bench = new Bench({
 })
 
 const FJS = require('..')
-const stringify = FJS(benchmark.schema)
+const stringify = benchmark.compile ? null : FJS(benchmark.schema, benchmark.options)
 
 bench.add(benchmark.name, () => {
-  stringify(benchmark.input)
+  if (benchmark.compile) {
+    FJS(benchmark.schema, benchmark.options)(benchmark.input)
+  } else {
+    stringify(benchmark.input)
+  }
 }).run().then(() => {
   const task = bench.tasks[0]
   const hz = task.result.throughput.mean // ops/sec

--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -301,6 +301,92 @@ const benchmarks = [
     input: { firstName: 'Max', lastName: 'Power', age: 22 }
   },
   {
+    name: 'oneOf external refs compile and first stringify',
+    compile: true,
+    schema: {
+      title: 'External refs oneOf schema',
+      type: 'object',
+      properties: {
+        content: {
+          oneOf: [
+            { $ref: 'BenchmarkFoo#' },
+            { $ref: 'BenchmarkBar#' },
+            { $ref: 'BenchmarkBaz#' }
+          ]
+        }
+      }
+    },
+    options: {
+      schema: {
+        BenchmarkFoo: {
+          type: 'object',
+          properties: {
+            kind: { const: 'foo' },
+            title: { type: 'string' },
+            count: { type: 'integer' },
+            flags: {
+              type: 'array',
+              items: { type: 'string' }
+            }
+          },
+          required: ['kind', 'title', 'count', 'flags'],
+          additionalProperties: false
+        },
+        BenchmarkBar: {
+          type: 'object',
+          properties: {
+            kind: { const: 'bar' },
+            name: { type: 'string' },
+            value: { type: 'number' },
+            meta: {
+              type: 'object',
+              properties: {
+                active: { type: 'boolean' },
+                tags: {
+                  type: 'array',
+                  items: { type: 'string' }
+                }
+              },
+              required: ['active', 'tags'],
+              additionalProperties: false
+            }
+          },
+          required: ['kind', 'name', 'value', 'meta'],
+          additionalProperties: false
+        },
+        BenchmarkBaz: {
+          type: 'object',
+          properties: {
+            kind: { const: 'baz' },
+            id: { type: 'string' },
+            nested: {
+              type: 'object',
+              properties: {
+                score: { type: 'number' },
+                note: { type: 'string' }
+              },
+              required: ['score', 'note'],
+              additionalProperties: false
+            }
+          },
+          required: ['kind', 'id', 'nested'],
+          additionalProperties: false
+        }
+      }
+    },
+    input: {
+      content: {
+        kind: 'bar',
+        name: 'benchmark',
+        value: 42.5,
+        meta: {
+          active: true,
+          tags: ['one', 'two', 'three']
+        }
+      }
+    }
+  },
+  {
     name: 'object with const string property',
     schema: {
       type: 'object',

--- a/index.js
+++ b/index.js
@@ -100,6 +100,51 @@ function getSafeSchemaRef (context, location) {
   return schemaRef
 }
 
+function getValidatorSchemaRef (context, location) {
+  let schemaRef = location.getSchemaRef()
+  const schema = location.schema
+
+  // A schema that is only a registered $ref can validate against that target
+  // instead of a JSON-pointer path through the root schema.
+  if (
+    typeof schema.$ref !== 'string' ||
+    Object.keys(schema).length !== 1
+  ) {
+    return schemaRef
+  }
+
+  const ref = schema.$ref
+  const hashIndex = ref.indexOf('#')
+  const refSchemaId = hashIndex === -1 ? ref : ref.slice(0, hashIndex)
+  const refJsonPointer = hashIndex === -1 ? '' : ref.slice(hashIndex)
+  const isBareRef = refJsonPointer === '' || refJsonPointer === '#'
+  const isNamedFragmentRef = /^#[A-Za-z_][-A-Za-z0-9._]*$/.test(refJsonPointer)
+  const isJsonPointerRef = refJsonPointer.startsWith('#/')
+
+  if (
+    (isBareRef || isNamedFragmentRef || isJsonPointerRef) &&
+    refSchemaId &&
+    context.refResolver.hasSchema(refSchemaId)
+  ) {
+    const refSchema = context.refResolver.getSchema(refSchemaId)
+    const refSubSchema = isBareRef
+      ? refSchema
+      : context.refResolver.getSchema(refSchemaId, refJsonPointer)
+    const hasRelativeSchemaId = (
+      typeof refSchema.$id === 'string' &&
+      refSchema.$id.charAt(0) === '#'
+    )
+    if (
+      refSubSchema !== null &&
+      (!hasRelativeSchemaId || refSchema.$id === refJsonPointer)
+    ) {
+      schemaRef = refSchemaId + (isBareRef ? '#' : refJsonPointer)
+    }
+  }
+
+  return schemaRef
+}
+
 function build (schema, options) {
   isValidSchema(schema)
 
@@ -1148,7 +1193,7 @@ function buildOneOf (context, location, input) {
     }
 
     const nestedResult = buildValue(context, mergedLocation, input)
-    const schemaRef = optionLocation.getSchemaRef()
+    const schemaRef = getValidatorSchemaRef(context, optionLocation)
 
     code += `
       ${index === 0 ? 'if' : 'else if'}(validator.validate("${schemaRef}", ${input})) {
@@ -1181,7 +1226,7 @@ function buildIfThenElse (context, location, input) {
   )
 
   const ifLocation = location.getPropertyLocation('if')
-  const ifSchemaRef = ifLocation.getSchemaRef()
+  const ifSchemaRef = getValidatorSchemaRef(context, ifLocation)
 
   const thenLocation = location.getPropertyLocation('then')
   let thenMergedSchemaId = context.mergedSchemasIds.get(thenSchema)

--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ const mergeSchemas = require('./lib/merge-schemas')
 let largeArraySize = 2e4
 let largeArrayMechanism = 'default'
 
+const NAMED_FRAGMENT_REF = /^#[a-z_][-\w._]*$/i
+
 const serializerFns = `
 const {
   asString,
@@ -118,7 +120,7 @@ function getValidatorSchemaRef (context, location) {
   const refSchemaId = hashIndex === -1 ? ref : ref.slice(0, hashIndex)
   const refJsonPointer = hashIndex === -1 ? '' : ref.slice(hashIndex)
   const isBareRef = refJsonPointer === '' || refJsonPointer === '#'
-  const isNamedFragmentRef = /^#[A-Za-z_][-A-Za-z0-9._]*$/.test(refJsonPointer)
+  const isNamedFragmentRef = NAMED_FRAGMENT_REF.test(refJsonPointer)
   const isJsonPointerRef = refJsonPointer.startsWith('#/')
 
   if (

--- a/test/anyof.test.js
+++ b/test/anyof.test.js
@@ -387,6 +387,48 @@ test('anyOf and $ref - multiple external $ref', (t) => {
   t.assert.equal(output, '{"obj":{"prop":{"prop2":"test"}}}')
 })
 
+test('anyOf with registered $ref branches validates directly against the ref target', (t) => {
+  t.plan(3)
+
+  const schema = {
+    title: 'anyOf with registered $ref branches',
+    type: 'object',
+    properties: {
+      content: {
+        anyOf: [
+          { $ref: 'Foo#' },
+          { $ref: 'Bar#/definitions/Baz' }
+        ]
+      }
+    }
+  }
+  const externalSchema = {
+    Foo: {
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      required: ['a'],
+      additionalProperties: false
+    },
+    Bar: {
+      definitions: {
+        Baz: {
+          type: 'object',
+          properties: { b: { type: 'string' } },
+          required: ['b'],
+          additionalProperties: false
+        }
+      }
+    }
+  }
+
+  const code = build(schema, { mode: 'standalone', schema: externalSchema })
+  t.assert.ok(code.includes('validator.validate("Foo#"'), 'validates directly against the bare registered id')
+  t.assert.ok(code.includes('validator.validate("Bar#/definitions/Baz"'), 'validates directly against the registered sub-path ref')
+
+  const stringify = build(schema, { schema: externalSchema })
+  t.assert.equal(stringify({ content: { b: 'yo' } }), '{"content":{"b":"yo"}}')
+})
+
 test('anyOf looks for all of the array items', (t) => {
   t.plan(1)
 

--- a/test/if-then-else.test.js
+++ b/test/if-then-else.test.js
@@ -538,3 +538,115 @@ test('if-then-else with allOf', (t) => {
   t.assert.doesNotThrow(() => JSON.parse(output))
   t.assert.equal(output, '{"base":"test","foo":"value"}')
 })
+
+test('if with a bare top-level $ref validates directly against the registered schema', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    if: { $ref: 'IsFoo#' },
+    then: {
+      type: 'object',
+      properties: {
+        foo: { type: 'string' }
+      }
+    },
+    else: {
+      type: 'object',
+      properties: {
+        bar: { type: 'string' }
+      }
+    }
+  }
+  const externalSchema = {
+    IsFoo: {
+      type: 'object',
+      properties: {
+        kind: { type: 'string', const: 'foo' }
+      },
+      required: ['kind']
+    }
+  }
+
+  const code = build(schema, { mode: 'standalone', schema: externalSchema })
+  t.assert.ok(code.includes('validator.validate("IsFoo#"'), 'validates directly against the bare registered id')
+
+  const stringify = build(schema, { schema: externalSchema })
+  t.assert.equal(stringify({ kind: 'foo', foo: 'value', bar: 'ignored' }), '{"foo":"value"}')
+})
+
+test('if with a $ref into a JSON-pointer sub-path validates directly against that sub-path', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    if: { $ref: 'Rules#/definitions/IsFoo' },
+    then: {
+      type: 'object',
+      properties: {
+        foo: { type: 'string' }
+      }
+    },
+    else: {
+      type: 'object',
+      properties: {
+        bar: { type: 'string' }
+      }
+    }
+  }
+  const externalSchema = {
+    Rules: {
+      definitions: {
+        IsFoo: {
+          type: 'object',
+          properties: {
+            kind: { type: 'string', const: 'foo' }
+          },
+          required: ['kind']
+        }
+      }
+    }
+  }
+
+  const code = build(schema, { mode: 'standalone', schema: externalSchema })
+  t.assert.ok(code.includes('validator.validate("Rules#/definitions/IsFoo"'), 'validates directly against the registered sub-path ref')
+
+  const stringify = build(schema, { schema: externalSchema })
+  t.assert.equal(stringify({ kind: 'foo', foo: 'value', bar: 'ignored' }), '{"foo":"value"}')
+})
+
+test('if with a $ref that has sibling keywords is left unchanged', (t) => {
+  t.plan(2)
+
+  const schema = {
+    type: 'object',
+    if: { $ref: 'IsFoo#', required: ['extra'] },
+    then: {
+      type: 'object',
+      properties: {
+        foo: { type: 'string' }
+      }
+    },
+    else: {
+      type: 'object',
+      properties: {
+        bar: { type: 'string' }
+      }
+    }
+  }
+  const externalSchema = {
+    IsFoo: {
+      type: 'object',
+      properties: {
+        kind: { type: 'string', const: 'foo' }
+      },
+      required: ['kind']
+    }
+  }
+
+  const code = build(schema, { mode: 'standalone', schema: externalSchema })
+  t.assert.ok(!code.includes('validator.validate("IsFoo#"'), 'ref with sibling keywords is not redirected')
+
+  const stringify = build(schema, { schema: externalSchema })
+  t.assert.equal(stringify({ kind: 'foo', foo: 'ignored', bar: 'fallback' }), '{"bar":"fallback"}')
+})

--- a/test/oneof.test.js
+++ b/test/oneof.test.js
@@ -348,6 +348,248 @@ test('oneOf and $ref - multiple external $ref', (t) => {
   t.assert.equal(output, '{"obj":{"prop":{"prop2":"test"}}}')
 })
 
+test('oneOf with a bare top-level $ref branch validates directly against the registered schema, not a root-relative pointer', (t) => {
+  t.plan(3)
+
+  const schema = {
+    title: 'oneOf with bare $ref branches',
+    type: 'object',
+    properties: {
+      content: {
+        oneOf: [
+          { $ref: 'Foo#' },
+          { $ref: 'Bar#' }
+        ]
+      }
+    }
+  }
+  const externalSchema = {
+    Foo: {
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      required: ['a'],
+      additionalProperties: false
+    },
+    Bar: {
+      type: 'object',
+      properties: { b: { type: 'string' } },
+      required: ['b'],
+      additionalProperties: false
+    }
+  }
+
+  const code = build(schema, { mode: 'standalone', schema: externalSchema })
+  t.assert.ok(code.includes('validator.validate("Foo#"'), 'validates directly against the bare registered id')
+  t.assert.ok(code.includes('validator.validate("Bar#"'), 'validates directly against the bare registered id')
+
+  const stringify = build(schema, { schema: externalSchema })
+  t.assert.equal(stringify({ content: { b: 'yo' } }), '{"content":{"b":"yo"}}')
+})
+
+test('oneOf with a bare top-level $ref branch to a $id schema validates directly against the registered schema', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'oneOf with bare $id $ref branch',
+    type: 'object',
+    properties: {
+      content: {
+        oneOf: [
+          { $ref: 'urn:fjs:test:Foo#' },
+          { type: 'null' }
+        ]
+      }
+    }
+  }
+  const externalSchema = {
+    Foo: {
+      $id: 'urn:fjs:test:Foo',
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      required: ['a'],
+      additionalProperties: false
+    }
+  }
+
+  const code = build(schema, { mode: 'standalone', schema: externalSchema })
+  t.assert.ok(code.includes('validator.validate("urn:fjs:test:Foo#"'), 'validates directly against the bare registered $id')
+
+  const stringify = build(schema, { schema: externalSchema })
+  t.assert.equal(stringify({ content: { a: 'yo' } }), '{"content":{"a":"yo"}}')
+})
+
+test('oneOf with a bare top-level $ref branch to a relative $id schema is left unchanged', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'oneOf with bare $ref branch to relative $id',
+    type: 'object',
+    properties: {
+      content: {
+        oneOf: [
+          { $ref: 'Foo#' },
+          { type: 'null' }
+        ]
+      }
+    }
+  }
+  const externalSchema = {
+    Foo: {
+      $id: '#foo',
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      required: ['a']
+    }
+  }
+
+  const code = build(schema, { mode: 'standalone', schema: externalSchema })
+  t.assert.ok(!code.includes('validator.validate("Foo#"'), 'relative $id schema is not redirected to the bare parent id')
+})
+
+test('oneOf with a $ref branch to a relative root $id validates directly against the registered schema', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'oneOf with $ref branch to relative root $id',
+    type: 'object',
+    properties: {
+      content: {
+        oneOf: [
+          { $ref: 'Foo#foo' },
+          { type: 'null' }
+        ]
+      }
+    }
+  }
+  const externalSchema = {
+    Foo: {
+      $id: '#foo',
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      required: ['a']
+    }
+  }
+
+  const code = build(schema, { mode: 'standalone', schema: externalSchema })
+  t.assert.ok(code.includes('validator.validate("Foo#foo"'), 'validates directly against the relative root $id')
+
+  const stringify = build(schema, { schema: externalSchema })
+  t.assert.equal(stringify({ content: { a: 'yo' } }), '{"content":{"a":"yo"}}')
+})
+
+test('oneOf with a named-fragment $ref branch validates directly against the registered schema anchor', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'oneOf with named-fragment $ref branch',
+    type: 'object',
+    properties: {
+      content: {
+        oneOf: [
+          { $ref: 'Foo#tag' },
+          { type: 'null' }
+        ]
+      }
+    }
+  }
+  const externalSchema = {
+    Foo: {
+      $id: 'Foo',
+      $defs: {
+        tag: { $id: '#tag', type: 'string' }
+      }
+    }
+  }
+
+  const code = build(schema, { mode: 'standalone', schema: externalSchema })
+  t.assert.ok(code.includes('validator.validate("Foo#tag"'), 'validates directly against the registered schema anchor')
+
+  const stringify = build(schema, { schema: externalSchema })
+  t.assert.equal(stringify({ content: 'yo' }), '{"content":"yo"}')
+})
+
+test('oneOf with a $ref into a JSON-pointer sub-path validates directly against that sub-path', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'oneOf with a sub-path $ref branch',
+    type: 'object',
+    properties: {
+      content: {
+        oneOf: [
+          { $ref: 'Foo#/definitions/Bar' },
+          { type: 'null' }
+        ]
+      }
+    }
+  }
+  const externalSchema = {
+    Foo: {
+      definitions: {
+        Bar: { type: 'object', properties: { b: { type: 'string' } } }
+      }
+    }
+  }
+
+  const code = build(schema, { mode: 'standalone', schema: externalSchema })
+  t.assert.ok(code.includes('validator.validate("Foo#/definitions/Bar"'), 'validates directly against the sub-path ref')
+
+  const stringify = build(schema, { schema: externalSchema })
+  t.assert.equal(stringify({ content: { b: 'yo' } }), '{"content":{"b":"yo"}}')
+})
+
+test('oneOf with a $ref branch that has sibling keywords is left unchanged', (t) => {
+  t.plan(2)
+
+  const schema = {
+    title: 'oneOf with a $ref branch with sibling keywords',
+    type: 'object',
+    properties: {
+      content: {
+        oneOf: [
+          { $ref: 'Foo#', required: ['c'] },
+          { type: 'null' }
+        ]
+      }
+    }
+  }
+  const externalSchema = {
+    Foo: {
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      required: ['a']
+    }
+  }
+
+  const code = build(schema, { mode: 'standalone', schema: externalSchema })
+  t.assert.ok(!code.includes('validator.validate("Foo#"'), 'ref with sibling keywords is not redirected')
+
+  const stringify = build(schema, { schema: externalSchema })
+  t.assert.throws(() => stringify({ content: { a: 'yo' } }))
+})
+
+test('oneOf with an inline (non-$ref) branch is left unchanged', (t) => {
+  t.plan(1)
+
+  const schema = {
+    title: 'oneOf with an inline branch, no $ref',
+    type: 'object',
+    properties: {
+      content: {
+        oneOf: [
+          { type: 'string' },
+          { type: 'object', properties: { a: { type: 'string' } }, required: ['a'] }
+        ]
+      }
+    }
+  }
+
+  // Should compile and serialize exactly as before -- this is a pure
+  // regression guard, not exercising the new code path at all.
+  const stringify = build(schema)
+  t.assert.equal(stringify({ content: 'hello' }), '{"content":"hello"}')
+})
+
 test('oneOf with enum with more than 100 entries', (t) => {
   t.plan(1)
 


### PR DESCRIPTION
Redirect buildOneOf's Ajv ref to a registered ref target when possible.

buildOneOf currently validates oneOf/anyOf branches through location.getSchemaRef(), which points back into the generated root schema even when the branch is only an external ref already registered with Ajv. This lets those branches validate against the exact external ref target instead, so Ajv can use the already-registered schema path rather than resolving through the root document.

The helper is intentionally guarded:
- only pure  branches are redirected
- inline branches and refs with sibling keywords are left unchanged
- unresolved refs are left unchanged
- JSON-pointer and supported fragment refs are redirected only when the resolver can resolve the exact target
- relative root  cases are only redirected when the fragment matches the registered schema id shape

This also applies the same validator-ref selection to if schemas, which use the same runtime validator path.

Verification:
- npm run lint
- git diff --check
- node --test test/oneof.test.js
- node --test test/oneof.test.js test/anyof.test.js test/if-then-else.test.js
- npm run test:unit

npm run test:unit passed locally with 488 tests and 0 failures. The local run printed Node inspector auto-attach warnings, but exited successfully.