### PR TITLE
fix: apply sibling keywords when a schema resolves a $ref

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 /* eslint no-prototype-builtins: 0 */
 
 const { RefResolver } = require('json-schema-ref-resolver')
+const { MergeError } = require('@fastify/merge-json-schemas')
 
 const Serializer = require('./lib/serializer')
 const Validator = require('./lib/validator')
@@ -119,7 +120,8 @@ function resolveRef (context, location) {
     mergedSchemaId = `__fjs_merged_${schemaIdCounter++}`
     try {
       mergeLocations(context, mergedSchemaId, [newLocation, siblingLocation])
-    } catch {
+    } catch (err) {
+      if (!(err instanceof MergeError)) throw err
       return newLocation
     }
     context.mergedRefsIds.set(mergedSchemaKey, mergedSchemaId)

--- a/index.js
+++ b/index.js
@@ -42,6 +42,19 @@ const validLargeArrayMechanisms = new Set([
   'json-stringify'
 ])
 
+// Keywords that do not change the output, so a $ref carrying only these
+// can still be dereferenced directly instead of merged with its target.
+const IGNORED_REF_SIBLING_KEYWORDS = new Set([
+  '$ref',
+  '$comment',
+  'title',
+  'description',
+  'examples',
+  'deprecated',
+  'readOnly',
+  'writeOnly'
+])
+
 let schemaIdCounter = 0
 
 function isValidSchema (schema, name) {
@@ -59,7 +72,8 @@ function isValidSchema (schema, name) {
 }
 
 function resolveRef (context, location) {
-  const ref = location.schema.$ref
+  const refSchema = location.schema
+  const ref = refSchema.$ref
 
   let hashIndex = ref.indexOf('#')
   if (hashIndex === -1) {
@@ -74,12 +88,44 @@ function resolveRef (context, location) {
     throw new Error(`Cannot find reference "${ref}"`)
   }
 
-  const newLocation = new Location(schema, schemaId, jsonPointer)
+  let newLocation = new Location(schema, schemaId, jsonPointer)
   if (schema.$ref !== undefined) {
-    return resolveRef(context, newLocation)
+    newLocation = resolveRef(context, newLocation)
   }
 
-  return newLocation
+  const siblingSchema = {}
+  for (const key in refSchema) {
+    if (!IGNORED_REF_SIBLING_KEYWORDS.has(key)) {
+      siblingSchema[key] = refSchema[key]
+    }
+  }
+
+  if (Object.keys(siblingSchema).length === 0) {
+    return newLocation
+  }
+
+  const siblingLocation = new Location(
+    cloneOriginSchema(context, siblingSchema, location.schemaId),
+    location.schemaId,
+    location.jsonPointer
+  )
+
+  // Keyed by content, not by identity: a merged schema is cloned on every
+  // merge, so a recursive $ref would otherwise be merged again on each level.
+  const mergedSchemaKey = newLocation.getSchemaRef() + JSON.stringify(siblingLocation.schema)
+
+  let mergedSchemaId = context.mergedRefsIds.get(mergedSchemaKey)
+  if (mergedSchemaId === undefined) {
+    mergedSchemaId = `__fjs_merged_${schemaIdCounter++}`
+    try {
+      mergeLocations(context, mergedSchemaId, [newLocation, siblingLocation])
+    } catch {
+      return newLocation
+    }
+    context.mergedRefsIds.set(mergedSchemaKey, mergedSchemaId)
+  }
+
+  return getMergedLocation(context, mergedSchemaId)
 }
 
 function getMergedLocation (context, mergedSchemaId) {
@@ -161,6 +207,7 @@ function build (schema, options) {
     rootSchemaId: schema.$id || `__fjs_root_${schemaIdCounter++}`,
     validatorSchemasIds: new Set(),
     mergedSchemasIds: new Map(),
+    mergedRefsIds: new Map(),
     recursiveSchemas: new Set(),
     recursivePaths: new Set(),
     buildingSet: new Set(),

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -2075,3 +2075,106 @@ test('ref nested', (t) => {
   t.assert.doesNotThrow(() => JSON.parse(output))
   t.assert.equal(output, '{"str":"test"}')
 })
+
+test('ref internal - sibling keywords', (t) => {
+  t.plan(3)
+
+  const schema = {
+    definitions: {
+      def: {
+        type: 'object',
+        properties: {
+          str: {
+            type: 'string'
+          },
+          num: {
+            type: 'integer'
+          }
+        },
+        required: ['str']
+      }
+    },
+    type: 'object',
+    properties: {
+      obj: {
+        $ref: '#/definitions/def',
+        required: ['num']
+      }
+    }
+  }
+
+  const object = {
+    obj: {
+      str: 'test',
+      num: 42
+    }
+  }
+
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"obj":{"str":"test","num":42}}')
+
+  t.assert.throws(() => {
+    stringify({
+      obj: {
+        str: 'test'
+      }
+    })
+  }, { message: '"num" is required!' })
+})
+
+test('ref external - sibling keywords', (t) => {
+  t.plan(3)
+
+  const externalSchema = {
+    external: {
+      definitions: {
+        def: {
+          type: 'object',
+          properties: {
+            str: {
+              type: 'string'
+            },
+            num: {
+              type: 'integer'
+            }
+          },
+          required: ['str']
+        }
+      }
+    }
+  }
+
+  const schema = {
+    type: 'object',
+    properties: {
+      obj: {
+        $ref: 'external#/definitions/def',
+        required: ['num']
+      }
+    }
+  }
+
+  const object = {
+    obj: {
+      str: 'test',
+      num: 42
+    }
+  }
+
+  const stringify = build(schema, { schema: externalSchema })
+  const output = stringify(object)
+
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"obj":{"str":"test","num":42}}')
+
+  t.assert.throws(() => {
+    stringify({
+      obj: {
+        str: 'test'
+      }
+    })
+  }, { message: '"num" is required!' })
+})

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -2178,3 +2178,57 @@ test('ref external - sibling keywords', (t) => {
     })
   }, { message: '"num" is required!' })
 })
+
+test('ref external - recursive sibling keywords', (t) => {
+  t.plan(3)
+
+  const externalSchema = {
+    node: {
+      $id: 'node',
+      type: 'object',
+      properties: {
+        str: {
+          type: 'string'
+        },
+        next: {
+          $ref: 'node#',
+          required: ['str']
+        }
+      }
+    }
+  }
+
+  const schema = {
+    type: 'object',
+    properties: {
+      root: {
+        $ref: 'node#',
+        required: ['str']
+      }
+    }
+  }
+
+  const object = {
+    root: {
+      str: 'test',
+      next: {
+        str: 'nested'
+      }
+    }
+  }
+
+  const stringify = build(schema, { schema: externalSchema })
+  const output = stringify(object)
+
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"root":{"str":"test","next":{"str":"nested"}}}')
+
+  t.assert.throws(() => {
+    stringify({
+      root: {
+        str: 'test',
+        next: {}
+      }
+    })
+  }, { message: '"str" is required!' })
+})

--- a/test/ref.test.js
+++ b/test/ref.test.js
@@ -2232,3 +2232,73 @@ test('ref external - recursive sibling keywords', (t) => {
     })
   }, { message: '"str" is required!' })
 })
+
+test('ref internal - conflicting sibling keywords', (t) => {
+  t.plan(2)
+
+  const schema = {
+    definitions: {
+      def: {
+        type: 'string'
+      }
+    },
+    type: 'object',
+    properties: {
+      value: {
+        $ref: '#/definitions/def',
+        type: 'integer'
+      }
+    }
+  }
+
+  const object = {
+    value: 42
+  }
+
+  const stringify = build(schema)
+  const output = stringify(object)
+
+  t.assert.doesNotThrow(() => JSON.parse(output))
+  t.assert.equal(output, '{"value":"42"}')
+})
+
+test('ref external - sibling keywords with a duplicated anchor', (t) => {
+  t.plan(1)
+
+  const externalSchema = {
+    external: {
+      $id: 'external',
+      definitions: {
+        def: {
+          type: 'object',
+          properties: {
+            str: {
+              $id: '#anchor',
+              type: 'string'
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const schema = {
+    type: 'object',
+    properties: {
+      obj: {
+        $ref: 'external#/definitions/def',
+        properties: {
+          num: {
+            $id: '#anchor',
+            type: 'integer'
+          }
+        }
+      }
+    }
+  }
+
+  t.assert.throws(
+    () => build(schema, { schema: externalSchema }),
+    { message: /There is already another anchor "#anchor"/ }
+  )
+})


### PR DESCRIPTION
## Problem

A property that both references another schema and adds its own keywords loses those keywords. `resolveRef` swaps the whole location for the reference target, so anything sitting next to `$ref` is gone before any code is generated:

```js
const stringify = build({
  type: 'object',
  properties: {
    x: { $ref: 'Foo#', required: ['extra'] }
  }
}, {
  schema: {
    Foo: {
      $id: 'Foo',
      type: 'object',
      properties: { value: { type: 'integer' }, extra: { type: 'string' } },
      required: ['value']
    }
  }
})

stringify({ x: { value: 1 } })
// ACTUAL:   {"x":{"value":1}}
// EXPECTED: throws '"extra" is required!'
```

`value` is enforced because it comes from `Foo`, `extra` is not, so incomplete data serializes as if it were valid.

## Fix

A `$ref` that carries siblings now gets the resolved target and those siblings merged through `mergeLocations`, the same path `allOf` already takes. Everything else keeps the direct dereference it always had:

- siblings that cannot change the output (`title`, `description`, `$comment`, `examples`, `deprecated`, `readOnly`, `writeOnly`) are skipped, so annotated refs still share one serializer
- when the sibling keywords and the target genuinely conflict (say a sibling `type` the target contradicts) the merge is dropped and the plain target is used, which is what happens today

Merged refs are cached by content rather than by object identity, since a merge clones its input and a recursive `$ref` would otherwise be merged again on every level.

## Test

Two cases in `test/ref.test.js`, internal and external `$ref` with a sibling `required`: the sibling constraint is enforced and the target's own `required` still is. Both fail on the current main.

Fixes #866